### PR TITLE
feat: show script output in launcher and notifications after every run

### DIFF
--- a/docs/explanation/run-tracking.md
+++ b/docs/explanation/run-tracking.md
@@ -77,21 +77,21 @@ Each row in the launcher list optionally displays a status dot. `statusForRow` i
 4. **`object_id.startsWith('cmd_scripts_dyn_')`** → `'active'` while a matching live run exists in the active slice; otherwise `null`. Script definition rows never receive a `'done'` dot: succeeded scripts auto-remove their run rows from the launcher entirely, so there is nothing to persist a green signal against.
 5. **`object_id.startsWith('cmd_agents_dyn_')` and everything else** → `null`. Agent definition rows stay quiet; the `run` / `run-done` row in the Agents section is the sole signal. Lighting up both the definition and the thread row would double-signal the same running state.
 
-`ItemStatus` is `'active' | 'done'` — the type has no failure variant because the dot is never used to convey failure.
+`ItemStatus` is `'active' | 'done' | 'failed'`.
 
 ## Run-row lifecycle policy
 
-Two distinct lifecycle policies govern when a run row leaves the launcher list:
+The launcher keeps three kinds of post-mortem rows so the user always sees how a run ended:
 
-**Scripts are transactional.** When a script run succeeds, its run row is removed from the active slice and does not enter any kept slice. The script definition row (`cmd_scripts_dyn_*`) remains in the list with no dot. This reflects the nature of scripts as one-shot tasks: success is the expected outcome, not something to persist a signal for.
+**Scripts are persistent until dismissed.** When a shell-script run succeeds, `runService.onStateChanged` pushes it into `runService.unacknowledgedScriptResults` (deduped by `subjectId` when present, else by id, capped at five). The script definition row (`cmd_scripts_dyn_*`) stays decorated with a green `done` dot and a `Done · {tailOutput}` subtitle until the user dismisses via Cmd+K → Dismiss Result, which calls `runService.dismissScriptResult(id)` — that filters the slice and invokes `runs_dismiss` to free the in-memory `OutputBuffer`. A "Script finished" system notification is fired on completion, carrying the tail-output preview.
 
-**Agent threads are persistent.** When an agent run succeeds, `runService.onStateChanged` moves it into `runService.keptAgents`. The slice is deduped by `subjectId`: if an agent has two concurrent threads and both succeed, only the most recent successful run is kept, so each agent shows at most one `run-done` row at a time. Kept rows render as `type:'run-done'` with a static green dot until the user explicitly dismisses them (Cmd+K → Dismiss Thread), which calls `runService.dismissKeptAgent(id)`. The persistent SQLite record is unaffected by dismissal.
+**Agent threads are persistent until dismissed.** When an agent run succeeds, `runService.onStateChanged` moves it into `runService.keptAgents`. The slice is deduped by `subjectId`: if an agent has two concurrent threads and both succeed, only the most recent successful run is kept, so each agent shows at most one `run-done` row at a time. Kept rows render as `type:'run-done'` with a static green dot until the user explicitly dismisses them (Cmd+K → Dismiss Thread), which calls `runService.dismissKeptAgent(id)`. No success notification fires for agents (the kept-thread row is the surface).
 
-**Failures, any kind:** failed runs are moved from the active slice into `runService.unacknowledgedFailures`, capped at five entries. They render as `type:'run-failed'` rows until dismissed (Cmd+K → Dismiss Failure). A system notification is also fired. The persistent record remains in SQLite.
+**Failures, any kind:** failed runs are moved from the active slice into `runService.unacknowledgedFailures`, capped at five entries. They render as `type:'run-failed'` rows with a red `failed` dot and `Failed · {tailOutput ?? errorMessage}` subtitle until dismissed (Cmd+K → Dismiss Failure). A "Run failed" notification carries the tail-output preview.
 
 **Cancellations, any kind:** cancelled runs leave the active slice and enter no kept slice. The row disappears immediately. Cancellation is always user-initiated — the act of cancelling is itself the closure signal.
 
-The `unacknowledgedFailures` and `keptAgents` slices are in-memory only and reset when the launcher restarts. The full run history is available in SQLite and surfaced in the RunView recent section.
+The three kept slices (`unacknowledgedFailures`, `keptAgents`, `unacknowledgedScriptResults`) are in-memory only and reset when the launcher restarts. The full run history (including `Run.tailOutput`) is persisted in SQLite and surfaced in the RunView recent section. The per-run `OutputBuffer` survives finalize and is dropped only by explicit `runs_dismiss` or session reset.
 
 ## Cross-references
 

--- a/src-tauri/src/commands/runs.rs
+++ b/src-tauri/src/commands/runs.rs
@@ -1,6 +1,6 @@
 use crate::error::AppError;
 use crate::runs::{Run, RunKind, RunStatus};
-use crate::runs::output_buffer::OutputBuffer;
+use crate::runs::output_buffer::{format_tail_output, OutputBuffer};
 use crate::runs::registry::{now_millis, RunRegistry};
 use crate::storage::{runs_history, DataStore};
 use rusqlite::Connection;
@@ -35,6 +35,7 @@ pub fn runs_start_impl(
         cancellable,
         error_message: None,
         subject_id,
+        tail_output: None,
     };
     registry.insert(run.clone())?;
     let payload = serde_json::to_value(&run)
@@ -60,7 +61,7 @@ pub fn runs_write_impl(
     Ok(())
 }
 
