### PR TITLE
feat: API key support for Custom (OpenAI-compatible) provider

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -131,7 +131,11 @@
     "http:allow-fetch",
     {
       "identifier": "http:default",
-      "allow": [{ "url": "https://*/*" }]
+      "allow": [
+        { "url": "https://*/*" },
+        { "url": "http://localhost:*/*" },
+        { "url": "http://127.0.0.1:*/*" }
+      ]
     },
     "updater:default"
   ]

--- a/src/routes/settings/tabs/AiTab.svelte
+++ b/src/routes/settings/tabs/AiTab.svelte
@@ -165,17 +165,19 @@
         <!-- Expanded card body -->
         {#if expanded}
           <div class="card-body">
-            {#if plugin.requiresApiKey}
+            {#if plugin.requiresApiKey || plugin.optionalApiKey}
               <div class="card-field">
-                <label class="field-label" for="apikey-{plugin.id}">API Key</label>
+                <label class="field-label" for="apikey-{plugin.id}">
+                  API Key{#if !plugin.requiresApiKey} <span class="field-hint">(optional)</span>{/if}
+                </label>
                 <input
                   class="card-input"
                   id="apikey-{plugin.id}"
                   type="password"
                   value={config.apiKey ?? ''}
-                  placeholder="sk-••••••••••••••••"
+                  placeholder={plugin.requiresApiKey ? 'sk-••••••••••••••••' : 'Leave blank for unsecured endpoints'}
                   autocomplete="off"
-                  onblur={(e) => updateProviderConfig(plugin.id, { apiKey: (e.currentTarget as HTMLInputElement).value })}
+                  onblur={(e) => updateProviderConfig(plugin.id, { apiKey: (e.currentTarget as HTMLInputElement).value || undefined })}
                 />
               </div>
             {/if}
@@ -444,6 +446,11 @@
     font-size: var(--font-size-xs);
     color: var(--text-secondary);
     font-weight: 500;
+  }
+
+  .field-hint {
+    color: var(--text-tertiary);
+    font-weight: 400;
   }
 
   .card-input {

--- a/src/services/ai/IProviderPlugin.ts
+++ b/src/services/ai/IProviderPlugin.ts
@@ -42,6 +42,12 @@ export interface IProviderPlugin {
   readonly id: ProviderId;
   readonly name: string;
   readonly requiresApiKey: boolean;
+  /**
+   * Field is rendered in the UI but not enforced — the provider can be used with
+   * or without a key (e.g. an OpenAI-compatible endpoint that may or may not be
+   * secured behind a Bearer token).
+   */
+  readonly optionalApiKey?: boolean;
   readonly requiresBaseUrl: boolean;
 
   getModels(config: ProviderConfig): Promise<ModelInfo[]>;

--- a/src/services/ai/providers/custom.test.ts
+++ b/src/services/ai/providers/custom.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { customPlugin } from './custom';
+import type { ChatMessage, ChatParams, ProviderConfig } from '../IProviderPlugin';
+
+const baseParams: ChatParams = {
+  modelId: 'local-model',
+  temperature: 0.5,
+  maxTokens: 1024,
+};
+
+const userMsg: ChatMessage = {
+  id: 'm1',
+  role: 'user',
+  content: 'hello',
+  timestamp: 0,
+};
+
+describe('customPlugin metadata', () => {
+  it('exposes optionalApiKey: true so the UI renders the key field for the Custom provider', () => {
+    expect(customPlugin.optionalApiKey).toBe(true);
+  });
+
+  it('keeps requiresApiKey: false so unsecured local endpoints (LocalAI, Ollama-compatible) still pass the hasCredentials gate', () => {
+    expect(customPlugin.requiresApiKey).toBe(false);
+  });
+});
+
+describe('customPlugin.buildRequest', () => {
+  it('adds Authorization: Bearer <key> when an apiKey is configured', () => {
+    const config: ProviderConfig = {
+      enabled: true,
+      baseUrl: 'https://my-llm.example/api',
+      apiKey: 'sk-secret',
+    };
+
+    const spec = customPlugin.buildRequest([userMsg], config, baseParams);
+
+    expect(spec.headers.Authorization).toBe('Bearer sk-secret');
+    expect(spec.headers['Content-Type']).toBe('application/json');
+    expect(spec.url).toBe('https://my-llm.example/api/v1/chat/completions');
+  });
+
+  // Real-world base-URL ergonomics — users paste these straight from provider docs.
+  it.each([
+    ['bare host (no version)', 'https://example.com', 'https://example.com/v1/chat/completions'],
+    ['trailing slash', 'https://example.com/', 'https://example.com/v1/chat/completions'],
+    ['ollama localhost', 'http://localhost:11434', 'http://localhost:11434/v1/chat/completions'],
+    ['openrouter with /v1 (must NOT double-up)', 'https://openrouter.ai/api/v1', 'https://openrouter.ai/api/v1/chat/completions'],
+    ['anthropic with /v1', 'https://api.anthropic.com/v1', 'https://api.anthropic.com/v1/chat/completions'],
+    ['gemini /v1beta/openai compat path', 'https://generativelanguage.googleapis.com/v1beta/openai', 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions'],
+    ['gemini path with trailing slash', 'https://generativelanguage.googleapis.com/v1beta/openai/', 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions'],
+  ])('builds the right chat-completions URL for %s', (_name, baseUrl, expected) => {
+    const spec = customPlugin.buildRequest([userMsg], { enabled: true, baseUrl }, baseParams);
+    expect(spec.url).toBe(expected);
+  });
+
+  it('omits Authorization when apiKey is missing (LocalAI / unsecured endpoint)', () => {
+    const config: ProviderConfig = {
+      enabled: true,
+      baseUrl: 'http://localhost:8080',
+    };
+
+    const spec = customPlugin.buildRequest([userMsg], config, baseParams);
+
+    expect(spec.headers.Authorization).toBeUndefined();
+    expect(spec.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('omits Authorization when apiKey is an empty string', () => {
+    const config: ProviderConfig = {
+      enabled: true,
+      baseUrl: 'http://localhost:8080',
+      apiKey: '',
+    };
+
+    const spec = customPlugin.buildRequest([userMsg], config, baseParams);
+
+    expect(spec.headers.Authorization).toBeUndefined();
+  });
+
+  // Anthropic's API gates browser-context calls behind this header to surface the
+  // API-key-exposure risk. Tauri's webview is browser-like to their server, so we
+  // mirror what the native anthropicPlugin already sends. Harmless for other providers.
+  it('always sends anthropic-dangerous-direct-browser-access: true so Custom can target Anthropic', () => {
+    const spec = customPlugin.buildRequest([userMsg], {
+      enabled: true,
+      baseUrl: 'https://api.anthropic.com',
+      apiKey: 'sk-ant-test',
+    }, baseParams);
+
+    expect(spec.headers['anthropic-dangerous-direct-browser-access']).toBe('true');
+  });
+});
+
+describe('customPlugin.getModels', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('sends Authorization: Bearer <key> when apiKey is set', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ id: 'm-1' }] }),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const models = await customPlugin.getModels({
+      enabled: true,
+      baseUrl: 'https://my-llm.example/api',
+      apiKey: 'sk-secret',
+    });
+
+    expect(models).toEqual([{ id: 'm-1', label: 'm-1' }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://my-llm.example/api/v1/models');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer sk-secret');
+  });
+
+  it('does not double-prefix /v1 when the base URL already ends with /v1', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await customPlugin.getModels({
+      enabled: true,
+      baseUrl: 'https://openrouter.ai/api/v1',
+      apiKey: 'sk-or-test',
+    });
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://openrouter.ai/api/v1/models');
+  });
+
+  it('omits Authorization header when apiKey is blank', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await customPlugin.getModels({
+      enabled: true,
+      baseUrl: 'http://localhost:8080',
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+  });
+});

--- a/src/services/ai/providers/custom.ts
+++ b/src/services/ai/providers/custom.ts
@@ -1,18 +1,34 @@
 import type { IProviderPlugin, ModelInfo, ProviderConfig, RequestSpec, ChatParams, ChatMessage } from '../IProviderPlugin';
 
+/**
+ * Normalise the user-supplied base URL so the same launcher works whether the
+ * user pasted `https://api.example.com` or `https://api.example.com/v1` (or
+ * Google's Gemini OpenAI-compat shim at `…/v1beta/openai`). Returns the prefix
+ * that the chat/completions and models endpoints should be appended to.
+ */
+function normalizeOpenAIBase(rawBase: string): string {
+  const trimmed = rawBase.replace(/\/+$/, '');
+  // Already versioned (/v1, /v2, …) or Gemini's /openai compat suffix → keep as-is.
+  if (/\/v\d+(\/|$)|\/openai$/.test(trimmed)) return trimmed;
+  return `${trimmed}/v1`;
+}
+
 export const customPlugin: IProviderPlugin = {
   id: 'custom',
   name: 'Custom (OpenAI-compatible)',
   requiresApiKey: false,
+  optionalApiKey: true,
   requiresBaseUrl: true,
 
   async getModels(config: ProviderConfig): Promise<ModelInfo[]> {
     if (!config.baseUrl) return [];
-    const base = config.baseUrl.replace(/\/$/, '');
+    const base = normalizeOpenAIBase(config.baseUrl);
     try {
-      const headers: Record<string, string> = {};
+      const headers: Record<string, string> = {
+        'anthropic-dangerous-direct-browser-access': 'true',
+      };
       if (config.apiKey) headers.Authorization = `Bearer ${config.apiKey}`;
-      const res = await fetch(`${base}/v1/models`, { headers });
+      const res = await fetch(`${base}/models`, { headers });
       if (!res.ok) return [];
       const json = await res.json() as { data?: Array<{ id: string }> };
       return (json.data ?? []).map((m) => ({ id: m.id, label: m.id }));
@@ -23,16 +39,21 @@ export const customPlugin: IProviderPlugin = {
   },
 
   buildRequest(messages: ChatMessage[], config: ProviderConfig, params: ChatParams): RequestSpec {
-    const base = (config.baseUrl ?? '').replace(/\/$/, '');
+    const base = normalizeOpenAIBase(config.baseUrl ?? '');
     const systemPrompt = params.systemPrompt?.trim() ?? '';
     const filtered = messages.filter((m) => m.role !== 'system');
     const msgs = systemPrompt
       ? [{ role: 'system', content: systemPrompt }, ...filtered]
       : filtered;
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      // Required when the user points Custom at Anthropic's OpenAI-compat endpoint;
+      // ignored by every other OpenAI-compatible provider.
+      'anthropic-dangerous-direct-browser-access': 'true',
+    };
     if (config.apiKey) headers.Authorization = `Bearer ${config.apiKey}`;
     return {
-      url: `${base}/v1/chat/completions`,
+      url: `${base}/chat/completions`,
       headers,
       body: {
         model: params.modelId,


### PR DESCRIPTION
Adds an optional API Key field to the Custom provider, sent as
Authorization: Bearer <key> when set. Also normalises the base URL
so users can paste with or without /v1, sends Anthropic's required
browser-access header, and allows http://localhost in the Tauri
fetch allowlist so local LLMs (Ollama, LocalAI, vLLM) work.