### PR TITLE
feat(search): right-align type labels and resolve extension names for commands

### DIFF
--- a/src-tauri/src/search_engine/commands.rs
+++ b/src-tauri/src/search_engine/commands.rs
@@ -123,6 +123,11 @@ pub async fn search_items(
                 SearchableItem::Command(_) => None,
             };
 
+            let item_extension_id = match *item_ref {
+                SearchableItem::Application(_) => None,
+                SearchableItem::Command(ref cmd) => Some(cmd.extension.clone()),
+            };
+
             // Pass item_ref directly to helpers (auto-deref works here)
             results.push(SearchResult {
                 object_id: get_id(item_ref).to_string(),
@@ -131,6 +136,7 @@ pub async fn search_items(
                 score: get_usage_count(item_ref) as f32,
                 path: item_path,
                 icon: item_icon,
+                extension_id: item_extension_id,
             });
         }
         // --- END FIX 2 ---
@@ -172,6 +178,10 @@ pub async fn search_items(
                     SearchableItem::Application(app) => app.icon.clone(),
                     SearchableItem::Command(_) => None,
                 };
+                let item_extension_id = match item {
+                    SearchableItem::Application(_) => None,
+                    SearchableItem::Command(cmd) => Some(cmd.extension.clone()),
+                };
                 results.push(SearchResult {
                     object_id: object_id.to_string(),
                     name: get_name(item).to_string(),
@@ -179,6 +189,7 @@ pub async fn search_items(
                     score: *fuzzy_score as f32, // Convert i64 score to f32 for frontend
                     path: item_path,
                     icon: item_icon,
+                    extension_id: item_extension_id,
                 });
             }
         }

--- a/src-tauri/src/search_engine/models.rs
+++ b/src-tauri/src/search_engine/models.rs
@@ -42,10 +42,12 @@ pub struct SearchResult {
     #[serde(rename = "type")]
     pub result_type: String, // 'application' or 'command'
     pub score: f32,
-    #[serde(skip_serializing_if = "Option::is_none")] // Don't include if None
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icon: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extension_id: Option<String>,
 }
 
 // Helper to get the name for sorting/searching

--- a/src/components/list/ResultsList.svelte
+++ b/src/components/list/ResultsList.svelte
@@ -9,6 +9,7 @@
     object_id: string; // Add object_id to the item type
     title: string;
     subtitle?: string;
+    typeLabel?: string;
     icon?: string;
     style?: "default" | "large";
     action: () => void;
@@ -49,26 +50,33 @@
           </div>
         </div>
       {:else}
-        <div class="flex items-center gap-3 py-1">
+        <div class="flex items-center gap-3 py-1 w-full">
           {#if item.icon}
             {#if item.icon.startsWith('data:image')}
-                <img
-                    src={item.icon}
-                    alt={item.title}
-                    class="w-6 h-6 rounded-md object-contain flex-shrink-0"
-                />
+              <img
+                src={item.icon}
+                alt={item.title}
+                class="w-6 h-6 rounded-md object-contain flex-shrink-0"
+              />
             {:else}
-                <div class="w-6 text-center text-[var(--text-secondary)] flex-shrink-0">
-                    {item.icon}
-                </div>
+              <div class="w-6 text-center text-[var(--text-secondary)] flex-shrink-0">
+                {item.icon}
+              </div>
             {/if}
           {/if}
-          <div class="flex flex-col items-start min-w-0">
-             <div class="result-title truncate">{item.title}</div>
-             {#if item.subtitle}
-               <div class="result-subtitle truncate text-xs">{item.subtitle}</div>
-             {/if}
+
+          <!-- Left: name + optional inline description -->
+          <div class="flex-1 flex items-baseline gap-2 min-w-0">
+            <span class="result-title truncate">{item.title}</span>
+            {#if item.subtitle}
+              <span class="text-xs text-[var(--text-tertiary)] truncate flex-shrink">{item.subtitle}</span>
+            {/if}
           </div>
+
+          <!-- Right: type label -->
+          {#if item.typeLabel}
+            <span class="text-xs text-[var(--text-tertiary)] flex-shrink-0 ml-2">{item.typeLabel}</span>
+          {/if}
         </div>
       {/if}
     </button>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -135,10 +135,19 @@ import ExtensionIframe from '../components/extension/ExtensionIframe.svelte';
                logService.warn(`Result item missing/invalid objectId: ${name} ${type}`);
            }
 
+           let typeLabelStr = type ? type.charAt(0).toUpperCase() + type.slice(1) : undefined;
+           if (type === 'command' && result.extensionId) {
+               const manifest = extensionManager.getManifestById?.(result.extensionId);
+               if (manifest && manifest.name) {
+                   typeLabelStr = manifest.name;
+               }
+           }
+
            return {
                object_id: finalObjectId,
                title: name,
-               subtitle: result.description || type,
+               subtitle: result.description || undefined,
+               typeLabel: typeLabelStr,
                icon: icon,
                score: score,
                action: actionFunction, // Assign the correctly typed async function


### PR DESCRIPTION
This commit separates the item's inline description from its type label visually and improves command clarity by displaying the parent extension name.