-/// Shared finalization path for done/fail/cancel: transition, persist, drop buffer, emit.
+/// Shared finalization path for done/fail/cancel: capture tail, transition, persist, emit.
 fn finalize_impl(
     registry: &RunRegistry,
     buffer: &OutputBuffer,
@@ -70,9 +71,13 @@ fn finalize_impl(
     new_status: RunStatus,
     error_message: Option<String>,
 ) -> Result<(), AppError> {
-    let run = registry.transition(id, new_status, error_message)?;
+    let snapshot = buffer.snapshot(id);
+    let tail = format_tail_output(&snapshot);
+    let run = registry.transition(id, new_status, error_message, tail)?;
     runs_history::insert(conn, &run)?;
-    buffer.drop_for_run(id);
+    // Buffer is kept alive for post-mortem reads by RunView and notification
+    // consumers. It will be dropped by runs_dismiss (on user dismiss) and on
+    // session reset.
     let payload = serde_json::to_value(&run)
         .map_err(|e| AppError::Validation(format!("serialize Run: {e}")))?;
     let _ = emit("runs:state-changed", &payload);
@@ -139,6 +144,14 @@ pub fn runs_history_clear_impl(conn: &Connection) -> Result<(), AppError> {
 
 pub fn runs_get_output_impl(buffer: &OutputBuffer, id: &str) -> Vec<String> {
     buffer.snapshot(id)
+}
+
+/// Drop the per-run output buffer for `id`. No-op when the id is unknown,
+/// so callers can dismiss anything (active or terminal, attributed or anon)
+/// without first checking existence.
+pub fn runs_dismiss_impl(buffer: &OutputBuffer, id: &str) -> Result<(), AppError> {
+    buffer.drop_for_run(id);
+    Ok(())
 }
 
 // ── Tauri command wrappers ────────────────────────────────────────────────────
@@ -248,6 +261,13 @@ pub async fn runs_history_clear(db: State<'_, DataStore>) -> Result<(), AppError
 #[tauri::command]
 pub async fn runs_get_output(id: String) -> Result<Vec<String>, AppError> {
     Ok(runs_get_output_impl(OutputBuffer::instance(), &id))
+}
+
+/// Drop the per-run output buffer for `id`. Called when the user dismisses
+/// a kept run-row from the launcher list.
+#[tauri::command]
+pub async fn runs_dismiss(id: String) -> Result<(), AppError> {
+    runs_dismiss_impl(OutputBuffer::instance(), &id)
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -572,7 +592,7 @@ mod tests {
     }
 
     #[test]
-    fn done_persists_to_history_and_drops_buffer() {
+    fn done_persists_to_history_and_keeps_buffer() {
         let (registry, buffer, conn, events) = make_test_env();
         let emit = events.as_emit_fn();
 
@@ -606,10 +626,7 @@ mod tests {
         );
 
         let snap = buffer.snapshot("r1");
-        assert!(
-            snap.is_empty(),
-            "output buffer must be dropped after done, got {snap:?}"
-        );
+        assert_eq!(snap, vec!["some output"], "buffer must survive finalize");
     }
 
     #[test]
@@ -670,6 +687,8 @@ mod tests {
         )
         .unwrap();
 
+        runs_write_impl(&registry, &buffer, &emit, "r1".to_string(), "some fail output".to_string()).unwrap();
+
         runs_fail_impl(
             &registry,
             &buffer,
@@ -695,7 +714,7 @@ mod tests {
         assert_eq!(history[0].error_message.as_deref(), Some("boom"));
 
         let snap = buffer.snapshot("r1");
-        assert!(snap.is_empty(), "buffer must be dropped after fail");
+        assert!(!snap.is_empty(), "buffer must survive finalize for post-mortem reading");
     }
 
     // ── runs_cancel tests ─────────────────────────────────────────────────────
@@ -718,6 +737,8 @@ mod tests {
         )
         .unwrap();
 
+        runs_write_impl(&registry, &buffer, &emit, "r1".to_string(), "partial work".to_string()).unwrap();
+
         runs_cancel_impl(&registry, &buffer, &emit, &conn, "r1".to_string()).unwrap();
 
         let stored = registry.get("r1").expect("run must be accessible after cancel");
@@ -733,7 +754,7 @@ mod tests {
         assert_eq!(history[0].status, RunStatus::Cancelled);
 
         let snap = buffer.snapshot("r1");
-        assert!(snap.is_empty(), "buffer must be dropped after cancel");
+        assert!(!snap.is_empty(), "buffer must survive finalize for post-mortem reading");
     }
 
     // ── terminal-state guard ──────────────────────────────────────────────────
@@ -914,16 +935,175 @@ mod tests {
         assert!(output.is_empty(), "expected empty Vec for unknown id 'ghost', got {output:?}");
     }
 
+    // ── runs_dismiss tests ────────────────────────────────────────────────────
+
     #[test]
-    fn get_output_empty_after_finalize() {
+    fn dismiss_drops_buffer_for_id() {
+        let (registry, buffer, conn, events) = make_test_env();
+        let emit = events.as_emit_fn();
+
+        runs_start_impl(&registry, &buffer, &emit, "r1".to_string(), RunKind::ShellScript, "Script".to_string(), None, false, None).unwrap();
+        runs_write_impl(&registry, &buffer, &emit, "r1".to_string(), "alive".to_string()).unwrap();
+        runs_done_impl(&registry, &buffer, &emit, &conn, "r1".to_string()).unwrap();
+
+        assert_eq!(
+            runs_get_output_impl(&buffer, "r1"),
+            vec!["alive"],
+            "buffer must still be readable before dismiss"
+        );
+
+        runs_dismiss_impl(&buffer, "r1").unwrap();
+
+        assert!(
+            runs_get_output_impl(&buffer, "r1").is_empty(),
+            "buffer must be empty after dismiss"
+        );
+    }
+
+    #[test]
+    fn dismiss_unknown_id_is_noop() {
+        let (_registry, buffer, _conn, _events) = make_test_env();
+
+        runs_dismiss_impl(&buffer, "never-started").unwrap();
+    }
+
+    // ── tail_output capture + buffer survival tests ───────────────────────────
+
+    #[test]
+    fn finalize_captures_tail_output_into_run() {
+        let (registry, buffer, conn, events) = make_test_env();
+        let emit = events.as_emit_fn();
+
+        runs_start_impl(&registry, &buffer, &emit, "r1".to_string(), RunKind::ShellScript, "Script".to_string(), None, false, None).unwrap();
+        runs_write_impl(&registry, &buffer, &emit, "r1".to_string(), "first".to_string()).unwrap();
+        runs_write_impl(&registry, &buffer, &emit, "r1".to_string(), "middle".to_string()).unwrap();
+        runs_write_impl(&registry, &buffer, &emit, "r1".to_string(), "line three".to_string()).unwrap();
+
+        runs_done_impl(&registry, &buffer, &emit, &conn, "r1".to_string()).unwrap();
+
+        let run = runs_get_impl(&registry, "r1").expect("run must be accessible after done");
+        assert_eq!(
+            run.tail_output.as_deref(),
+            Some("line three"),
+            "tail_output must be set to the last non-empty line after finalize"
+        );
+    }
+
+    #[test]
+    fn finalize_keeps_buffer_alive_for_post_mortem_read() {
         let (registry, buffer, conn, events) = make_test_env();
         let emit = events.as_emit_fn();
 
         runs_start_impl(&registry, &buffer, &emit, "r1".to_string(), RunKind::ShellScript, "Script".to_string(), None, false, None).unwrap();
         runs_write_impl(&registry, &buffer, &emit, "r1".to_string(), "hello".to_string()).unwrap();
+        runs_write_impl(&registry, &buffer, &emit, "r1".to_string(), "world".to_string()).unwrap();
+
         runs_done_impl(&registry, &buffer, &emit, &conn, "r1".to_string()).unwrap();
 
         let output = runs_get_output_impl(&buffer, "r1");
-        assert!(output.is_empty(), "buffer must be empty after finalize drops it, got {output:?}");
+        assert_eq!(
+            output,
+            vec!["hello", "world"],
+            "buffer must survive finalize so RunView can read post-mortem"
+        );
     }
+
+    #[test]
+    fn finalize_persists_tail_output_to_sqlite_history() {
+        let (registry, buffer, conn, events) = make_test_env();
+        let emit = events.as_emit_fn();
+
+        runs_start_impl(&registry, &buffer, &emit, "r1".to_string(), RunKind::ShellScript, "Script".to_string(), None, false, None).unwrap();
+        runs_write_impl(&registry, &buffer, &emit, "r1".to_string(), "persisted line".to_string()).unwrap();
+
+        runs_done_impl(&registry, &buffer, &emit, &conn, "r1".to_string()).unwrap();
+
+        let recent = runs_history::list_recent(&conn, 10).unwrap();
+        assert_eq!(
+            recent[0].tail_output.as_deref(),
+            Some("persisted line"),
+            "tail_output must be persisted to SQLite history row"
+        );
+    }
+
+    #[test]
+    fn finalize_fail_captures_tail_output_and_keeps_buffer() {
+        let (registry, buffer, conn, events) = make_test_env();
+        let emit = events.as_emit_fn();
+
+        runs_start_impl(&registry, &buffer, &emit, "r1".to_string(), RunKind::ShellScript, "Script".to_string(), None, false, None).unwrap();
+        runs_write_impl(&registry, &buffer, &emit, "r1".to_string(), "warning: thing".to_string()).unwrap();
+        runs_write_impl(&registry, &buffer, &emit, "r1".to_string(), "Error: explosion".to_string()).unwrap();
+
+        runs_fail_impl(&registry, &buffer, &emit, &conn, "r1".to_string(), "exit code 1".to_string()).unwrap();
+
+        let run = registry.get("r1").expect("run must be accessible after fail");
+        assert_eq!(
+            run.tail_output.as_deref(),
+            Some("Error: explosion"),
+            "tail_output must capture the last non-empty line on fail"
+        );
+
+        let output = runs_get_output_impl(&buffer, "r1");
+        assert!(!output.is_empty(), "buffer must survive fail finalize for post-mortem reading");
+    }
+
+    #[test]
+    fn finalize_cancel_captures_tail_output_and_keeps_buffer() {
+        let (registry, buffer, conn, events) = make_test_env();
+        let emit = events.as_emit_fn();
+
+        runs_start_impl(&registry, &buffer, &emit, "r1".to_string(), RunKind::AiChat, "Chat".to_string(), None, true, None).unwrap();
+        runs_write_impl(&registry, &buffer, &emit, "r1".to_string(), "partial work".to_string()).unwrap();
+
+        runs_cancel_impl(&registry, &buffer, &emit, &conn, "r1".to_string()).unwrap();
+
+        let run = registry.get("r1").expect("run must be accessible after cancel");
+        assert_eq!(
+            run.tail_output.as_deref(),
+            Some("partial work"),
+            "tail_output must capture the last non-empty line on cancel"
+        );
+
+        let output = runs_get_output_impl(&buffer, "r1");
+        assert!(!output.is_empty(), "buffer must survive cancel finalize for post-mortem reading");
+    }
+
+    #[test]
+    fn finalize_with_no_output_leaves_tail_output_none() {
+        let (registry, buffer, conn, events) = make_test_env();
+        let emit = events.as_emit_fn();
+
+        runs_start_impl(&registry, &buffer, &emit, "r1".to_string(), RunKind::ShellScript, "Script".to_string(), None, false, None).unwrap();
+
+        runs_done_impl(&registry, &buffer, &emit, &conn, "r1".to_string()).unwrap();
+
+        let run = registry.get("r1").expect("run must be accessible after done");
+        assert!(
+            run.tail_output.is_none(),
+            "tail_output must be None when no lines were written, got {:?}",
+            run.tail_output
+        );
+    }
+
+    #[test]
+    fn finalize_with_only_whitespace_output_leaves_tail_output_none() {
+        let (registry, buffer, conn, events) = make_test_env();
+        let emit = events.as_emit_fn();
+
+        runs_start_impl(&registry, &buffer, &emit, "r1".to_string(), RunKind::ShellScript, "Script".to_string(), None, false, None).unwrap();
+        runs_write_impl(&registry, &buffer, &emit, "r1".to_string(), "".to_string()).unwrap();
+        runs_write_impl(&registry, &buffer, &emit, "r1".to_string(), "   ".to_string()).unwrap();
+        runs_write_impl(&registry, &buffer, &emit, "r1".to_string(), "\t".to_string()).unwrap();
+
+        runs_done_impl(&registry, &buffer, &emit, &conn, "r1".to_string()).unwrap();
+
+        let run = registry.get("r1").expect("run must be accessible after done");
+        assert!(
+            run.tail_output.is_none(),
+            "tail_output must be None when all written lines are whitespace-only, got {:?}",
+            run.tail_output
+        );
+    }
+
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -440,6 +440,7 @@ pub fn run() {
             commands::runs::runs_history_list,
             commands::runs::runs_history_clear,
             commands::runs::runs_get_output,
+            commands::runs::runs_dismiss,
             // Agent CRUD
             commands::agents::agents_create,
             commands::agents::agents_update,

--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -1216,11 +1216,9 @@ mod show_more_bar {
     /// silently if the bar hasn't been built yet (early TS push before
     /// `create()` ran).
     ///
-    /// Done-label text differs by kind: Scripts get "Done" (matching the
-    /// transactional script lifecycle — completed scripts auto-remove and
-    /// the count is effectively always 0 today, but the visual hook is
-    /// here for the day it isn't), Agents get "Idle" (persistent kept
-    /// threads waiting to be reused).
+    /// Done-label text differs by kind: Scripts get "Done" (kept-success
+    /// rows from `runService.unacknowledgedScriptResults`), Agents get
+    /// "Idle" (persistent kept threads waiting to be reused).
     pub(super) fn apply_huds(
         scripts_active: u32,
         scripts_done: u32,

--- a/src-tauri/src/runs/output_buffer.rs
+++ b/src-tauri/src/runs/output_buffer.rs
@@ -5,6 +5,42 @@ use std::sync::{Mutex, OnceLock};
 /// When the cap is exceeded the oldest line is evicted.
 pub const MAX_LINES_PER_RUN: usize = 10_000;
 
+/// Maximum character length (Unicode scalar count) of a tail-output preview
+/// returned by [`format_tail_output`]. Longer previews are truncated and
+/// suffixed with `…`.
+pub const MAX_TAIL_CHARS: usize = 200;
+
+/// Pick a one-line preview from a per-run output snapshot, for surfacing in
+/// row subtitles, notifications, and the RunView header.
+///
+/// Contract:
+/// - Returns the **last non-empty** line from `lines` (whitespace-only
+///   lines count as empty).
+/// - Trims trailing whitespace from the chosen line.
+/// - Truncates to [`MAX_TAIL_CHARS`] Unicode scalars (NOT bytes) and
+///   appends `…` when truncation happens.
+/// - Returns `None` when `lines` is empty or every line is whitespace-only.
+///
+/// Notes:
+/// - `lines` is chronological (push_back order from [`OutputBuffer::snapshot`]).
+/// - Stream tag (stdout vs stderr) is **not** preserved by `OutputBuffer`
+///   today; this formatter picks whichever was last regardless of stream.
+pub fn format_tail_output(lines: &[String]) -> Option<String> {
+    let trimmed = lines
+        .iter()
+        .rev()
+        .map(|l| l.trim_end())
+        .find(|l| !l.is_empty())?;
+
+    if trimmed.chars().count() <= MAX_TAIL_CHARS {
+        Some(trimmed.to_string())
+    } else {
+        let mut out: String = trimmed.chars().take(MAX_TAIL_CHARS).collect();
+        out.push('…');
+        Some(out)
+    }
+}
+
 /// Per-run ring buffer of streamed output lines (stdout / stderr).
 /// Singleton via `instance()`; tests should construct isolated instances
 /// with `new_for_test()`.
@@ -221,5 +257,63 @@ mod tests {
             0,
             "line_count for r2 must be 0 after appending only to r1"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // format_tail_output — user-contribution spec
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn format_tail_output_returns_none_for_empty_slice() {
+        assert_eq!(format_tail_output(&[]), None);
+    }
+
+    #[test]
+    fn format_tail_output_returns_none_for_only_whitespace_lines() {
+        let lines = vec!["".to_string(), "   ".to_string(), "\t\n".to_string()];
+        assert_eq!(format_tail_output(&lines), None);
+    }
+
+    #[test]
+    fn format_tail_output_returns_last_non_empty_line() {
+        let lines = vec!["first".to_string(), "middle".to_string(), "last".to_string()];
+        assert_eq!(format_tail_output(&lines).as_deref(), Some("last"));
+    }
+
+    #[test]
+    fn format_tail_output_skips_trailing_blank_lines() {
+        let lines = vec![
+            "real output".to_string(),
+            "".to_string(),
+            "   ".to_string(),
+        ];
+        assert_eq!(format_tail_output(&lines).as_deref(), Some("real output"));
+    }
+
+    #[test]
+    fn format_tail_output_trims_trailing_whitespace() {
+        let lines = vec!["hello world   \n".to_string()];
+        assert_eq!(format_tail_output(&lines).as_deref(), Some("hello world"));
+    }
+
+    #[test]
+    fn format_tail_output_truncates_long_line_with_ellipsis() {
+        let long = "x".repeat(MAX_TAIL_CHARS + 50);
+        let out = format_tail_output(&[long]).expect("non-empty input must yield Some");
+        assert!(
+            out.chars().count() <= MAX_TAIL_CHARS + 1,
+            "max {MAX_TAIL_CHARS} chars + ellipsis, got {} chars",
+            out.chars().count()
+        );
+        assert!(
+            out.ends_with('…'),
+            "truncated output must end with an ellipsis, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn format_tail_output_preserves_short_unicode_unchanged() {
+        let s = "héllo 🚀".to_string();
+        assert_eq!(format_tail_output(std::slice::from_ref(&s)).as_deref(), Some(s.as_str()));
     }
 }

--- a/src-tauri/src/runs/registry.rs
+++ b/src-tauri/src/runs/registry.rs
@@ -38,20 +38,17 @@ impl RunRegistry {
         Ok(())
     }
 
-    /// Transition `id` to `status`, recording `error` when provided.
+    /// Transition `id` to `status`, recording `error` and `tail_output` when provided.
     /// Returns the updated `Run` on success.
     ///
     /// State-machine contract: once a run is in a terminal status
     /// (Succeeded, Failed, Cancelled), any further transition must return Err.
-    ///
-    /// Item 5 will extend this to broadcast a `runs:state-changed` Tauri event
-    /// after a successful mutation; the signature may grow an `&AppHandle`
-    /// parameter at that time.
     pub fn transition(
         &self,
         id: &str,
         status: RunStatus,
         error: Option<String>,
+        tail_output: Option<String>,
     ) -> Result<Run, AppError> {
         let mut guard = self.runs.lock().expect("RunRegistry mutex poisoned");
         let run = guard
@@ -64,6 +61,7 @@ impl RunRegistry {
         }
         run.status = status;
         run.error_message = error;
+        run.tail_output = tail_output;
         if status.is_terminal() {
             run.ended_at = Some(now_millis());
         }
@@ -125,6 +123,7 @@ mod tests {
             cancellable: false,
             error_message: None,
             subject_id: None,
+            tail_output: None,
         }
     }
 
@@ -164,10 +163,10 @@ mod tests {
         let reg = RunRegistry::new_for_test();
         reg.insert(make_test_run("r1")).unwrap();
 
-        let after_running = reg.transition("r1", RunStatus::Running, None).unwrap();
+        let after_running = reg.transition("r1", RunStatus::Running, None, None).unwrap();
         assert_eq!(after_running.status, RunStatus::Running);
 
-        let after_succeeded = reg.transition("r1", RunStatus::Succeeded, None).unwrap();
+        let after_succeeded = reg.transition("r1", RunStatus::Succeeded, None, None).unwrap();
         assert_eq!(after_succeeded.status, RunStatus::Succeeded);
 
         // get() must also reflect the final status
@@ -183,7 +182,7 @@ mod tests {
         reg.insert(make_test_run("r2")).unwrap();
 
         let result = reg
-            .transition("r2", RunStatus::Failed, Some("boom".to_string()))
+            .transition("r2", RunStatus::Failed, Some("boom".to_string()), None)
             .unwrap();
 
         assert_eq!(result.status, RunStatus::Failed);
@@ -202,9 +201,9 @@ mod tests {
     fn transition_succeeded_to_running_rejected() {
         let reg = RunRegistry::new_for_test();
         reg.insert(make_test_run("r3")).unwrap();
-        reg.transition("r3", RunStatus::Succeeded, None).unwrap();
+        reg.transition("r3", RunStatus::Succeeded, None, None).unwrap();
 
-        let result = reg.transition("r3", RunStatus::Running, None);
+        let result = reg.transition("r3", RunStatus::Running, None, None);
         assert!(
             result.is_err(),
             "expected Err when transitioning out of terminal Succeeded"
@@ -215,7 +214,7 @@ mod tests {
     #[test]
     fn transition_unknown_id_errors() {
         let reg = RunRegistry::new_for_test();
-        let result = reg.transition("ghost", RunStatus::Running, None);
+        let result = reg.transition("ghost", RunStatus::Running, None, None);
         assert!(result.is_err(), "expected Err for unknown run id");
     }
 
@@ -237,15 +236,15 @@ mod tests {
 
         // Insert Succeeded via transition
         reg.insert(make_test_run("succeeded-1")).unwrap();
-        reg.transition("succeeded-1", RunStatus::Succeeded, None).unwrap();
+        reg.transition("succeeded-1", RunStatus::Succeeded, None, None).unwrap();
 
         // Insert Failed via transition
         reg.insert(make_test_run("failed-1")).unwrap();
-        reg.transition("failed-1", RunStatus::Failed, None).unwrap();
+        reg.transition("failed-1", RunStatus::Failed, None, None).unwrap();
 
         // Insert Cancelled via transition
         reg.insert(make_test_run("cancelled-1")).unwrap();
-        reg.transition("cancelled-1", RunStatus::Cancelled, None).unwrap();
+        reg.transition("cancelled-1", RunStatus::Cancelled, None, None).unwrap();
 
         let active = reg.list_active();
         assert_eq!(active.len(), 2, "expected exactly 2 active runs, got {active:?}");
@@ -283,7 +282,7 @@ mod tests {
     fn pending_to_running_leaves_ended_at_none() {
         let registry = RunRegistry::new_for_test();
         registry.insert(make_test_run("r1")).unwrap();
-        let run = registry.transition("r1", RunStatus::Running, None).unwrap();
+        let run = registry.transition("r1", RunStatus::Running, None, None).unwrap();
         assert!(run.ended_at.is_none(), "Running is non-terminal; ended_at must remain None");
     }
 
@@ -291,8 +290,8 @@ mod tests {
     fn running_to_succeeded_sets_ended_at() {
         let registry = RunRegistry::new_for_test();
         registry.insert(make_test_run("r1")).unwrap();
-        registry.transition("r1", RunStatus::Running, None).unwrap();
-        let run = registry.transition("r1", RunStatus::Succeeded, None).unwrap();
+        registry.transition("r1", RunStatus::Running, None, None).unwrap();
+        let run = registry.transition("r1", RunStatus::Succeeded, None, None).unwrap();
         assert!(run.ended_at.is_some(), "Succeeded is terminal; ended_at must be set");
     }
 
@@ -300,8 +299,8 @@ mod tests {
     fn running_to_cancelled_sets_ended_at() {
         let registry = RunRegistry::new_for_test();
         registry.insert(make_test_run("r1")).unwrap();
-        registry.transition("r1", RunStatus::Running, None).unwrap();
-        let run = registry.transition("r1", RunStatus::Cancelled, None).unwrap();
+        registry.transition("r1", RunStatus::Running, None, None).unwrap();
+        let run = registry.transition("r1", RunStatus::Cancelled, None, None).unwrap();
         assert!(run.ended_at.is_some(), "Cancelled is terminal; ended_at must be set");
     }
 

--- a/src-tauri/src/runs/types.rs
+++ b/src-tauri/src/runs/types.rs
@@ -49,6 +49,10 @@ pub struct Run {
     /// for an agent. `None` for ad-hoc runs (Tier 2 RunService.start, custom
     /// kinds, label-only runs).
     pub subject_id: Option<String>,
+    /// Last captured lines from the script's stdout/stderr, surfaced to the
+    /// user in the run response. `None` until Phase 3 wires the capture logic.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tail_output: Option<String>,
 }
 
 #[cfg(test)]
@@ -69,6 +73,7 @@ mod tests {
             cancellable: false,
             error_message: None,
             subject_id: None,
+            tail_output: None,
         }
     }
 
@@ -131,5 +136,32 @@ mod tests {
         assert!(v.get("ended_at").is_none(), "snake_case ended_at must not appear");
         assert!(v.get("error_message").is_none(), "snake_case error_message must not appear");
         assert!(v.get("subject_id").is_none(), "snake_case subject_id must not appear");
+    }
+
+    #[test]
+    fn run_serializes_tail_output_as_camel_case() {
+        let mut run = make_test_run("r1");
+        run.tail_output = Some("last output line".to_string());
+        let json = serde_json::to_value(&run).unwrap();
+        assert_eq!(
+            json["tailOutput"],
+            serde_json::json!("last output line"),
+            "expected tailOutput key with value, got {json}"
+        );
+        assert!(
+            json.get("tail_output").is_none(),
+            "snake_case tail_output must not appear in JSON"
+        );
+    }
+
+    #[test]
+    fn run_serializes_tail_output_absent_when_none() {
+        let run = make_test_run("r1");
+        // tail_output defaults to None; skip_serializing_if means key must be absent
+        let json = serde_json::to_value(&run).unwrap();
+        assert!(
+            json.get("tailOutput").is_none(),
+            "tailOutput key must be absent when None (skip_serializing_if), got {json}"
+        );
     }
 }

--- a/src-tauri/src/storage/runs_history.rs
+++ b/src-tauri/src/storage/runs_history.rs
@@ -20,23 +20,30 @@ pub fn init_table(conn: &Connection) -> Result<(), AppError> {
             ended_at      INTEGER,
             cancellable   INTEGER NOT NULL,
             error_message TEXT,
-            subject_id    TEXT
+            subject_id    TEXT,
+            tail_output   TEXT
         );
         CREATE INDEX IF NOT EXISTS idx_runs_history_started_at
             ON runs_history(started_at DESC);",
     )
     .map_err(|e| AppError::Database(format!("Failed to init runs_history table: {e}")))?;
 
-    // Patch upgrades: pre-subject_id databases get the column added in place.
-    let has_subject_id: bool = conn
+    let cols: Vec<String> = conn
         .prepare("PRAGMA table_info(runs_history)")
         .map_err(|e| AppError::Database(e.to_string()))?
         .query_map([], |row| row.get::<_, String>(1))
         .map_err(|e| AppError::Database(e.to_string()))?
         .filter_map(Result::ok)
-        .any(|name| name == "subject_id");
-    if !has_subject_id {
+        .collect();
+
+    // Patch upgrades: pre-subject_id databases get the column added in place.
+    if !cols.contains(&"subject_id".to_string()) {
         conn.execute("ALTER TABLE runs_history ADD COLUMN subject_id TEXT", [])
+            .map_err(|e| AppError::Database(e.to_string()))?;
+    }
+    // Patch upgrades: pre-tail_output databases get the column added in place.
+    if !cols.contains(&"tail_output".to_string()) {
+        conn.execute("ALTER TABLE runs_history ADD COLUMN tail_output TEXT", [])
             .map_err(|e| AppError::Database(e.to_string()))?;
     }
     Ok(())
@@ -48,8 +55,8 @@ pub fn insert(conn: &Connection, run: &Run) -> Result<(), AppError> {
     let status = status_to_db(run.status)?;
     conn.execute(
         "INSERT OR REPLACE INTO runs_history
-         (id, kind, label, status, extension_id, started_at, ended_at, cancellable, error_message, subject_id)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+         (id, kind, label, status, extension_id, started_at, ended_at, cancellable, error_message, subject_id, tail_output)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
         params![
             run.id,
             kind,
@@ -61,6 +68,7 @@ pub fn insert(conn: &Connection, run: &Run) -> Result<(), AppError> {
             run.cancellable as i64,
             run.error_message,
             run.subject_id,
+            run.tail_output,
         ],
     )
     .map_err(|e| AppError::Database(e.to_string()))?;
@@ -73,7 +81,7 @@ pub fn list_recent(conn: &Connection, limit: usize) -> Result<Vec<Run>, AppError
     let mut stmt = conn
         .prepare(
             "SELECT id, kind, label, status, extension_id, started_at, ended_at,
-                    cancellable, error_message, subject_id
+                    cancellable, error_message, subject_id, tail_output
              FROM runs_history
              ORDER BY started_at DESC
              LIMIT ?1",
@@ -85,23 +93,24 @@ pub fn list_recent(conn: &Connection, limit: usize) -> Result<Vec<Run>, AppError
             let kind_str: String = row.get(1)?;
             let status_str: String = row.get(3)?;
             Ok((
-                row.get::<_, String>(0)?,         // id
+                row.get::<_, String>(0)?,          // id
                 kind_str,
-                row.get::<_, String>(2)?,         // label
+                row.get::<_, String>(2)?,          // label
                 status_str,
-                row.get::<_, Option<String>>(4)?, // extension_id
-                row.get::<_, i64>(5)?,            // started_at
-                row.get::<_, Option<i64>>(6)?,    // ended_at
-                row.get::<_, i64>(7)?,            // cancellable
-                row.get::<_, Option<String>>(8)?, // error_message
-                row.get::<_, Option<String>>(9)?, // subject_id
+                row.get::<_, Option<String>>(4)?,  // extension_id
+                row.get::<_, i64>(5)?,             // started_at
+                row.get::<_, Option<i64>>(6)?,     // ended_at
+                row.get::<_, i64>(7)?,             // cancellable
+                row.get::<_, Option<String>>(8)?,  // error_message
+                row.get::<_, Option<String>>(9)?,  // subject_id
+                row.get::<_, Option<String>>(10)?, // tail_output
             ))
         })
         .map_err(|e| AppError::Database(e.to_string()))?;
 
     let mut runs = Vec::new();
     for row in rows {
-        let (id, kind_str, label, status_str, extension_id, started_at, ended_at, cancellable_int, error_message, subject_id) =
+        let (id, kind_str, label, status_str, extension_id, started_at, ended_at, cancellable_int, error_message, subject_id, tail_output) =
             row.map_err(|e| AppError::Database(e.to_string()))?;
         let kind = kind_from_db(&kind_str)?;
         let status = status_from_db(&status_str)?;
@@ -116,6 +125,7 @@ pub fn list_recent(conn: &Connection, limit: usize) -> Result<Vec<Run>, AppError
             cancellable: cancellable_int != 0,
             error_message,
             subject_id,
+            tail_output,
         });
     }
     Ok(runs)
@@ -202,6 +212,7 @@ mod tests {
             cancellable: true,
             error_message: None,
             subject_id: None,
+            tail_output: None,
         }
     }
 
@@ -478,6 +489,55 @@ mod tests {
 
         assert_eq!(rows.len(), 1);
         assert!(rows[0].subject_id.is_none());
+    }
+
+    #[test]
+    fn init_table_adds_tail_output_column_to_legacy_db() {
+        // Simulate a legacy DB that predates the tail_output column.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE runs_history (
+                id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                label TEXT NOT NULL,
+                status TEXT NOT NULL,
+                extension_id TEXT,
+                started_at INTEGER NOT NULL,
+                ended_at INTEGER,
+                cancellable INTEGER NOT NULL,
+                error_message TEXT,
+                subject_id TEXT
+            );",
+        )
+        .unwrap();
+        init_table(&conn).unwrap();
+        let mut stmt = conn.prepare("PRAGMA table_info(runs_history)").unwrap();
+        let cols: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+        assert!(
+            cols.contains(&"tail_output".to_string()),
+            "expected tail_output column after init_table on legacy schema, got: {cols:?}"
+        );
+    }
+
+    #[test]
+    fn tail_output_round_trips_through_sqlite() {
+        let conn = make_conn();
+        let mut run = make_run("r1", 1000);
+        run.tail_output = Some("last line".to_string());
+
+        insert(&conn, &run).unwrap();
+        let recent = list_recent(&conn, 10).unwrap();
+
+        assert_eq!(recent.len(), 1);
+        assert_eq!(
+            recent[0].tail_output.as_deref(),
+            Some("last line"),
+            "tail_output must round-trip through SQLite"
+        );
     }
 
     #[test]

--- a/src/built-in-features/runs/RunView.svelte
+++ b/src/built-in-features/runs/RunView.svelte
@@ -175,7 +175,7 @@
             message="No output yet"
             description={selectedRun.status === 'running'
               ? 'Output will appear as it streams.'
-              : 'Output retained only while running.'}
+              : 'Output has been dismissed.'}
           />
         {/if}
       {:else}

--- a/src/components/layout/ShowMoreBarHuds.svelte
+++ b/src/components/layout/ShowMoreBarHuds.svelte
@@ -21,7 +21,11 @@
   import { runService } from '../../services/run/runService.svelte';
   import { aggregateKindCounts } from '../../services/launcher/itemStatusLogic';
 
-  const counts = $derived(aggregateKindCounts(runService.active, runService.keptAgents));
+  const counts = $derived(aggregateKindCounts(
+    runService.active,
+    runService.keptAgents,
+    runService.unacknowledgedScriptResults,
+  ));
   const scriptsVisible = $derived(counts.scripts.active > 0 || counts.scripts.done > 0);
   const agentsVisible  = $derived(counts.agents.active  > 0 || counts.agents.done  > 0);
 </script>

--- a/src/components/list/ResultsList.svelte
+++ b/src/components/list/ResultsList.svelte
@@ -70,7 +70,7 @@
         </div>
       </button>
     {:else}
-      {@const status = statusForRow(item, runService.active, runService.unacknowledgedFailures)}
+      {@const status = statusForRow(item, runService.active, runService.unacknowledgedFailures, runService.unacknowledgedScriptResults)}
       <LauncherListRow
         data-index={i}
         selected={i === selectedIndex}

--- a/src/components/list/SectionedResultsList.svelte
+++ b/src/components/list/SectionedResultsList.svelte
@@ -73,7 +73,7 @@
           </div>
         </button>
       {:else}
-        {@const status = statusForRow(row.item, runService.active, runService.unacknowledgedFailures)}
+        {@const status = statusForRow(row.item, runService.active, runService.unacknowledgedFailures, runService.unacknowledgedScriptResults)}
         <LauncherListRow
           data-index={row.originalIndex}
           selected={row.originalIndex === selectedIndex}

--- a/src/lib/launcher/selectionEffects.svelte.ts
+++ b/src/lib/launcher/selectionEffects.svelte.ts
@@ -43,6 +43,7 @@ export function setupSelectionEffects(state: LauncherState) {
       activeRuns: runService.active,
       failedRuns: runService.unacknowledgedFailures,
       keptAgentRuns: runService.keptAgents,
+      scriptResultRuns: runService.unacknowledgedScriptResults,
       query: state.localSearchValue,
       onError: (msg) => diagnosticsService.report({
         source: 'frontend', kind: 'action_failed', severity: 'error',
@@ -139,16 +140,26 @@ export function setupSelectionEffects(state: LauncherState) {
 
     if (item && item.type === 'run-done') {
       const runId = item.object_id.replace(/^run_/, '');
+      const matchingRun =
+        runService.unacknowledgedScriptResults.find((r) => r.id === runId) ??
+        runService.keptAgents.find((r) => r.id === runId);
+      const isScript = matchingRun?.kind === 'shell-script';
       actionService.registerAction({
         id: 'runs:dismiss',
-        label: 'Dismiss Thread',
+        label: isScript ? 'Dismiss Result' : 'Dismiss Thread',
         icon: 'icon:trash',
-        description: 'Remove this completed thread from the launcher list (still kept in history)',
+        description: isScript
+          ? 'Remove this script result row and free its output (history record is kept)'
+          : 'Remove this completed thread from the launcher list (still kept in history)',
         category: 'Runs',
         extensionId: 'runs',
         context: ActionContext.CORE,
         execute: async () => {
-          runService.dismissKeptAgent(runId);
+          if (isScript) {
+            runService.dismissScriptResult(runId);
+          } else {
+            runService.dismissKeptAgent(runId);
+          }
           state.getBottomBar()?.closeActionList();
         },
       });

--- a/src/lib/searchResultMapper.test.ts
+++ b/src/lib/searchResultMapper.test.ts
@@ -760,3 +760,128 @@ describe('buildMappedItems run injection', () => {
     expect(mappedItems[0].object_id).toBe('cmd_safari')
   })
 })
+
+describe('buildMappedItems script-result rows surface tail output', () => {
+  it('script definition stays visible when a scriptResultRun matches its objectId', () => {
+    const scriptRow = makeResult({
+      objectId: 'cmd_scripts_dyn_hosts',
+      name: 'Hosts Update',
+      type: 'command',
+    })
+    const result = makeRun({
+      id: 'r-hosts-1',
+      label: 'Hosts Update',
+      kind: 'shell-script',
+      status: 'succeeded',
+      subjectId: 'cmd_scripts_dyn_hosts',
+      tailOutput: 'OK — synced 12 files',
+      endedAt: Date.now(),
+    })
+
+    const { mappedItems } = buildMappedItems({
+      searchItems: [scriptRow],
+      activeContext: null,
+      shortcutStore: [],
+      localSearchValue: '',
+      selectedIndex: 0,
+      onError: vi.fn(),
+      scriptResultRuns: [result],
+      query: '',
+    })
+
+    expect(mappedItems).toHaveLength(1)
+    expect(mappedItems[0].object_id).toBe('cmd_scripts_dyn_hosts')
+    expect(mappedItems[0].subtitle).toBe('Done · OK — synced 12 files')
+  })
+
+  it('failed run subtitle prefers tailOutput over errorMessage', () => {
+    const scriptRow = makeResult({
+      objectId: 'cmd_scripts_dyn_broken',
+      name: 'Broken Script',
+      type: 'command',
+    })
+    const run = makeRun({
+      id: 'r-broken',
+      label: 'Broken Script',
+      kind: 'shell-script',
+      status: 'failed',
+      subjectId: 'cmd_scripts_dyn_broken',
+      tailOutput: 'Error: file not found',
+      errorMessage: 'exit code 1',
+      endedAt: Date.now(),
+    })
+
+    const { mappedItems } = buildMappedItems({
+      searchItems: [scriptRow],
+      activeContext: null,
+      shortcutStore: [],
+      localSearchValue: '',
+      selectedIndex: 0,
+      onError: vi.fn(),
+      failedRuns: [run],
+      query: '',
+    })
+
+    expect(mappedItems[0].subtitle).toBe('Failed · Error: file not found')
+  })
+
+  it('failed run subtitle falls back to errorMessage when tailOutput is missing', () => {
+    const scriptRow = makeResult({
+      objectId: 'cmd_scripts_dyn_silent',
+      name: 'Silent',
+      type: 'command',
+    })
+    const run = makeRun({
+      id: 'r-silent',
+      label: 'Silent',
+      kind: 'shell-script',
+      status: 'failed',
+      subjectId: 'cmd_scripts_dyn_silent',
+      errorMessage: 'exit code 137',
+      endedAt: Date.now(),
+    })
+
+    const { mappedItems } = buildMappedItems({
+      searchItems: [scriptRow],
+      activeContext: null,
+      shortcutStore: [],
+      localSearchValue: '',
+      selectedIndex: 0,
+      onError: vi.fn(),
+      failedRuns: [run],
+      query: '',
+    })
+
+    expect(mappedItems[0].subtitle).toBe('Failed · exit code 137')
+  })
+
+  it('succeeded run with no tailOutput shows "(no output)"', () => {
+    const scriptRow = makeResult({
+      objectId: 'cmd_scripts_dyn_quiet',
+      name: 'Quiet',
+      type: 'command',
+    })
+    const run = makeRun({
+      id: 'r-quiet',
+      label: 'Quiet',
+      kind: 'shell-script',
+      status: 'succeeded',
+      subjectId: 'cmd_scripts_dyn_quiet',
+      tailOutput: undefined,
+      endedAt: Date.now(),
+    })
+
+    const { mappedItems } = buildMappedItems({
+      searchItems: [scriptRow],
+      activeContext: null,
+      shortcutStore: [],
+      localSearchValue: '',
+      selectedIndex: 0,
+      onError: vi.fn(),
+      scriptResultRuns: [run],
+      query: '',
+    })
+
+    expect(mappedItems[0].subtitle).toBe('Done · (no output)')
+  })
+})

--- a/src/lib/searchResultMapper.ts
+++ b/src/lib/searchResultMapper.ts
@@ -77,9 +77,12 @@ export type BuildMappedItemsParams = {
   failedRuns?: Run[];
   /** Kept (succeeded) agent runs — persistent thread rows the user hasn't
    * dismissed yet. Rendered after active + failed so all surfaced runs sit
-   * above the catalog. Per the lifecycle policy: scripts auto-remove on
-   * success; agent threads persist until manually dismissed. */
+   * above the catalog. */
   keptAgentRuns?: Run[];
+  /** Succeeded shell-script runs the user hasn't dismissed yet — surfaced
+   * as `run-done` rows so script output (captured in `tailOutput`) stays
+   * inspectable after the run ends. */
+  scriptResultRuns?: Run[];
   /** When non-empty, runs are demoted below the mapped search results.
    * When empty, runs are prepended (default-mode browse view). */
   query?: string;
@@ -146,17 +149,16 @@ function buildRunAction(runId: string, runKind: string): () => Promise<void> {
 function buildRunMappedItem(run: Run): MappedSearchItem {
   // Three row variants are emitted today:
   //   - 'run'        — live run, blue active dot via statusForRow
-  //   - 'run-failed' — failed run, subtitle conveys failure (no dot)
-  //   - 'run-done'   — kept (succeeded) agent thread, green done dot
+  //   - 'run-failed' — failed run, subtitle conveys failure tail / message
+  //   - 'run-done'   — kept (succeeded) agent thread or kept script, with
+  //                    tail-output preview when available
   const isFailed = run.status === 'failed';
   const isKeptDone = run.status === 'succeeded';
   const type = isFailed ? 'run-failed' : isKeptDone ? 'run-done' : 'run';
   const subtitle = isFailed
-    ? run.errorMessage
-      ? `Failed · ${run.errorMessage}`
-      : 'Failed'
+    ? `Failed · ${run.tailOutput ?? run.errorMessage ?? '(no output)'}`
     : isKeptDone
-      ? 'Done'
+      ? `Done · ${run.tailOutput ?? '(no output)'}`
       : 'Running';
   return {
     object_id: `run_${run.id}`,
@@ -220,6 +222,7 @@ export function buildMappedItems({
   activeRuns = [],
   failedRuns = [],
   keptAgentRuns = [],
+  scriptResultRuns = [],
   query,
 }: BuildMappedItemsParams): BuildMappedItemsResult {
   // --- Portal injection for url/view-type contexts ---
@@ -239,14 +242,16 @@ export function buildMappedItems({
 
   const hasQuery = (query ?? '').trim().length > 0;
 
-  // In empty-query mode, only show script definitions if they have an active or failed run.
-  // Succeeded scripts must disappear completely from the default launcher results.
+  // In empty-query mode, only show script definitions if they have an active,
+  // failed, or kept-success run. Succeeded scripts persist as result rows so
+  // the user can read the output until they explicitly dismiss them.
   if (!hasQuery) {
     baseItems = baseItems.filter((item) => {
       if (!item.objectId.startsWith('cmd_scripts_dyn_')) return true;
       const isLive = activeRuns.some((r) => r.subjectId === item.objectId);
       const isFailed = failedRuns.some((r) => r.subjectId === item.objectId);
-      return isLive || isFailed;
+      const isResult = scriptResultRuns.some((r) => r.subjectId === item.objectId);
+      return isLive || isFailed || isResult;
     });
   }
 
@@ -274,16 +279,17 @@ export function buildMappedItems({
     const matchingRun = objectId ? (
       activeRuns.find(r => r.subjectId === objectId) ||
       failedRuns.find(r => r.subjectId === objectId) ||
-      keptAgentRuns.find(r => r.subjectId === objectId)
+      keptAgentRuns.find(r => r.subjectId === objectId) ||
+      scriptResultRuns.find(r => r.subjectId === objectId)
     ) : null;
 
     if (matchingRun) {
       actionFunction = buildRunAction(matchingRun.id, matchingRun.kind);
-      
+
       if (matchingRun.status === 'failed') {
-        subtitle = matchingRun.errorMessage ? `Failed · ${matchingRun.errorMessage}` : 'Failed';
+        subtitle = `Failed · ${matchingRun.tailOutput ?? matchingRun.errorMessage ?? '(no output)'}`;
       } else if (matchingRun.status === 'succeeded') {
-        subtitle = 'Done';
+        subtitle = `Done · ${matchingRun.tailOutput ?? '(no output)'}`;
       }
     } else if (typeof extensionAction === 'function') {
       const originalExtAction = extensionAction;
@@ -385,20 +391,22 @@ export function buildMappedItems({
   const definitionIds = new Set(baseItems.map(r => r.objectId));
   const isAttributed = (run: Run) => !!run.subjectId && definitionIds.has(run.subjectId);
 
-  const unattributedActive = activeRuns.filter(r => !isAttributed(r));
-  const unattributedFailed = failedRuns.filter(r => !isAttributed(r));
-  const unattributedKept   = keptAgentRuns.filter(r => !isAttributed(r));
+  const unattributedActive       = activeRuns.filter(r => !isAttributed(r));
+  const unattributedFailed       = failedRuns.filter(r => !isAttributed(r));
+  const unattributedKept         = keptAgentRuns.filter(r => !isAttributed(r));
+  const unattributedScriptResult = scriptResultRuns.filter(r => !isAttributed(r));
 
-  const activeItems = unattributedActive.map(buildRunMappedItem);
-  const failedItems = unattributedFailed.map(buildRunMappedItem);
-  const keptItems   = unattributedKept.map(buildRunMappedItem);
+  const activeItems        = unattributedActive.map(buildRunMappedItem);
+  const failedItems        = unattributedFailed.map(buildRunMappedItem);
+  const keptItems          = unattributedKept.map(buildRunMappedItem);
+  const scriptResultItems  = unattributedScriptResult.map(buildRunMappedItem);
 
   if (!hasQuery) {
     // Default-mode browse view: empty-query sectioned list (Scripts / Agents /
     // Commands) lives downstream. To ensure keyboard navigation is consistent
     // with visual rendering, we must pre-sort the items by the exact same
     // section weighting before returning.
-    const runItems = [...activeItems, ...failedItems, ...keptItems];
+    const runItems = [...activeItems, ...failedItems, ...keptItems, ...scriptResultItems];
     // JS Array.prototype.sort is guaranteed stable since ES2019, so within
     // the same weight, the original [runs -> catalog] order is preserved.
     const allMappedItems = [...runItems, ...mappedItems].sort(
@@ -435,6 +443,7 @@ export function buildMappedItems({
     ...activeItems.map((item, i) => ({ kind: 'run' as const, item, tier: matchTier(unattributedActive[i].label, q) })),
     ...failedItems.map((item, i) => ({ kind: 'run' as const, item, tier: matchTier(unattributedFailed[i].label, q) })),
     ...keptItems.map  ((item, i) => ({ kind: 'run' as const, item, tier: matchTier(unattributedKept[i].label, q) })),
+    ...scriptResultItems.map((item, i) => ({ kind: 'run' as const, item, tier: matchTier(unattributedScriptResult[i].label, q) })),
   ];
 
   // Stable-sort by tier ascending; Array.prototype.sort is stable in modern

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -144,7 +144,11 @@
   // dedup cache fires only when the four numbers actually change. No-op on
   // non-macOS (the chips render inline via ShowMoreBarHuds.svelte there).
   $effect(() => {
-    const counts = aggregateKindCounts(runService.active, runService.keptAgents);
+    const counts = aggregateKindCounts(
+      runService.active,
+      runService.keptAgents,
+      runService.unacknowledgedScriptResults,
+    );
     void pushShowMoreBarHuds(counts);
   });
 

--- a/src/services/launcher/itemStatusLogic.test.ts
+++ b/src/services/launcher/itemStatusLogic.test.ts
@@ -28,10 +28,17 @@ describe('computeItemStatus', () => {
     expect(computeItemStatus('cmd_scripts_dyn_abc', [snap({ status: 'pending' })])).toBe('active');
   });
 
-  it('returns "done" when a matching run has succeeded', () => {
-    // Succeeded shell-script runs are kept in the active snapshot for a brief
-    // cooldown window (e.g., 3s) so the UI can show positive feedback (green dot).
-    expect(computeItemStatus('cmd_scripts_dyn_abc', [snap({ status: 'succeeded' })])).toBe('done');
+  it('returns "done" when a matching kept-success run exists', () => {
+    // Succeeded scripts live in unacknowledgedScriptResults until dismissed,
+    // and are passed in as the 4th `succeeded` argument.
+    const succeeded = [snap({ status: 'succeeded', subjectId: 'cmd_scripts_dyn_abc' })];
+    expect(computeItemStatus('cmd_scripts_dyn_abc', [], [], succeeded)).toBe('done');
+  });
+
+  it('active wins over kept-success when both exist for the same subjectId', () => {
+    const active = [snap({ status: 'running', subjectId: 'cmd_scripts_dyn_abc' })];
+    const succeeded = [snap({ id: 'r2', status: 'succeeded', subjectId: 'cmd_scripts_dyn_abc' })];
+    expect(computeItemStatus('cmd_scripts_dyn_abc', active, [], succeeded)).toBe('active');
   });
 
   it('returns "failed" when a matching unacknowledged failed run exists', () => {
@@ -65,14 +72,15 @@ describe('aggregateKindCounts', () => {
     expect(result.agents.active).toBe(1);
   });
 
-  it('counts succeeded scripts toward scripts.done during cooldown', () => {
-    // When a succeeded script run is kept in active snapshot during its 3s cooldown,
-    // it contributes to the HUD Done count.
-    const result = aggregateKindCounts(
-      [snap({ kind: 'shell-script', status: 'succeeded', subjectId: 'cmd_scripts_dyn_a' })],
-      [],
-    );
-    expect(result.scripts.done).toBe(1);
+  it('scripts.done == scriptResults.length', () => {
+    // Succeeded scripts persist in unacknowledgedScriptResults until dismissed.
+    // The HUD Done count tracks that slice directly.
+    const scriptResults: RunSnapshot[] = [
+      snap({ id: 'k1', kind: 'shell-script', status: 'succeeded', subjectId: 'cmd_scripts_dyn_a', endedAt: 1 }),
+      snap({ id: 'k2', kind: 'shell-script', status: 'succeeded', subjectId: 'cmd_scripts_dyn_b', endedAt: 2 }),
+    ];
+    const result = aggregateKindCounts([], [], scriptResults);
+    expect(result.scripts.done).toBe(2);
   });
 
   it('agents.done == keptAgents.length (no time window)', () => {
@@ -155,19 +163,23 @@ describe('statusForRow', () => {
     )).toBe('active');
   });
 
-  it('returns null for a script row when its run has succeeded and cooldown expired', () => {
-    // After the 3s cooldown, the run vanishes from active, so the dot turns off.
+  it('returns null for a script row when its succeeded run was dismissed', () => {
+    // After dismissal, the run leaves unacknowledgedScriptResults, so the dot turns off.
     expect(statusForRow(
       { type: 'command', object_id: 'cmd_scripts_dyn_abc' },
-      [],  // run has already vanished from active
+      [],
+      [],
+      [],
     )).toBeNull();
   });
 
-  it('returns "done" for a script row during the succeeded run cooldown', () => {
-    const active = [snap({ status: 'succeeded', subjectId: 'cmd_scripts_dyn_abc' })];
+  it('returns "done" for a script row with a matching kept-success run', () => {
+    const succeeded = [snap({ status: 'succeeded', subjectId: 'cmd_scripts_dyn_abc' })];
     expect(statusForRow(
       { type: 'command', object_id: 'cmd_scripts_dyn_abc' },
-      active,
+      [],
+      [],
+      succeeded,
     )).toBe('done');
   });
 

--- a/src/services/launcher/itemStatusLogic.ts
+++ b/src/services/launcher/itemStatusLogic.ts
@@ -5,10 +5,11 @@
 // macOS HUD push effect) pass in the current snapshot each render.
 //
 // Lifecycle policy (user-locked):
-//   - Scripts: auto-remove on success. Failed/cancelled run rows stay via
-//     runService.unacknowledgedFailures (no dot — subtitle handles it).
-//     The script-definition row (cmd_scripts_dyn_*) lights up blue only
-//     while a run is active; never green-after-success.
+//   - Scripts: succeeded scripts persist in runService.unacknowledgedScriptResults
+//     so the user can read the output until they dismiss. Failed/cancelled
+//     run rows stay via runService.unacknowledgedFailures. The script-
+//     definition row (cmd_scripts_dyn_*) lights up blue while a run is
+//     active, green after success (until dismissed), red on failure.
 //   - Threads (agents): persist after success in runService.keptAgents
 //     (deduped by subjectId — one row per agent). User dismisses manually.
 //     Failed/cancelled thread rows stay in unacknowledgedFailures like
@@ -37,23 +38,23 @@ function isActive(s: RunStatus): boolean {
 }
 
 /**
- * "Is there a live or recent run for this subjectId?" Used by the script-definition
- * row to light up with a blue active dot while running, a green done dot during its
- * short cooldown window, or a red failed dot if there is an unacknowledged failure.
+ * "Is there a live or recent run for this subjectId?" Used by the script-
+ * definition row to light up with a blue active dot while running, a green
+ * done dot when a kept-success entry exists, or a red failed dot when an
+ * unacknowledged failure exists. Active takes precedence over done; done
+ * takes precedence over failed (a re-run that succeeds clears the prior
+ * failed signal as soon as it's kept-saved).
  */
 export function computeItemStatus(
   subjectId: string | undefined,
   active: RunSnapshot[],
   failed: RunSnapshot[] = [],
+  succeeded: RunSnapshot[] = [],
 ): ItemStatus | null {
   if (!subjectId) return null;
-  const matchingActive = active.filter(r => r.subjectId === subjectId);
-  if (matchingActive.some(r => isActive(r.status))) return 'active';
-  if (matchingActive.some(r => r.status === 'succeeded')) return 'done';
-  
-  const matchingFailed = failed.filter(r => r.subjectId === subjectId);
-  if (matchingFailed.length > 0) return 'failed';
-  
+  if (active.some(r => r.subjectId === subjectId && isActive(r.status))) return 'active';
+  if (succeeded.some(r => r.subjectId === subjectId)) return 'done';
+  if (failed.some(r => r.subjectId === subjectId)) return 'failed';
   return null;
 }
 
@@ -68,22 +69,22 @@ export interface AggregateCounts {
 }
 
 /**
- * Counts shown in the Show More bar HUD chips. Sourced from two reactive
- * slices:
+ * Counts shown in the Show More bar HUD chips. Sourced from three slices:
  *   - `active`        — live runs (runService.active)
  *   - `keptAgents`    — succeeded agent runs the user hasn't dismissed
- *                       (runService.keptAgents). Already deduped by
- *                       subjectId at the service layer, so .length gives
- *                       the per-agent kept-thread count.
+ *                       (runService.keptAgents). Deduped by subjectId.
+ *   - `scriptResults` — succeeded shell-script runs the user hasn't
+ *                       dismissed (runService.unacknowledgedScriptResults).
+ *                       Deduped by subjectId at the service layer.
  *
  * `subjectId` is NOT required — the HUD is a machine-level aggregate, not
  * an item-row indicator. Anonymous Tier 2 runs (e.g. sdk-playground's
- * `shellService.spawn` without a Tier-1 dispatch wrapper) count too, so
- * the chip matches what the SectionedResultsList shows in default mode.
+ * `shellService.spawn` without a Tier-1 dispatch wrapper) count too.
  */
 export function aggregateKindCounts(
   active: RunSnapshot[],
   keptAgents: RunSnapshot[],
+  scriptResults: RunSnapshot[] = [],
 ): AggregateCounts {
   const out: AggregateCounts = {
     scripts: { active: 0, done: 0 },
@@ -92,38 +93,39 @@ export function aggregateKindCounts(
 
   for (const r of active) {
     if (r.kind === 'shell-script' && isActive(r.status)) out.scripts.active++;
-    else if (r.kind === 'shell-script' && r.status === 'succeeded') out.scripts.done++;
-    else if (r.kind === 'agent'   && isActive(r.status)) out.agents.active++;
+    else if (r.kind === 'agent' && isActive(r.status)) out.agents.active++;
   }
+  out.scripts.done = scriptResults.length;
   out.agents.done = keptAgents.length;
   return out;
 }
 
 /**
  * Per-row status used by the launcher list components. Encodes the
- * four-class row rule:
+ * row rules:
  *   1. `type === 'run'`        → 'active' (live run row).
- *   2. `type === 'run-done'`   → 'done'   (succeeded agent run that the
- *                                          user has not yet dismissed).
- *   3. `type === 'run-failed'` → null     (subtitle conveys failure).
- *   4. `cmd_scripts_dyn_*`     → 'active' if a matching live run exists;
- *                                otherwise null. Succeeded scripts
- *                                auto-remove, so we never light up the
- *                                definition row green.
+ *   2. `type === 'run-done'`   → 'done'   (kept succeeded run: agent thread
+ *                                          or script result).
+ *   3. `type === 'run-failed'` → 'failed' (red dot on failed run rows).
+ *   4. `cmd_scripts_dyn_*`     → 'active' if a matching live run exists,
+ *                                else 'done' if a kept-success result
+ *                                exists, else 'failed' if an unack failure
+ *                                exists, else null.
  *   5. anything else (incl. `cmd_agents_dyn_*`) → null. Agent definitions
- *      stay quiet so the kept-thread row in Agents section is the sole
- *      signal — no double-signal.
+ *      stay quiet so the kept-thread row is the sole signal — no
+ *      double-signal.
  */
 export function statusForRow(
   item: { type?: string; object_id: string },
   active: RunSnapshot[],
   failed: RunSnapshot[] = [],
+  succeeded: RunSnapshot[] = [],
 ): ItemStatus | null {
   if (item.type === 'run') return 'active';
   if (item.type === 'run-done') return 'done';
   if (item.type === 'run-failed') return 'failed';
   if (item.object_id.startsWith('cmd_scripts_dyn_')) {
-    return computeItemStatus(item.object_id, active, failed);
+    return computeItemStatus(item.object_id, active, failed, succeeded);
   }
   return null;
 }

--- a/src/services/run/runService.svelte.ts
+++ b/src/services/run/runService.svelte.ts
@@ -17,6 +17,12 @@ export interface LocalRunHandle {
 }
 
 const UNACK_FAILED_CAP = 5;
+const NOTIFICATION_BODY_MAX = 120;
+
+function truncate(text: string, max = NOTIFICATION_BODY_MAX): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1) + '…';
+}
 
 export class RunService {
   active = $state<Run[]>([]);
@@ -30,9 +36,8 @@ export class RunService {
   unacknowledgedFailures = $state<Run[]>([]);
   /**
    * Succeeded agent runs that the user hasn't dismissed yet — kept in the
-   * launcher's main list as `run-done` rows (a green-dot persistent entry).
-   * The lifecycle policy is: scripts auto-remove on success, agent threads
-   * persist until the user explicitly dismisses them.
+   * launcher's main list as `run-done` rows (a green-dot persistent entry)
+   * until the user explicitly dismisses via Cmd+K → Dismiss Thread.
    *
    * Deduped by `subjectId` (the per-agent dynamic-command id set by
    * `agentLoop.ts`) — one entry per agent. A newer successful run of the
@@ -41,6 +46,14 @@ export class RunService {
    * persistent history still lives in `recent` / SQLite.
    */
   keptAgents = $state<Run[]>([]);
+  /**
+   * Succeeded shell-script runs that the user hasn't dismissed yet — surfaced
+   * as `run-done` rows so script output stays inspectable after the run ends.
+   * Deduped by `subjectId` when present (so re-running the same script row
+   * collapses into one entry); anonymous runs are deduped by id. Capped at
+   * UNACK_FAILED_CAP.
+   */
+  unacknowledgedScriptResults = $state<Run[]>([]);
   selectedRunId = $state<string | null>(null);
   activeCount = $derived(this.active.length);
   /**
@@ -178,7 +191,7 @@ export class RunService {
 
         void notificationService.send('runs', {
           title: 'Run failed',
-          body: run.label,
+          body: truncate(run.tailOutput ?? run.errorMessage ?? '(no output)'),
           actions: [
             {
               id: 'open',
@@ -197,6 +210,29 @@ export class RunService {
           run,
           ...this.keptAgents.filter((r) => r.subjectId !== run.subjectId),
         ].slice(0, UNACK_FAILED_CAP);
+      }
+
+      if (run.status === 'succeeded' && run.kind === 'shell-script') {
+        // Scripts persist after success so the user can read the output.
+        // Dedupe by subjectId when present so re-running the same script row
+        // collapses into one entry; anonymous (no subjectId) runs dedupe by id.
+        const filtered = run.subjectId
+          ? this.unacknowledgedScriptResults.filter((r) => r.subjectId !== run.subjectId)
+          : this.unacknowledgedScriptResults.filter((r) => r.id !== run.id);
+        this.unacknowledgedScriptResults = [run, ...filtered].slice(0, UNACK_FAILED_CAP);
+
+        void notificationService.send('runs', {
+          title: 'Script finished',
+          body: truncate(`${run.label}\n${run.tailOutput ?? '(no output)'}`),
+          actions: [
+            {
+              id: 'view-output',
+              title: 'View output',
+              commandId: 'open-runs',
+              args: { arguments: { id: run.id } },
+            },
+          ],
+        });
       }
 
       if (run.status === 'cancelled' && run.extensionId) {
@@ -249,6 +285,17 @@ export class RunService {
    */
   dismissKeptAgent(id: string): void {
     this.keptAgents = this.keptAgents.filter((r) => r.id !== id);
+  }
+
+  /**
+   * User-initiated dismissal of a succeeded shell-script result row. Drops
+   * the row from the launcher list AND frees the in-memory output buffer
+   * via `runs_dismiss`. The persistent SQLite history record (including the
+   * captured `tailOutput`) is unaffected.
+   */
+  dismissScriptResult(id: string): void {
+    this.unacknowledgedScriptResults = this.unacknowledgedScriptResults.filter((r) => r.id !== id);
+    void invokeSafe('runs_dismiss', { id });
   }
 
   async startLocal(input: {
@@ -312,6 +359,7 @@ export class RunService {
     this.recent = [];
     this.unacknowledgedFailures = [];
     this.keptAgents = [];
+    this.unacknowledgedScriptResults = [];
     this.selectedRunId = null;
     this.subscribe();
   }

--- a/src/services/run/runService.test.ts
+++ b/src/services/run/runService.test.ts
@@ -132,7 +132,8 @@ describe('onStateChanged', () => {
     runService['onStateChanged'](runRunning);
     runService['onStateChanged'](runSucceeded);
     
-    // Removes immediately on success per transactional lifecycle policy
+    // Succeeded shell-script leaves the active slice; the kept row lives in
+    // unacknowledgedScriptResults (see separate test).
     expect(runService.active.some((r) => r.id === 'r1')).toBe(false);
 
     const inRecent = runService.recent.find((r) => r.id === 'r1');
@@ -147,7 +148,8 @@ describe('onStateChanged', () => {
     runService['onStateChanged'](runRunning);
     expect(runService.active.some((r) => r.id === 'r2')).toBe(true);
     
-    // Without a subjectId, no cooldown applies; it must vanish immediately
+    // Anonymous (no subjectId) shell-script still leaves active on success;
+    // it lives in unacknowledgedScriptResults (deduped by id).
     runService['onStateChanged'](runSucceeded);
     expect(runService.active.some((r) => r.id === 'r2')).toBe(false);
   });
@@ -193,15 +195,16 @@ describe('onStateChanged', () => {
     expect(runService.keptAgents[0].id).toBe('r1');
   });
 
-  it('succeeded_shell_script_does_NOT_populate_keptAgents', () => {
-    // Lifecycle policy: scripts auto-remove on success. The kept slice is
-    // strictly agent-only.
+  it('succeeded_shell_script_does_NOT_populate_keptAgents_but_does_populate_scriptResults', () => {
+    // Scripts persist in their own slice; the agent kept-slice stays agent-only.
     const run = makeRun({
       id: 'r1', status: 'succeeded', kind: 'shell-script',
       subjectId: 'cmd_scripts_dyn_abc', endedAt: Date.now(),
     });
     runService['onStateChanged'](run);
     expect(runService.keptAgents).toHaveLength(0);
+    expect(runService.unacknowledgedScriptResults).toHaveLength(1);
+    expect(runService.unacknowledgedScriptResults[0].id).toBe('r1');
   });
 
   it('keptAgents_dedupes_by_subjectId_keeping_newest', () => {
@@ -248,6 +251,73 @@ describe('onStateChanged', () => {
     }));
     runService.dismissKeptAgent('r1');
     expect(runService.keptAgents).toHaveLength(0);
+  });
+
+  // ── unacknowledgedScriptResults: persistent script-success rows ─────────────
+
+  it('succeeded_shell_script_with_subjectId_is_added_to_scriptResults', () => {
+    const run = makeRun({
+      id: 'r1', status: 'succeeded', kind: 'shell-script',
+      subjectId: 'cmd_scripts_dyn_abc', tailOutput: 'OK', endedAt: Date.now(),
+    });
+    runService['onStateChanged'](run);
+    expect(runService.unacknowledgedScriptResults).toHaveLength(1);
+    expect(runService.unacknowledgedScriptResults[0].id).toBe('r1');
+    expect(runService.unacknowledgedScriptResults[0].tailOutput).toBe('OK');
+  });
+
+  it('succeeded_agent_does_NOT_populate_scriptResults', () => {
+    const run = makeRun({
+      id: 'r1', status: 'succeeded', kind: 'agent',
+      subjectId: 'cmd_agents_dyn_a1', endedAt: Date.now(),
+    });
+    runService['onStateChanged'](run);
+    expect(runService.unacknowledgedScriptResults).toHaveLength(0);
+  });
+
+  it('scriptResults_dedupes_by_subjectId_keeping_newest', () => {
+    const old = makeRun({
+      id: 'r1', status: 'succeeded', kind: 'shell-script',
+      subjectId: 'cmd_scripts_dyn_abc', endedAt: 1,
+    });
+    const fresh = makeRun({
+      id: 'r2', status: 'succeeded', kind: 'shell-script',
+      subjectId: 'cmd_scripts_dyn_abc', endedAt: 2,
+    });
+    runService['onStateChanged'](old);
+    runService['onStateChanged'](fresh);
+    expect(runService.unacknowledgedScriptResults).toHaveLength(1);
+    expect(runService.unacknowledgedScriptResults[0].id).toBe('r2');
+  });
+
+  it('anonymous_succeeded_shell_script_without_subjectId_is_added_dedupes_by_id', () => {
+    const run = makeRun({
+      id: 'r1', status: 'succeeded', kind: 'shell-script',
+      subjectId: undefined, endedAt: Date.now(),
+    });
+    runService['onStateChanged'](run);
+    expect(runService.unacknowledgedScriptResults).toHaveLength(1);
+  });
+
+  it('dismissScriptResult_filters_slice_and_invokes_runs_dismiss', () => {
+    runService['onStateChanged'](makeRun({
+      id: 'r1', status: 'succeeded', kind: 'shell-script',
+      subjectId: 'cmd_scripts_dyn_abc', endedAt: 1,
+    }));
+    vi.mocked(invokeSafe).mockResolvedValue(null);
+    runService.dismissScriptResult('r1');
+    expect(runService.unacknowledgedScriptResults).toHaveLength(0);
+    expect(invokeSafe).toHaveBeenCalledWith('runs_dismiss', { id: 'r1' });
+  });
+
+  it('reset_clears_unacknowledgedScriptResults', () => {
+    runService['onStateChanged'](makeRun({
+      id: 'r1', status: 'succeeded', kind: 'shell-script',
+      subjectId: 'cmd_scripts_dyn_abc', endedAt: 1,
+    }));
+    expect(runService.unacknowledgedScriptResults).toHaveLength(1);
+    runService.reset();
+    expect(runService.unacknowledgedScriptResults).toHaveLength(0);
   });
 });
 
@@ -425,7 +495,7 @@ describe('startLocal', () => {
 // ── Failure notifications ─────────────────────────────────────────────────────
 
 describe('failure notifications', () => {
-  it('failed_run_fires_notification_with_open_action', () => {
+  it('failed_run_fires_notification_with_tail_or_error_in_body', () => {
     const run = makeRun({ id: 'r1', label: 'My Run', status: 'failed', errorMessage: 'boom' });
     runService['onStateChanged'](run);
 
@@ -434,7 +504,7 @@ describe('failure notifications', () => {
     const [callerExtId, options] = vi.mocked(notificationService.send).mock.calls[0];
     expect(callerExtId).toBe('runs');
     expect(options.title.toLowerCase()).toContain('failed');
-    expect(options.body).toContain('My Run');
+    expect(options.body).toContain('boom');
     expect(options.actions).toBeDefined();
     expect(options.actions!.length).toBeGreaterThanOrEqual(1);
 
@@ -443,8 +513,48 @@ describe('failure notifications', () => {
     expect(openAction.args).toEqual(expect.objectContaining({ arguments: { id: 'r1' } }));
   });
 
-  it('succeeded_run_does_not_fire_notification', () => {
-    const run = makeRun({ id: 'r2', status: 'succeeded', endedAt: Date.now() });
+  it('failed_run_notification_prefers_tailOutput_over_errorMessage', () => {
+    const run = makeRun({
+      id: 'r1', status: 'failed',
+      tailOutput: 'Error: file not found',
+      errorMessage: 'exit code 1',
+    });
+    runService['onStateChanged'](run);
+    const [, options] = vi.mocked(notificationService.send).mock.calls[0];
+    expect(options.body).toBe('Error: file not found');
+  });
+
+  it('failed_run_notification_falls_back_to_no_output_text_when_both_missing', () => {
+    const run = makeRun({
+      id: 'r1', status: 'failed',
+      tailOutput: undefined, errorMessage: undefined,
+    });
+    runService['onStateChanged'](run);
+    const [, options] = vi.mocked(notificationService.send).mock.calls[0];
+    expect(options.body).toBe('(no output)');
+  });
+
+  it('succeeded_shell_script_fires_script_finished_notification_with_tail_preview', () => {
+    const run = makeRun({
+      id: 'r1', label: 'Hosts Update', status: 'succeeded', kind: 'shell-script',
+      tailOutput: 'OK — synced 12 files', endedAt: Date.now(),
+    });
+    runService['onStateChanged'](run);
+
+    expect(notificationService.send).toHaveBeenCalledTimes(1);
+    const [callerExtId, options] = vi.mocked(notificationService.send).mock.calls[0];
+    expect(callerExtId).toBe('runs');
+    expect(options.title).toBe('Script finished');
+    expect(options.body).toContain('Hosts Update');
+    expect(options.body).toContain('OK — synced 12 files');
+
+    const viewAction = options.actions![0];
+    expect(viewAction.commandId).toBe('open-runs');
+    expect(viewAction.args).toEqual(expect.objectContaining({ arguments: { id: 'r1' } }));
+  });
+
+  it('succeeded_agent_run_does_not_fire_notification', () => {
+    const run = makeRun({ id: 'r1', status: 'succeeded', kind: 'agent', endedAt: Date.now() });
     runService['onStateChanged'](run);
     expect(notificationService.send).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Scripts now keep their last-line output preview after they finish, on both
the success and failure paths, so users can always see how a script ended
without having to open the run detail view in time.

- Capture Run.tailOutput at finalize from the in-memory OutputBuffer; keep
  the buffer alive past finalize so RunView can show the full output
  post-mortem and dismiss explicitly frees it via runs_dismiss.
- Succeeded shell-scripts persist as "Done · {output}" rows in the Scripts
  section until dismissed (mirroring the kept-agents pattern); previously
  they vanished silently.
- Failed-run rows and notifications now lead with the captured output tail
  instead of just the run label or raw error code.
- New "Script finished" notification carries the tail preview and opens
  RunView with the run pre-selected; agent runs still notify only on
  failure.