### PR TITLE
Refactor action list focus restoration to use events

### DIFF
--- a/src/components/layout/BottomActionBar.svelte
+++ b/src/components/layout/BottomActionBar.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount, onDestroy, createEventDispatcher } from 'svelte';
+
+  const dispatch = createEventDispatcher<{ actionListClosed: void }>();
   import { logService } from '../../services/log/logService';
   import { actionStore } from '../../services/action/actionService';
   import type { ApplicationAction } from '../../services/action/actionService';
@@ -60,20 +62,20 @@
 
   // Exported function to toggle the action list popup
   export function toggleActionList() {
+    const wasOpen = isActionListOpen;
     isActionListOpen = !isActionListOpen;
     logService.debug(`[BottomActionBar] Action list toggled: ${isActionListOpen ? 'Open' : 'Closed'}`);
-    if (isActionListOpen) {
-        // Focus management will be handled within ActionListPopup onMount
-    } else {
-        // Focus restoration to search input should happen in the parent (+page.svelte)
-        // after the popup closes. We might need a small delay or event.
+    if (wasOpen && !isActionListOpen) {
+      // Closed via ⌘K toggle — notify parent to restore focus
+      dispatch('actionListClosed');
     }
   }
 
   function handlePopupClose() {
     isActionListOpen = false;
     logService.debug(`[BottomActionBar] Action list closed via event.`);
-    // Potentially dispatch an event here if parent needs to know for focus restoration
+    // Notify parent to restore focus to search input
+    dispatch('actionListClosed');
   }
 
   // --- Lifecycle ---

--- a/src/components/layout/BottomActionBar.svelte
+++ b/src/components/layout/BottomActionBar.svelte
@@ -71,6 +71,18 @@
     }
   }
 
+  export function closeActionList() {
+    if (isActionListOpen) {
+      isActionListOpen = false;
+      logService.debug(`[BottomActionBar] Action list closed via closeActionList().`);
+      dispatch('actionListClosed');
+    }
+  }
+
+  export function isOpen(): boolean {
+    return isActionListOpen;
+  }
+
   function handlePopupClose() {
     isActionListOpen = false;
     logService.debug(`[BottomActionBar] Action list closed via event.`);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -255,8 +255,8 @@ import ExtensionIframe from '../components/extension/ExtensionIframe.svelte';
     // Handle keys relevant to the main page when a view is active
      if ($activeView && ['Escape', 'Backspace', 'Delete'].includes(event.key)) {
          if (!event.defaultPrevented) {
-             // If the action panel is open, Backspace/Delete should close it — not navigate back
-             if ((event.key === 'Backspace' || event.key === 'Delete') && bottomActionBarInstance?.isOpen()) {
+             // If the action panel is open, Escape/Backspace/Delete should close it — not navigate back
+             if (bottomActionBarInstance?.isOpen()) {
                  bottomActionBarInstance.closeActionList();
                  event.preventDefault();
                  return;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -217,6 +217,12 @@ import ExtensionIframe from '../components/extension/ExtensionIframe.svelte';
      }
   }
 
+  function restoreSearchFocus() {
+    setTimeout(() => {
+      searchInput?.focus({ preventScroll: true });
+    }, 50);
+  }
+
   function isInputFocused(): boolean {
     if ($extensionHasInputFocus) return true;
     const el = document.activeElement;
@@ -241,17 +247,8 @@ import ExtensionIframe from '../components/extension/ExtensionIframe.svelte';
     if ((event.key === 'k' || event.key === 'K') && (event.metaKey || event.ctrlKey)) {
       event.preventDefault();
       event.stopPropagation();
-      const wasInView = !!$activeView;
-      bottomActionBarInstance?.toggleActionList(); // Toggle the action list popup
-
-      // Refocus search input if Cmd+K was pressed while in a view
-      if (wasInView && searchInput) {
-        setTimeout(() => {
-            if (searchInput) { // Check again if element exists
-                searchInput.focus();
-            }
-        }, 50);
-      }
+      bottomActionBarInstance?.toggleActionList();
+      // Focus restoration is handled by the actionListClosed event from BottomActionBar
       return;
     }
 
@@ -561,6 +558,7 @@ import ExtensionIframe from '../components/extension/ExtensionIframe.svelte';
     bind:this={bottomActionBarInstance}
     selectedItem={currentSelectedItemOriginal}
     errorState={currentError}
+    on:actionListClosed={restoreSearchFocus}
   />
 
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -255,6 +255,12 @@ import ExtensionIframe from '../components/extension/ExtensionIframe.svelte';
     // Handle keys relevant to the main page when a view is active
      if ($activeView && ['Escape', 'Backspace', 'Delete'].includes(event.key)) {
          if (!event.defaultPrevented) {
+             // If the action panel is open, Backspace/Delete should close it — not navigate back
+             if ((event.key === 'Backspace' || event.key === 'Delete') && bottomActionBarInstance?.isOpen()) {
+                 bottomActionBarInstance.closeActionList();
+                 event.preventDefault();
+                 return;
+             }
              if (isInputFocused() && document.activeElement !== searchInput) {
                  if (event.key === 'Escape') {
                      (document.activeElement as HTMLElement)?.blur();
@@ -353,6 +359,13 @@ import ExtensionIframe from '../components/extension/ExtensionIframe.svelte';
     if ($activeView && (event.key === 'Backspace' || event.key === 'Delete') && searchInput?.value === '') {
       if (isInputFocused() && document.activeElement !== searchInput) return;
       
+      // If the action panel is open, close it instead of navigating back
+      if (bottomActionBarInstance?.isOpen()) {
+        bottomActionBarInstance.closeActionList();
+        event.preventDefault();
+        return;
+      }
+
       event.preventDefault();
       extensionManager.goBack();
       return;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -252,15 +252,16 @@ import ExtensionIframe from '../components/extension/ExtensionIframe.svelte';
       return;
     }
 
+    // If the action panel is open, always close it first — regardless of active view
+    if (['Escape', 'Backspace', 'Delete'].includes(event.key) && bottomActionBarInstance?.isOpen()) {
+      bottomActionBarInstance.closeActionList();
+      event.preventDefault();
+      return;
+    }
+
     // Handle keys relevant to the main page when a view is active
      if ($activeView && ['Escape', 'Backspace', 'Delete'].includes(event.key)) {
          if (!event.defaultPrevented) {
-             // If the action panel is open, Escape/Backspace/Delete should close it — not navigate back
-             if (bottomActionBarInstance?.isOpen()) {
-                 bottomActionBarInstance.closeActionList();
-                 event.preventDefault();
-                 return;
-             }
              if (isInputFocused() && document.activeElement !== searchInput) {
                  if (event.key === 'Escape') {
                      (document.activeElement as HTMLElement)?.blur();


### PR DESCRIPTION
- Introduced the `actionListClosed` event in `BottomActionBar` to signal when the popup menu is hidden.
- Replaced the hardcoded, view-specific `setTimeout` hack in [+page.svelte](/asyar/src/routes/+page.svelte:0:0-0:0)'s global keydown handler with a dedicated `restoreSearchFocus` function.
- Ensures the search input reliably regains focus whether the popup is closed via Escape, an action click, or a repeated ⌘K toggle.