### PR TITLE
fix: use osascript for notifications in dev mode to prevent crash

### DIFF
--- a/src-tauri/src/command.rs
+++ b/src-tauri/src/command.rs
@@ -857,3 +857,41 @@ pub async fn fetch_url(url: String, method: Option<String>, headers: Option<Hash
         "ok": ok,
     }))
 }
+
+/// Send a system notification.
+/// Dev builds (debug_assertions): use osascript — avoids UNUserNotificationCenter crash
+/// which requires a signed .app bundle (not available in `pnpm tauri dev`).
+/// Release builds: use tauri-plugin-notification Rust API, which works in signed builds.
+#[tauri::command]
+pub fn send_notification(
+    app: tauri::AppHandle,
+    title: String,
+    body: String,
+) -> Result<(), String> {
+    #[cfg(debug_assertions)]
+    {
+        let _ = app; // not needed in dev path
+        let script = format!(
+            "display notification \"{}\" with title \"{}\"",
+            body.replace('"', "\\\""),
+            title.replace('"', "\\\"")
+        );
+        std::process::Command::new("osascript")
+            .arg("-e")
+            .arg(&script)
+            .spawn()
+            .map_err(|e| format!("osascript error: {}", e))?;
+        return Ok(());
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        use tauri_plugin_notification::NotificationExt;
+        app.notification()
+            .builder()
+            .title(&title)
+            .body(&body)
+            .show()
+            .map_err(|e| e.to_string())
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -232,6 +232,7 @@ pub fn run() {
             command::spawn_headless_extension,
             command::kill_extension,
             command::fetch_url,
+            command::send_notification,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/services/notification/notificationService.ts
+++ b/src/services/notification/notificationService.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import {
   isPermissionGranted,
   requestPermission,
@@ -35,16 +36,26 @@ export class NotificationService implements INotificationService {
    * Send a notification
    */
   async notify(options: Options): Promise<void> {
-    let permissionGranted = await this.checkPermission();
-
-    if (!permissionGranted) {
-      permissionGranted = await this.requestPermission();
-      if (!permissionGranted) {
-        console.warn("Notification permission not granted");
+    // Dev mode: use osascript via custom Rust command.
+    // tauri-plugin-notification crashes in dev — it calls UNUserNotificationCenter
+    // which requires a signed .app bundle, not available in `pnpm tauri dev`.
+    if (import.meta.env.DEV) {
+        await invoke('send_notification', {
+            title: options.title ?? '',
+            body:  options.body  ?? '',
+        });
         return;
-      }
     }
 
+    // Production: use the plugin with permission check (works in signed build)
+    let permissionGranted = await this.checkPermission();
+    if (!permissionGranted) {
+        permissionGranted = await this.requestPermission();
+        if (!permissionGranted) {
+            console.warn("Notification permission not granted");
+            return;
+        }
+    }
     sendNotification(options);
   }
 


### PR DESCRIPTION
The tauri-plugin-notification library relies on UNUserNotificationCenter,
which requires a signed .app bundle to function properly on macOS. During
`pnpm tauri dev`, the app runs as an unsigned debug binary, resulting in
a null pointer crash when encountering `bundleProxyForCurrentProcess`.

This commit adds a custom Rust command ([send_notification](/asyar/src-tauri/src/command.rs:860:0-896:1)) that utilizes
`osascript` for notifications when running in development (debug_assertions).
In production releases, it preserves the standard `tauri-plugin-notification`
API behavior since the app is properly signed and bundled.

Files changed:
- src-tauri/src/command.rs
- src-tauri/src/lib.rs
- src/services/notification/notificationService.ts