### PR TITLE
feat: silent AI commands that replace selected text in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ https://github.com/user-attachments/assets/fc3b0e5e-9af8-49c4-8da8-d87b44338a0e
 | Deep Link Integration | ✅ | ✅ | ✅ |
 | Background Scheduling (native Rust daemon) | ✅ | ❌ | ❌ |
 | Reactive Live Subtitles (real-time root list updates) | ✅ | ❌ | ❌ |
+| **Silent AI Commands** (no-window in-place text replacement) | ✅ | ❌ | ❌ |
 
 ---
 
@@ -48,6 +49,7 @@ Asyar is built with **Tauri + Rust** instead of Electron. That means:
 
 - **Application Launcher** — Find and launch any installed application instantly
 - **AI Agents with Tool Calling** — Build custom AI agents with persistent threads and tool calling, backed by your choice of provider (OpenAI, Anthropic, Google, Ollama, OpenRouter, or any OpenAI-compatible endpoint). **Asyar Assistant** is built in — press `Tab` from the empty launcher to summon it. Streaming responses, LaTeX math, syntax highlighting, and Mermaid diagrams included.
+- **Silent AI Commands** — Mark any agent as silent, point it at your selection (or clipboard, or a one-shot argument), and have the response **replace the text in place** in whatever app you were typing in. No launcher window, no chat view, no confirm dialog. Perfect for "fix grammar", "translate this", "make it shorter", or any other one-shot transform you run dozens of times a day.
 - **Built-in Tools for Agents** — Eight tools your agents can use out of the box: calculator, clipboard read/write, file read/write, shell execution, web fetch, and launcher search. Extensions can register their own tools too.
 - **MCP (Model Context Protocol)** — Connect any MCP-compatible server. Auto-detects existing configs from Claude Desktop, Cursor, Cline, Continue, and Zed; bundled `bun` and `uv` let `npx`/`uvx`-based servers run without a local Node.js or Python install. First-call permission prompts gate write and exec tools per agent.
 - **Scripts** — Run shell scripts from the launcher. Add metadata headers (`@asyar.title`, `@asyar.icon`, `@asyar.argument:N`) so your script gets a name, icon, and prompted arguments. Live progress surfaces as a run row.
@@ -162,6 +164,7 @@ See [`docs/explanation/clipboard-privacy.md`](docs/explanation/clipboard-privacy
 | Applications | ✅ | ✅ | ✅ |
 | Application Icons | ✅ | ✅ | ✅ |
 | AI Agents | ✅ | ✅ | ✅ |
+| Silent AI Commands | ✅ | ✅ | ✅ |
 | MCP Servers | ✅ | ✅ | ✅ |
 | Scripts | ✅ | ✅ | ✅ |
 | Calculator | ✅ | ✅ | ✅ |
@@ -251,6 +254,35 @@ Asyar agents are first-class command targets — type the agent's name, press `E
 - **MCP integration** — Add Model Context Protocol servers from **Settings → MCP**, or auto-import existing configs from Claude Desktop, Cursor, Cline, Continue, or Zed. Bundled `bun` and `uv` sidecars run `npx`/`uvx`-based servers without system installs.
 - **Streaming + cancellation** — Replies stream word-by-word; cancel mid-response.
 - **Your key, your data** — requests go directly from your device to your provider; nothing routes through Asyar servers.
+
+---
+
+## Silent AI Commands
+
+1. Open the launcher → **Manage Agents** → **New Agent**.
+2. Name it (e.g. *Grammar Fix*), set a one-line system prompt (*"Reply ONLY with the corrected text — no preamble, no quotes"*).
+3. Toggle **Run silently (no chat view)** on. Pick an **Input source** and an **Output action**.
+4. Save, then bind a hotkey from the launcher root with ⌘K → *Set Shortcut*.
+
+Now select text anywhere — TextEdit, your editor, a browser textarea, Mail — and press your hotkey. The selection is sent to the LLM and the response **replaces it in place**. The launcher never opens.
+
+| Input source | Where the agent's input comes from |
+|---|---|
+| **Selected text in the active app** | The text you currently have highlighted (read via Accessibility) |
+| **Clipboard** | Whatever you most recently copied |
+| **Argument** | A one-shot text argument typed in the chip row |
+| **None** | Empty input — the prompt alone drives the response |
+
+| Output action | What happens to the LLM's response |
+|---|---|
+| **Replace the selection with the result** | Saves your clipboard, writes the result, pastes (replacing the selection), then restores your clipboard a moment later |
+| **Copy to clipboard** | Quietly copies the result; nothing is pasted |
+| **Paste at cursor** | Pastes at the cursor position without trying to replace anything |
+| **Show a HUD with the last line** | Brief top-of-screen toast with the last line of the response |
+
+The whole pipeline is structurally headless — silent agents never create a thread, never enter the Run Tracker's "Done" list, never fire a notification on success (failures still notify, with the error in the body). Tool-using silent agents are supported: the loop iterates until a final assistant message and only then triggers the output action.
+
+See [`docs/reference/silent-agents.md`](docs/reference/silent-agents.md) for the full reference.
 
 ---
 

--- a/docs/explanation/run-tracking.md
+++ b/docs/explanation/run-tracking.md
@@ -97,5 +97,6 @@ The three kept slices (`unacknowledgedFailures`, `keptAgents`, `unacknowledgedSc
 
 - [RunService — SDK reference](../reference/sdk/run-service.md) — the public API that Tier 2 extensions call to start, write, and finish runs.
 - [Script Headers](../reference/script-headers.md) — `# @asyar.*` directives for user scripts, including `mode: inline` (which deliberately *bypasses* the Run Tracker so live-ticking subtitles don't pollute the kept-Done slice).
+- [Silent AI Commands](../reference/silent-agents.md) — silent agents bypass the Run Tracker for the same reason: a hotkey-driven grammar fix shouldn't pin a kept-Done row every keystroke.
 - [Extension Runtime](./extension-runtime.md) — worker-survives-Dormant context; why long-running work must be anchored to the worker iframe, not the view.
 - [Two-Tier Model](./two-tier-model.md) — Tier 1 (built-in features, direct host access) vs Tier 2 (sandbox iframe); why `subjectId` is only settable from built-in dispatch sites.

--- a/docs/reference/silent-agents.md
+++ b/docs/reference/silent-agents.md
@@ -1,0 +1,149 @@
+---
+order: 60
+---
+# Silent AI Commands
+
+A **silent AI command** is an agent that runs headlessly: the user
+selects text somewhere in the OS (editor, browser, email), presses a
+hotkey bound to the agent, and the launcher reads the selection, sends
+it to the LLM, and replaces the selection in place with the model's
+reply. The launcher window never opens. No confirm dialog, no preview,
+no chat view. The reference UX is the Reddit "Silent AI command" flow
+— one keystroke, in-place replacement, dozens of times a day.
+
+Use this for one-shot text transformations: grammar fixes,
+translations, tone adjustments, summaries, formatting touch-ups. For
+multi-turn back-and-forth, keep the normal chat-view flow.
+
+## How it works
+
+Agents now carry three extra fields:
+
+| Field | Type | Default | Meaning when `silent === false` |
+| --- | --- | --- | --- |
+| `silent` | `boolean` | `false` | Default chat-view flow. |
+| `inputSource` | `'selection' \| 'clipboard' \| 'argument' \| 'none'` | `'argument'` | Stored but unused. |
+| `outputAction` | `'replaceSelection' \| 'paste' \| 'copy' \| 'hud'` | `'replaceSelection'` | Stored but unused. |
+
+When `silent === true`, dispatching the agent (via the launcher row
+Enter or a bound item shortcut) routes to the **silent dispatcher**
+instead of opening the chat view:
+
+1. **Input capture** — read the user text from the chosen `inputSource`:
+   - `selection` — macOS Accessibility selection of the previously
+     frontmost app. Empty selection HUDs "No selection" and aborts.
+   - `clipboard` — current clipboard contents. Empty clipboard HUDs
+     "Clipboard is empty" and aborts.
+   - `argument` — text typed in the launcher bar (or passed through
+     command arguments). Empty string is acceptable.
+   - `none` — empty string. The agent's system prompt is fully
+     self-contained.
+2. **LLM call** — a single assistant turn. Tools selected on the
+   agent are still allowed: the loop iterates until the model emits a
+   final non-tool-call response, same as the chat-view flow.
+3. **Output action** — apply one of:
+   - `replaceSelection` — save clipboard → write result → hide
+     launcher → simulate Cmd+V → restore clipboard after ~200 ms.
+   - `paste` — identical flow to `replaceSelection`. Distinct intent
+     for apps without selection semantics.
+   - `copy` — write result to clipboard only. No paste, no clipboard
+     restore.
+   - `hud` — show the last non-empty line of the result in a HUD
+     toast.
+
+The original clipboard contents are restored after a short delay so
+the paste lands before the restore overwrites the result. Image and
+file clipboard contents can't be saved as text — those won't be
+restored after a `replaceSelection`/`paste` action.
+
+## Run-tracker suppression — the hard rule
+
+Silent agent invocations **must not** pollute the run tracker. They
+bypass `runService.startLocal`, never create a thread row, never
+insert messages, never touch `agentsManager.currentAgentId` or
+`viewManager.navigateToView`. A hotkey-driven grammar fix run a
+hundred times a day would otherwise flood the Scripts/Agents HUD
+chips, the launcher kept-Done row, and the Runs view with kept rows.
+This mirrors the inline-mode script scheduler: the timer-driven runs
+bypass the normal `shellService.spawn` promotion so a 30 s clock
+script doesn't pin a kept-Done row every tick.
+
+Failures (provider error, missing API key, empty model response) are
+the only thing surfaced — through `diagnosticsService.report({ kind:
+'silent_agent_failed', severity: 'warning' })` plus a system
+notification carrying the agent name and the error message. Success
+is fully silent.
+
+## Hotkeys
+
+Silent agents use the same item-shortcut UI as any other launcher
+row. Open the launcher, type the agent name, hit `Cmd+K` while the
+row is selected, pick **Set Shortcut**, press your chosen key combo.
+There are no manifest-declared per-command global hotkeys — this is
+the user's choice, not the agent author's.
+
+## Example — Grammar Fix
+
+The canonical silent-AI command:
+
+| Field | Value |
+| --- | --- |
+| Name | `Grammar Fix` |
+| Description | `Silent agent: replace selected text with the grammar-corrected version.` |
+| System prompt | (see below) |
+| Provider | Your preferred LLM provider |
+| Model | A fast model — `gpt-4o-mini`, `claude-3-5-haiku-20241022`, etc. |
+| Silent | `true` |
+| Input from | `Selected text in the active app` |
+| Then | `Replace the selection with the result` |
+| Tools | (none) |
+
+System prompt:
+
+> You are a grammar and style assistant. The user gives you a piece
+> of text and you reply ONLY with the corrected version. Fix grammar,
+> spelling, and awkward phrasing. Preserve the user’s original tone,
+> voice, language, and formatting. Do not add preamble, commentary,
+> or quotation marks — just the corrected text and nothing else.
+
+To create it programmatically:
+
+```ts
+import { buildGrammarFixAgentInput } from 'asyar-launcher/.../defaultAgent';
+import { agentService } from 'asyar-launcher/.../agentService.svelte';
+
+await agentService.create(
+  buildGrammarFixAgentInput('openai', 'gpt-4o-mini'),
+);
+```
+
+After it appears in the launcher, bind a hotkey to its row through
+the item-shortcut UI, select some text in any app, press the hotkey:
+the text is replaced with the corrected version. The launcher window
+never opens.
+
+## Architecture notes
+
+- Rust owns persistence: `silent` is an `INTEGER NOT NULL DEFAULT 0`
+  column on `agents`; `input_source` / `output_action` are short
+  lowercase strings stored as `TEXT`. Adding new variants is purely
+  additive — the parser falls back to defaults for unknown values.
+- The `init_table` migration uses the same idempotent `ALTER TABLE
+  IF NOT EXISTS` guard pattern as `runs_history.subject_id` and
+  `tail_output` — upgraded installs gain the columns in place
+  without dropping data.
+- The TS contract mirrors the Rust enums (camelCase string unions)
+  in [`built-in-features/agents/types.ts`](../../src/built-in-features/agents/agents/types.ts).
+- The silent dispatcher lives in
+  [`silentDispatch.ts`](../../src/built-in-features/agents/silentDispatch.ts);
+  the routing decision in
+  [`dispatch.ts`](../../src/built-in-features/agents/dispatch.ts)
+  is a single `if (agent.silent)` branch.
+
+## Cross-links
+
+- [Run Tracking](../explanation/run-tracking.md) — the run-promotion
+  policy this feature deliberately bypasses.
+- [Dynamic Commands](./dynamic-commands.md) — agents register as
+  dynamic commands so hotkey binding goes through the standard
+  item-shortcut path.

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -2,7 +2,8 @@ use crate::error::AppError;
 use crate::storage::agents::{
     backfill_thread_titles, delete_agent, delete_thread, find_run_origin, get_agent, insert_agent,
     insert_message, insert_thread, list_agents, list_messages_for_thread, list_threads_for_agent,
-    update_agent, update_thread_title, AgentRow, MessageRow, MessageRole, RunOrigin, ThreadRow,
+    update_agent, update_thread_title, AgentRow, MessageRow, MessageRole, RunOrigin,
+    SilentInputSource, SilentOutputAction, ThreadRow,
 };
 use crate::storage::DataStore;
 use rusqlite::Connection;
@@ -39,6 +40,16 @@ pub struct AgentCreateInput {
     pub provider_id: String,
     pub model_id: String,
     pub tool_selection: Vec<String>,
+    /// Optional silent-AI command settings. Defaults: `silent=false`,
+    /// `input_source=argument`, `output_action=replaceSelection`. The three
+    /// fields are stored regardless of `silent` — the agent editor flips
+    /// the toggle without re-validating the other two.
+    #[serde(default)]
+    pub silent: Option<bool>,
+    #[serde(default)]
+    pub input_source: Option<SilentInputSource>,
+    #[serde(default)]
+    pub output_action: Option<SilentOutputAction>,
 }
 
 #[derive(serde::Deserialize, specta::Type)]
@@ -51,6 +62,12 @@ pub struct AgentUpdateInput {
     pub provider_id: String,
     pub model_id: String,
     pub tool_selection: Vec<String>,
+    #[serde(default)]
+    pub silent: Option<bool>,
+    #[serde(default)]
+    pub input_source: Option<SilentInputSource>,
+    #[serde(default)]
+    pub output_action: Option<SilentOutputAction>,
 }
 
 #[derive(serde::Deserialize, specta::Type)]
@@ -85,6 +102,11 @@ pub fn agents_create_impl(conn: &Connection, input: AgentCreateInput) -> Result<
         provider_id,
         model_id,
         tool_selection: input.tool_selection,
+        silent: input.silent.unwrap_or(false),
+        input_source: input.input_source.unwrap_or(SilentInputSource::Argument),
+        output_action: input
+            .output_action
+            .unwrap_or(SilentOutputAction::ReplaceSelection),
         created_at: Some(now),
         updated_at: Some(now),
     };
@@ -109,6 +131,12 @@ pub fn agents_update_impl(conn: &Connection, input: AgentUpdateInput) -> Result<
         provider_id,
         model_id,
         tool_selection: input.tool_selection,
+        // For silent fields, fall back to the existing row's values when the
+        // input omits them — lets clients PATCH-style update without sending
+        // every field every time, while still allowing explicit overrides.
+        silent: input.silent.unwrap_or(existing.silent),
+        input_source: input.input_source.unwrap_or(existing.input_source),
+        output_action: input.output_action.unwrap_or(existing.output_action),
         created_at: existing.created_at,
         updated_at: Some(now_ms()),
     };

--- a/src-tauri/src/commands/agents_test.rs
+++ b/src-tauri/src/commands/agents_test.rs
@@ -5,7 +5,9 @@ use crate::commands::agents::{
     AgentUpdateInput, MessageInsertInput, ThreadCreateInput,
 };
 use crate::error::AppError;
-use crate::storage::agents::{insert_thread, MessageRole, ThreadRow};
+use crate::storage::agents::{
+    insert_thread, MessageRole, SilentInputSource, SilentOutputAction, ThreadRow,
+};
 use rusqlite::Connection;
 
 fn make_conn() -> Connection {
@@ -23,6 +25,9 @@ fn valid_create_input() -> AgentCreateInput {
         provider_id: "openai".to_string(),
         model_id: "gpt-4o".to_string(),
         tool_selection: vec![],
+        silent: None,
+        input_source: None,
+        output_action: None,
     }
 }
 
@@ -58,6 +63,9 @@ fn agents_create_impl_rejects_empty_name() {
         provider_id: "openai".to_string(),
         model_id: "gpt-4o".to_string(),
         tool_selection: vec![],
+        silent: None,
+        input_source: None,
+        output_action: None,
     };
     let result = agents_create_impl(&conn, input);
     assert!(
@@ -76,6 +84,9 @@ fn agents_create_impl_rejects_empty_system_prompt() {
         provider_id: "openai".to_string(),
         model_id: "gpt-4o".to_string(),
         tool_selection: vec![],
+        silent: None,
+        input_source: None,
+        output_action: None,
     };
     let result = agents_create_impl(&conn, input);
     assert!(
@@ -94,6 +105,9 @@ fn agents_create_impl_rejects_empty_provider_id() {
         provider_id: "  ".to_string(),
         model_id: "gpt-4o".to_string(),
         tool_selection: vec![],
+        silent: None,
+        input_source: None,
+        output_action: None,
     };
     let result = agents_create_impl(&conn, input);
     assert!(
@@ -112,6 +126,9 @@ fn agents_create_impl_rejects_empty_model_id() {
         provider_id: "openai".to_string(),
         model_id: "  ".to_string(),
         tool_selection: vec![],
+        silent: None,
+        input_source: None,
+        output_action: None,
     };
     let result = agents_create_impl(&conn, input);
     assert!(
@@ -135,6 +152,9 @@ fn agents_update_impl_updates_existing() {
         provider_id: "anthropic".to_string(),
         model_id: "claude-3-5-sonnet".to_string(),
         tool_selection: vec!["builtin:search".to_string()],
+        silent: None,
+        input_source: None,
+        output_action: None,
     };
     let updated = agents_update_impl(&conn, update_input).unwrap();
 
@@ -160,6 +180,9 @@ fn agents_update_impl_errors_when_id_unknown() {
         provider_id: "openai".to_string(),
         model_id: "gpt-4o".to_string(),
         tool_selection: vec![],
+        silent: None,
+        input_source: None,
+        output_action: None,
     };
     let result = agents_update_impl(&conn, input);
     assert!(
@@ -196,6 +219,9 @@ fn agents_list_impl_returns_all() {
         provider_id: "openai".to_string(),
         model_id: "gpt-4o".to_string(),
         tool_selection: vec![],
+        silent: None,
+        input_source: None,
+        output_action: None,
     };
     let input2 = AgentCreateInput {
         name: "Second".to_string(),
@@ -204,6 +230,9 @@ fn agents_list_impl_returns_all() {
         provider_id: "anthropic".to_string(),
         model_id: "claude-3-5-sonnet".to_string(),
         tool_selection: vec![],
+        silent: None,
+        input_source: None,
+        output_action: None,
     };
     agents_create_impl(&conn, input1).unwrap();
     agents_create_impl(&conn, input2).unwrap();
@@ -390,4 +419,110 @@ fn agents_messages_list_impl_orders_asc() {
     assert_eq!(messages.len(), 2, "expected 2 messages");
     assert_eq!(messages[0].id, m1.id, "earliest message must be first");
     assert_eq!(messages[1].id, m2.id);
+}
+
+// ── Silent AI command create/update ──────────────────────────────────────────
+
+#[test]
+fn agents_create_impl_defaults_silent_fields_when_unspecified() {
+    let conn = make_conn();
+    let row = agents_create_impl(&conn, valid_create_input()).unwrap();
+    assert!(!row.silent, "default silent must be false");
+    assert_eq!(row.input_source, SilentInputSource::Argument);
+    assert_eq!(row.output_action, SilentOutputAction::ReplaceSelection);
+}
+
+#[test]
+fn agents_create_impl_persists_silent_fields_when_provided() {
+    let conn = make_conn();
+    let input = AgentCreateInput {
+        name: "Grammar Fix".to_string(),
+        description: None,
+        system_prompt: "Fix grammar.".to_string(),
+        provider_id: "openai".to_string(),
+        model_id: "gpt-4o".to_string(),
+        tool_selection: vec![],
+        silent: Some(true),
+        input_source: Some(SilentInputSource::Selection),
+        output_action: Some(SilentOutputAction::ReplaceSelection),
+    };
+    let row = agents_create_impl(&conn, input).unwrap();
+    assert!(row.silent);
+    assert_eq!(row.input_source, SilentInputSource::Selection);
+    assert_eq!(row.output_action, SilentOutputAction::ReplaceSelection);
+
+    let fetched = agents_get_impl(&conn, row.id).unwrap().unwrap();
+    assert!(fetched.silent);
+    assert_eq!(fetched.input_source, SilentInputSource::Selection);
+}
+
+#[test]
+fn agents_update_impl_preserves_silent_fields_when_unspecified() {
+    let conn = make_conn();
+    let created = agents_create_impl(
+        &conn,
+        AgentCreateInput {
+            name: "Agent".to_string(),
+            description: None,
+            system_prompt: "system".to_string(),
+            provider_id: "openai".to_string(),
+            model_id: "gpt-4o".to_string(),
+            tool_selection: vec![],
+            silent: Some(true),
+            input_source: Some(SilentInputSource::Clipboard),
+            output_action: Some(SilentOutputAction::Copy),
+        },
+    )
+    .unwrap();
+
+    // Update only the name/system-prompt; silent fields omitted (=None).
+    let updated = agents_update_impl(
+        &conn,
+        AgentUpdateInput {
+            id: created.id.clone(),
+            name: "Renamed".to_string(),
+            description: None,
+            system_prompt: "system".to_string(),
+            provider_id: "openai".to_string(),
+            model_id: "gpt-4o".to_string(),
+            tool_selection: vec![],
+            silent: None,
+            input_source: None,
+            output_action: None,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(updated.name, "Renamed");
+    assert!(updated.silent, "silent must be preserved across update");
+    assert_eq!(updated.input_source, SilentInputSource::Clipboard);
+    assert_eq!(updated.output_action, SilentOutputAction::Copy);
+}
+
+#[test]
+fn agents_update_impl_overrides_silent_fields_when_specified() {
+    let conn = make_conn();
+    let created = agents_create_impl(&conn, valid_create_input()).unwrap();
+    assert!(!created.silent);
+
+    let updated = agents_update_impl(
+        &conn,
+        AgentUpdateInput {
+            id: created.id.clone(),
+            name: created.name.clone(),
+            description: created.description.clone(),
+            system_prompt: created.system_prompt.clone(),
+            provider_id: created.provider_id.clone(),
+            model_id: created.model_id.clone(),
+            tool_selection: created.tool_selection.clone(),
+            silent: Some(true),
+            input_source: Some(SilentInputSource::Selection),
+            output_action: Some(SilentOutputAction::Hud),
+        },
+    )
+    .unwrap();
+
+    assert!(updated.silent);
+    assert_eq!(updated.input_source, SilentInputSource::Selection);
+    assert_eq!(updated.output_action, SilentOutputAction::Hud);
 }

--- a/src-tauri/src/storage/agents.rs
+++ b/src-tauri/src/storage/agents.rs
@@ -2,6 +2,83 @@ use crate::error::AppError;
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 
+/// Where the silent-AI dispatcher pulls the input from before it calls the
+/// LLM. Meaningless when `AgentRow.silent == false`. Stored as a short
+/// stable lowercase string in SQLite so adding variants later is purely
+/// additive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum SilentInputSource {
+    /// `selectionService.getSelectedText()` — captured from the previously
+    /// frontmost app via macOS AX before the launcher takes focus.
+    Selection,
+    /// Whatever is currently on the system clipboard.
+    Clipboard,
+    /// String passed in via the dispatcher's `arguments.<firstArgName>`.
+    /// Default — matches the existing "type a question in the bar" UX.
+    Argument,
+    /// Empty string — the prompt itself is fully self-contained.
+    None,
+}
+
+impl SilentInputSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            SilentInputSource::Selection => "selection",
+            SilentInputSource::Clipboard => "clipboard",
+            SilentInputSource::Argument => "argument",
+            SilentInputSource::None => "none",
+        }
+    }
+
+    fn parse(value: &str) -> Self {
+        match value {
+            "selection" => SilentInputSource::Selection,
+            "clipboard" => SilentInputSource::Clipboard,
+            "none" => SilentInputSource::None,
+            _ => SilentInputSource::Argument,
+        }
+    }
+}
+
+/// What the silent-AI dispatcher does with the LLM's final assistant
+/// message. Meaningless when `AgentRow.silent == false`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum SilentOutputAction {
+    /// Write result to clipboard, hide launcher, simulate Cmd+V, restore
+    /// previous clipboard. Default — matches the Reddit "grammar fix"
+    /// reference flow.
+    ReplaceSelection,
+    /// Write result to clipboard only. No paste, no clipboard restore.
+    Copy,
+    /// Same flow as ReplaceSelection. Distinct intent — explicit "paste,
+    /// don't replace": for apps where there's no selection to overwrite.
+    Paste,
+    /// Show last non-empty line of result in a transient HUD toast.
+    Hud,
+}
+
+impl SilentOutputAction {
+    fn as_str(self) -> &'static str {
+        match self {
+            SilentOutputAction::ReplaceSelection => "replaceSelection",
+            SilentOutputAction::Copy => "copy",
+            SilentOutputAction::Paste => "paste",
+            SilentOutputAction::Hud => "hud",
+        }
+    }
+
+    fn parse(value: &str) -> Self {
+        match value {
+            "copy" => SilentOutputAction::Copy,
+            "paste" => SilentOutputAction::Paste,
+            "hud" => SilentOutputAction::Hud,
+            _ => SilentOutputAction::ReplaceSelection,
+        }
+    }
+}
+
 /// A persisted AI agent configuration.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -14,6 +91,16 @@ pub struct AgentRow {
     pub model_id: String,
     /// Ordered list of tool identifiers (stored as JSON array in SQLite).
     pub tool_selection: Vec<String>,
+    /// When true, dispatching this agent skips the chat view, runs a
+    /// single-turn loop headlessly, and applies `output_action` to the
+    /// result. When false the other two fields are stored but ignored.
+    pub silent: bool,
+    /// Where the silent dispatcher gets the user-text payload. Ignored
+    /// when `silent == false`.
+    pub input_source: SilentInputSource,
+    /// What the silent dispatcher does with the LLM's final text. Ignored
+    /// when `silent == false`.
+    pub output_action: SilentOutputAction,
     pub created_at: Option<i64>,
     pub updated_at: Option<i64>,
 }
@@ -52,7 +139,10 @@ pub struct MessageRow {
 }
 
 /// Idempotent: creates the agents, threads, and messages tables and their
-/// indexes if missing.
+/// indexes if missing. Also patches in the silent-AI columns (`silent`,
+/// `input_source`, `output_action`) for installs whose `agents` table
+/// predates them — mirrors the `runs_history.subject_id` / `tail_output`
+/// ALTER TABLE guard pattern.
 pub fn init_table(conn: &Connection) -> Result<(), AppError> {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS agents (
@@ -63,6 +153,9 @@ pub fn init_table(conn: &Connection) -> Result<(), AppError> {
             provider_id     TEXT    NOT NULL,
             model_id        TEXT    NOT NULL,
             tool_selection  TEXT    NOT NULL DEFAULT '[]',
+            silent          INTEGER NOT NULL DEFAULT 0,
+            input_source    TEXT    NOT NULL DEFAULT 'argument',
+            output_action   TEXT    NOT NULL DEFAULT 'replaceSelection',
             created_at      INTEGER NOT NULL,
             updated_at      INTEGER NOT NULL
         );
@@ -93,6 +186,36 @@ pub fn init_table(conn: &Connection) -> Result<(), AppError> {
             ON messages(thread_id, created_at);",
     )
     .map_err(|e| AppError::Database(format!("Failed to init agents tables: {e}")))?;
+
+    let cols: Vec<String> = conn
+        .prepare("PRAGMA table_info(agents)")
+        .map_err(|e| AppError::Database(e.to_string()))?
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|e| AppError::Database(e.to_string()))?
+        .filter_map(Result::ok)
+        .collect();
+
+    if !cols.contains(&"silent".to_string()) {
+        conn.execute(
+            "ALTER TABLE agents ADD COLUMN silent INTEGER NOT NULL DEFAULT 0",
+            [],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    }
+    if !cols.contains(&"input_source".to_string()) {
+        conn.execute(
+            "ALTER TABLE agents ADD COLUMN input_source TEXT NOT NULL DEFAULT 'argument'",
+            [],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    }
+    if !cols.contains(&"output_action".to_string()) {
+        conn.execute(
+            "ALTER TABLE agents ADD COLUMN output_action TEXT NOT NULL DEFAULT 'replaceSelection'",
+            [],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    }
     Ok(())
 }
 
@@ -101,8 +224,10 @@ pub fn insert_agent(conn: &Connection, agent: &AgentRow) -> Result<(), AppError>
     let tool_json = serde_json::to_string(&agent.tool_selection)
         .map_err(|e| AppError::Database(format!("serialize tool_selection: {e}")))?;
     conn.execute(
-        "INSERT INTO agents (id, name, description, system_prompt, provider_id, model_id, tool_selection, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        "INSERT INTO agents (id, name, description, system_prompt, provider_id, model_id,
+                             tool_selection, silent, input_source, output_action,
+                             created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
         params![
             agent.id,
             agent.name,
@@ -111,6 +236,9 @@ pub fn insert_agent(conn: &Connection, agent: &AgentRow) -> Result<(), AppError>
             agent.provider_id,
             agent.model_id,
             tool_json,
+            agent.silent as i64,
+            agent.input_source.as_str(),
+            agent.output_action.as_str(),
             agent.created_at,
             agent.updated_at,
         ],
@@ -125,7 +253,8 @@ pub fn update_agent(conn: &Connection, agent: &AgentRow) -> Result<(), AppError>
         .map_err(|e| AppError::Database(format!("serialize tool_selection: {e}")))?;
     conn.execute(
         "UPDATE agents SET name=?2, description=?3, system_prompt=?4, provider_id=?5,
-         model_id=?6, tool_selection=?7, updated_at=?8 WHERE id=?1",
+         model_id=?6, tool_selection=?7, silent=?8, input_source=?9, output_action=?10,
+         updated_at=?11 WHERE id=?1",
         params![
             agent.id,
             agent.name,
@@ -134,6 +263,9 @@ pub fn update_agent(conn: &Connection, agent: &AgentRow) -> Result<(), AppError>
             agent.provider_id,
             agent.model_id,
             tool_json,
+            agent.silent as i64,
+            agent.input_source.as_str(),
+            agent.output_action.as_str(),
             agent.updated_at,
         ],
     )
@@ -154,7 +286,8 @@ pub fn list_agents(conn: &Connection) -> Result<Vec<AgentRow>, AppError> {
     let mut stmt = conn
         .prepare(
             "SELECT id, name, description, system_prompt, provider_id, model_id,
-                    tool_selection, created_at, updated_at
+                    tool_selection, silent, input_source, output_action,
+                    created_at, updated_at
              FROM agents
              ORDER BY created_at ASC",
         )
@@ -170,16 +303,31 @@ pub fn list_agents(conn: &Connection) -> Result<Vec<AgentRow>, AppError> {
                 row.get::<_, String>(4)?,
                 row.get::<_, String>(5)?,
                 row.get::<_, String>(6)?,
-                row.get::<_, Option<i64>>(7)?,
-                row.get::<_, Option<i64>>(8)?,
+                row.get::<_, i64>(7)?,
+                row.get::<_, String>(8)?,
+                row.get::<_, String>(9)?,
+                row.get::<_, Option<i64>>(10)?,
+                row.get::<_, Option<i64>>(11)?,
             ))
         })
         .map_err(|e| AppError::Database(e.to_string()))?;
 
     let mut agents = Vec::new();
     for row in rows {
-        let (id, name, description, system_prompt, provider_id, model_id, tool_json, created_at, updated_at) =
-            row.map_err(|e| AppError::Database(e.to_string()))?;
+        let (
+            id,
+            name,
+            description,
+            system_prompt,
+            provider_id,
+            model_id,
+            tool_json,
+            silent_int,
+            input_str,
+            output_str,
+            created_at,
+            updated_at,
+        ) = row.map_err(|e| AppError::Database(e.to_string()))?;
         let tool_selection = serde_json::from_str::<Vec<String>>(&tool_json)
             .map_err(|e| AppError::Database(format!("deserialize tool_selection: {e}")))?;
         agents.push(AgentRow {
@@ -190,6 +338,9 @@ pub fn list_agents(conn: &Connection) -> Result<Vec<AgentRow>, AppError> {
             provider_id,
             model_id,
             tool_selection,
+            silent: silent_int != 0,
+            input_source: SilentInputSource::parse(&input_str),
+            output_action: SilentOutputAction::parse(&output_str),
             created_at,
             updated_at,
         });
@@ -202,7 +353,8 @@ pub fn get_agent(conn: &Connection, id: &str) -> Result<Option<AgentRow>, AppErr
     let mut stmt = conn
         .prepare(
             "SELECT id, name, description, system_prompt, provider_id, model_id,
-                    tool_selection, created_at, updated_at
+                    tool_selection, silent, input_source, output_action,
+                    created_at, updated_at
              FROM agents
              WHERE id = ?1",
         )
@@ -218,8 +370,11 @@ pub fn get_agent(conn: &Connection, id: &str) -> Result<Option<AgentRow>, AppErr
                 row.get::<_, String>(4)?,
                 row.get::<_, String>(5)?,
                 row.get::<_, String>(6)?,
-                row.get::<_, Option<i64>>(7)?,
-                row.get::<_, Option<i64>>(8)?,
+                row.get::<_, i64>(7)?,
+                row.get::<_, String>(8)?,
+                row.get::<_, String>(9)?,
+                row.get::<_, Option<i64>>(10)?,
+                row.get::<_, Option<i64>>(11)?,
             ))
         })
         .map_err(|e| AppError::Database(e.to_string()))?;
@@ -227,8 +382,20 @@ pub fn get_agent(conn: &Connection, id: &str) -> Result<Option<AgentRow>, AppErr
     match rows.next() {
         None => Ok(None),
         Some(row) => {
-            let (id, name, description, system_prompt, provider_id, model_id, tool_json, created_at, updated_at) =
-                row.map_err(|e| AppError::Database(e.to_string()))?;
+            let (
+                id,
+                name,
+                description,
+                system_prompt,
+                provider_id,
+                model_id,
+                tool_json,
+                silent_int,
+                input_str,
+                output_str,
+                created_at,
+                updated_at,
+            ) = row.map_err(|e| AppError::Database(e.to_string()))?;
             let tool_selection = serde_json::from_str::<Vec<String>>(&tool_json)
                 .map_err(|e| AppError::Database(format!("deserialize tool_selection: {e}")))?;
             Ok(Some(AgentRow {
@@ -239,6 +406,9 @@ pub fn get_agent(conn: &Connection, id: &str) -> Result<Option<AgentRow>, AppErr
                 provider_id,
                 model_id,
                 tool_selection,
+                silent: silent_int != 0,
+                input_source: SilentInputSource::parse(&input_str),
+                output_action: SilentOutputAction::parse(&output_str),
                 created_at,
                 updated_at,
             }))

--- a/src-tauri/src/storage/agents_test.rs
+++ b/src-tauri/src/storage/agents_test.rs
@@ -2,7 +2,7 @@
 use crate::storage::agents::{
     delete_agent, delete_thread, get_agent, init_table, insert_agent, insert_message,
     insert_thread, list_agents, list_messages_for_thread, list_threads_for_agent, update_agent,
-    AgentRow, MessageRole, MessageRow, ThreadRow,
+    AgentRow, MessageRole, MessageRow, SilentInputSource, SilentOutputAction, ThreadRow,
 };
 use rusqlite::Connection;
 
@@ -22,6 +22,9 @@ fn agent(id: &str, created_at: i64) -> AgentRow {
         provider_id: "openai".to_string(),
         model_id: "gpt-4o".to_string(),
         tool_selection: vec![],
+        silent: false,
+        input_source: SilentInputSource::Argument,
+        output_action: SilentOutputAction::ReplaceSelection,
         created_at: Some(created_at),
         updated_at: Some(created_at),
     }
@@ -245,4 +248,155 @@ fn messages_content_json_round_trips() {
     let msgs = list_messages_for_thread(&conn, "t1").unwrap();
     assert_eq!(msgs.len(), 1);
     assert_eq!(msgs[0].content, expected);
+}
+
+// ── Silent AI command columns ────────────────────────────────────────────────
+
+#[test]
+fn init_table_creates_silent_columns() {
+    let conn = Connection::open_in_memory().unwrap();
+    init_table(&conn).unwrap();
+    let mut stmt = conn.prepare("PRAGMA table_info(agents)").unwrap();
+    let cols: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .filter_map(Result::ok)
+        .collect();
+    assert!(cols.contains(&"silent".to_string()), "missing silent column: {cols:?}");
+    assert!(
+        cols.contains(&"input_source".to_string()),
+        "missing input_source column: {cols:?}"
+    );
+    assert!(
+        cols.contains(&"output_action".to_string()),
+        "missing output_action column: {cols:?}"
+    );
+}
+
+#[test]
+fn init_table_adds_silent_columns_to_legacy_db() {
+    // Simulate a pre-silent agents table (no silent / input_source / output_action).
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE agents (
+            id              TEXT    PRIMARY KEY,
+            name            TEXT    NOT NULL,
+            description     TEXT,
+            system_prompt   TEXT    NOT NULL,
+            provider_id     TEXT    NOT NULL,
+            model_id        TEXT    NOT NULL,
+            tool_selection  TEXT    NOT NULL DEFAULT '[]',
+            created_at      INTEGER NOT NULL,
+            updated_at      INTEGER NOT NULL
+        );",
+    )
+    .unwrap();
+    init_table(&conn).unwrap();
+    let mut stmt = conn.prepare("PRAGMA table_info(agents)").unwrap();
+    let cols: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .filter_map(Result::ok)
+        .collect();
+    assert!(cols.contains(&"silent".to_string()), "legacy upgrade missed silent: {cols:?}");
+    assert!(
+        cols.contains(&"input_source".to_string()),
+        "legacy upgrade missed input_source: {cols:?}"
+    );
+    assert!(
+        cols.contains(&"output_action".to_string()),
+        "legacy upgrade missed output_action: {cols:?}"
+    );
+}
+
+#[test]
+fn init_table_is_idempotent_on_silent_columns() {
+    let conn = Connection::open_in_memory().unwrap();
+    init_table(&conn).unwrap();
+    init_table(&conn).unwrap(); // second call must not error after columns exist
+    init_table(&conn).unwrap();
+}
+
+#[test]
+fn silent_fields_round_trip_through_sqlite() {
+    let conn = make_conn();
+    let mut a = agent("a1", 1000);
+    a.silent = true;
+    a.input_source = SilentInputSource::Selection;
+    a.output_action = SilentOutputAction::Copy;
+    insert_agent(&conn, &a).unwrap();
+
+    let got = get_agent(&conn, "a1").unwrap().expect("agent not found");
+    assert!(got.silent, "silent must round-trip as true");
+    assert_eq!(got.input_source, SilentInputSource::Selection);
+    assert_eq!(got.output_action, SilentOutputAction::Copy);
+}
+
+#[test]
+fn silent_fields_default_when_unspecified_on_legacy_row() {
+    // Legacy install: row exists from before silent columns landed. After
+    // init_table runs, the ALTER TABLE adds the columns with NULL values.
+    // Loading the row must surface sensible defaults
+    // (silent=false, input=Argument, output=ReplaceSelection).
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE agents (
+            id              TEXT    PRIMARY KEY,
+            name            TEXT    NOT NULL,
+            description     TEXT,
+            system_prompt   TEXT    NOT NULL,
+            provider_id     TEXT    NOT NULL,
+            model_id        TEXT    NOT NULL,
+            tool_selection  TEXT    NOT NULL DEFAULT '[]',
+            created_at      INTEGER NOT NULL,
+            updated_at      INTEGER NOT NULL
+        );",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO agents (id, name, description, system_prompt, provider_id, model_id, tool_selection, created_at, updated_at)
+         VALUES ('legacy', 'Legacy', NULL, 'system', 'openai', 'gpt-4o', '[]', 1, 1)",
+        [],
+    )
+    .unwrap();
+    init_table(&conn).unwrap();
+
+    let got = get_agent(&conn, "legacy").unwrap().expect("legacy row not found");
+    assert!(!got.silent, "legacy row must default silent=false");
+    assert_eq!(got.input_source, SilentInputSource::Argument);
+    assert_eq!(got.output_action, SilentOutputAction::ReplaceSelection);
+}
+
+#[test]
+fn update_agent_persists_silent_fields() {
+    let conn = make_conn();
+    let mut a = agent("a1", 1000);
+    insert_agent(&conn, &a).unwrap();
+
+    a.silent = true;
+    a.input_source = SilentInputSource::Clipboard;
+    a.output_action = SilentOutputAction::Hud;
+    a.updated_at = Some(2000);
+    update_agent(&conn, &a).unwrap();
+
+    let got = get_agent(&conn, "a1").unwrap().expect("agent not found");
+    assert!(got.silent);
+    assert_eq!(got.input_source, SilentInputSource::Clipboard);
+    assert_eq!(got.output_action, SilentOutputAction::Hud);
+}
+
+#[test]
+fn list_agents_returns_silent_fields() {
+    let conn = make_conn();
+    let mut a = agent("a1", 1000);
+    a.silent = true;
+    a.input_source = SilentInputSource::None;
+    a.output_action = SilentOutputAction::Paste;
+    insert_agent(&conn, &a).unwrap();
+
+    let rows = list_agents(&conn).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].silent);
+    assert_eq!(rows[0].input_source, SilentInputSource::None);
+    assert_eq!(rows[0].output_action, SilentOutputAction::Paste);
 }

--- a/src/built-in-features/agents/AgentEditView.svelte
+++ b/src/built-in-features/agents/AgentEditView.svelte
@@ -203,6 +203,59 @@
       </div>
     {/if}
 
+    <!--
+      Silent AI command settings. When `silent` is off, the agent opens the
+      chat view on dispatch (default behavior). When it's on, the agent runs
+      headlessly, takes its input from `inputSource`, and applies
+      `outputAction` to the LLM's reply. We still persist the choice for
+      the two extra fields even when silent is off, so the user doesn't
+      lose their picks when toggling.
+    -->
+    <div class="form-field">
+      <label class="silent-toggle">
+        <input
+          type="checkbox"
+          bind:checked={form.silent}
+        />
+        <span>Run silently (no chat view)</span>
+      </label>
+      <p class="field-hint silent-hint">
+        Silent agents run in the background and put the result back wherever
+        you triggered them from. Useful for one-shot tasks like grammar fixes
+        or translations.
+      </p>
+    </div>
+
+    <div class="form-field" class:disabled={!form.silent}>
+      <label class="field-label" for="agent-input-source">Input from</label>
+      <select
+        id="agent-input-source"
+        class="field-select"
+        bind:value={form.inputSource}
+        disabled={!form.silent}
+      >
+        <option value="argument">Argument (typed in the launcher bar)</option>
+        <option value="selection">Selected text in the active app</option>
+        <option value="clipboard">Clipboard contents</option>
+        <option value="none">Nothing (use the system prompt alone)</option>
+      </select>
+    </div>
+
+    <div class="form-field" class:disabled={!form.silent}>
+      <label class="field-label" for="agent-output-action">Then</label>
+      <select
+        id="agent-output-action"
+        class="field-select"
+        bind:value={form.outputAction}
+        disabled={!form.silent}
+      >
+        <option value="replaceSelection">Replace the selection with the result</option>
+        <option value="paste">Paste the result at the cursor</option>
+        <option value="copy">Copy the result to the clipboard</option>
+        <option value="hud">Show the result as a HUD message</option>
+      </select>
+    </div>
+
     {#if validationError}
       <p class="field-error">{validationError}</p>
     {/if}
@@ -308,5 +361,27 @@
     display: flex;
     gap: var(--space-2);
     justify-content: flex-end;
+  }
+
+  .silent-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--font-size-sm);
+    color: var(--text-primary);
+    cursor: pointer;
+  }
+
+  .silent-hint {
+    margin-top: var(--space-1);
+  }
+
+  .form-field.disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
+  .field-select:disabled {
+    cursor: not-allowed;
   }
 </style>

--- a/src/built-in-features/agents/agentEditView.helpers.test.ts
+++ b/src/built-in-features/agents/agentEditView.helpers.test.ts
@@ -27,6 +27,9 @@ const makeAgent = (over: Partial<AgentDef> = {}): AgentDef => ({
   providerId: 'openai',
   modelId: 'gpt-4',
   toolSelection: ['builtin:echo', 'ext-a:search'],
+  silent: false,
+  inputSource: 'argument',
+  outputAction: 'replaceSelection',
   createdAt: 1000,
   updatedAt: 2000,
   ...over,
@@ -39,6 +42,9 @@ const makeState = (over: Partial<EditFormState> = {}): EditFormState => ({
   providerId: 'openai',
   modelId: 'gpt-4',
   toolSelection: new Set(['builtin:echo']),
+  silent: false,
+  inputSource: 'argument',
+  outputAction: 'replaceSelection',
   ...over,
 });
 
@@ -90,6 +96,54 @@ describe('buildInitialFormState', () => {
     expect(state.toolSelection.has('builtin:echo')).toBe(true);
     expect(state.toolSelection.has('ext-a:search')).toBe(true);
     expect(state.toolSelection.size).toBe(2);
+  });
+
+  it('buildInitialFormState_carries_silent_fields_from_agent', () => {
+    const agent = makeAgent({
+      silent: true,
+      inputSource: 'selection',
+      outputAction: 'hud',
+    });
+    const state = buildInitialFormState(agent);
+    expect(state.silent).toBe(true);
+    expect(state.inputSource).toBe('selection');
+    expect(state.outputAction).toBe('hud');
+  });
+
+  it('buildInitialFormState_defaults_silent_fields_for_new_agent', () => {
+    const state = buildInitialFormState(null);
+    expect(state.silent).toBe(false);
+    expect(state.inputSource).toBe('argument');
+    expect(state.outputAction).toBe('replaceSelection');
+  });
+});
+
+// ── Silent fields round-trip through formStateToCreate/Update ────────────────
+
+describe('formStateToCreateInput silent fields', () => {
+  it('round_trips_silent_fields_into_create_input', () => {
+    const state = makeState({
+      silent: true,
+      inputSource: 'selection',
+      outputAction: 'replaceSelection',
+    });
+    const input = formStateToCreateInput(state);
+    expect(input.silent).toBe(true);
+    expect(input.inputSource).toBe('selection');
+    expect(input.outputAction).toBe('replaceSelection');
+  });
+
+  it('round_trips_silent_fields_into_update_input', () => {
+    const state = makeState({
+      silent: true,
+      inputSource: 'clipboard',
+      outputAction: 'copy',
+    });
+    const input = formStateToUpdateInput(state, 'agent-99');
+    expect(input.id).toBe('agent-99');
+    expect(input.silent).toBe(true);
+    expect(input.inputSource).toBe('clipboard');
+    expect(input.outputAction).toBe('copy');
   });
 });
 

--- a/src/built-in-features/agents/agentEditView.helpers.ts
+++ b/src/built-in-features/agents/agentEditView.helpers.ts
@@ -1,4 +1,10 @@
-import type { AgentDef, AgentCreateInput, AgentUpdateInput } from './types';
+import type {
+  AgentDef,
+  AgentCreateInput,
+  AgentUpdateInput,
+  SilentInputSource,
+  SilentOutputAction,
+} from './types';
 import type { ToolDescriptor } from 'asyar-sdk/contracts';
 import type { IProviderPlugin, ProviderConfig, ProviderId, ModelInfo } from '../../services/ai/IProviderPlugin';
 
@@ -11,6 +17,15 @@ export interface EditFormState {
   providerId: string;
   modelId: string;
   toolSelection: Set<string>;
+  /**
+   * Silent-AI command settings. `silent === false` means the agent opens
+   * the chat view on dispatch (default). The other two fields are still
+   * persisted in that case so flipping the toggle on/off doesn't lose
+   * the user's choice.
+   */
+  silent: boolean;
+  inputSource: SilentInputSource;
+  outputAction: SilentOutputAction;
 }
 
 export type ToolGroup =
@@ -40,6 +55,9 @@ export function buildInitialFormState(agent: AgentDef | null): EditFormState {
       providerId: '',
       modelId: '',
       toolSelection: new Set(),
+      silent: false,
+      inputSource: 'argument',
+      outputAction: 'replaceSelection',
     };
   }
   return {
@@ -49,6 +67,9 @@ export function buildInitialFormState(agent: AgentDef | null): EditFormState {
     providerId: agent.providerId,
     modelId: agent.modelId,
     toolSelection: new Set(agent.toolSelection),
+    silent: agent.silent,
+    inputSource: agent.inputSource,
+    outputAction: agent.outputAction,
   };
 }
 
@@ -72,6 +93,9 @@ export function formStateToCreateInput(state: EditFormState): AgentCreateInput {
     providerId: state.providerId,
     modelId: state.modelId,
     toolSelection: Array.from(state.toolSelection),
+    silent: state.silent,
+    inputSource: state.inputSource,
+    outputAction: state.outputAction,
   };
 }
 

--- a/src/built-in-features/agents/agentsManager.test.ts
+++ b/src/built-in-features/agents/agentsManager.test.ts
@@ -24,9 +24,7 @@ vi.mock('../../services/diagnostics/diagnosticsService.svelte', () => ({
 
 import { AgentsManager } from './agentsManager.svelte';
 import { AgentService } from './agentService.svelte';
-import { dispatchAgentCommand } from './dispatch';
 import * as commands from '../../lib/ipc/commands';
-import { viewManager } from '../../services/extension/viewManager.svelte';
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -166,30 +164,7 @@ describe('AgentsManager', () => {
 });
 
 // ── dispatchAgentCommand ─────────────────────────────────────────────────────
-
-describe('dispatchAgentCommand', () => {
-  let service: AgentService;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    service = new AgentService();
-  });
-
-  it('navigates_to_AgentChatView_when_agent_exists', async () => {
-    const a1 = makeAgent({ id: 'agent-uuid-1', name: 'Agent One' });
-    vi.mocked(commands.agentsList).mockResolvedValueOnce([a1] as never);
-    vi.mocked(commands.agentsThreadsList).mockResolvedValueOnce([] as never);
-    await service.init();
-
-    await dispatchAgentCommand('agent-uuid-1', undefined);
-
-    expect(viewManager.navigateToView).toHaveBeenCalledWith('agents/AgentChatView');
-  });
-
-  it('throws_when_agent_not_found_by_dynamic_id', async () => {
-    vi.mocked(commands.agentsList).mockResolvedValueOnce([] as never);
-    await service.init();
-
-    await expect(dispatchAgentCommand('unknown-id', undefined)).rejects.toThrow('unknown-id');
-  });
-});
+// Routing contract (chat-view vs silent dispatcher) lives in
+// `dispatch.test.ts`. Removed the older `navigates_to_AgentChatView_when_
+// agent_exists` assertion that fossilized the "every agent opens chat"
+// behavior — it predates the silent-AI command feature.

--- a/src/built-in-features/agents/defaultAgent.test.ts
+++ b/src/built-in-features/agents/defaultAgent.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { OOTB_DEFAULT_AGENT_SYSTEM_PROMPT, buildDefaultAgentInput } from './defaultAgent';
+import {
+  OOTB_DEFAULT_AGENT_SYSTEM_PROMPT,
+  buildDefaultAgentInput,
+  buildGrammarFixAgentInput,
+  GRAMMAR_FIX_SYSTEM_PROMPT,
+} from './defaultAgent';
 
 const LOCKED_SYSTEM_PROMPT =
   'You are Asyar Assistant, a friendly and helpful AI built into the Asyar launcher. ' +
@@ -26,5 +31,23 @@ describe('defaultAgent', () => {
   it('uses empty toolSelection so first-launch is fast', () => {
     const input = buildDefaultAgentInput('anthropic', 'claude-3-5-haiku-20241022');
     expect(input.toolSelection).toEqual([]);
+  });
+});
+
+describe('buildGrammarFixAgentInput', () => {
+  it('returns a silent agent configured for selection->replaceSelection', () => {
+    const input = buildGrammarFixAgentInput('openai', 'gpt-4o-mini');
+    expect(input.name).toBe('Grammar Fix');
+    expect(input.silent).toBe(true);
+    expect(input.inputSource).toBe('selection');
+    expect(input.outputAction).toBe('replaceSelection');
+    expect(input.systemPrompt).toBe(GRAMMAR_FIX_SYSTEM_PROMPT);
+    expect(input.toolSelection).toEqual([]);
+  });
+
+  it('passes through provider and model', () => {
+    const input = buildGrammarFixAgentInput('anthropic', 'claude-3-5-haiku-20241022');
+    expect(input.providerId).toBe('anthropic');
+    expect(input.modelId).toBe('claude-3-5-haiku-20241022');
   });
 });

--- a/src/built-in-features/agents/defaultAgent.ts
+++ b/src/built-in-features/agents/defaultAgent.ts
@@ -16,3 +16,39 @@ export function buildDefaultAgentInput(providerId: string, modelId: string): Age
     toolSelection: [],
   };
 }
+
+/**
+ * The canonical example silent-AI command — "Grammar Fix". The user
+ * selects text in any app, hits a hotkey bound to this agent's row,
+ * and the launcher replaces the selection with the corrected text in
+ * place. No window opens, no preview, no confirm. The reference UX
+ * for the silent-AI command feature; doubles as a quick way to verify
+ * the feature wired up end-to-end.
+ *
+ * Build this with `buildGrammarFixAgentInput(providerId, modelId)`
+ * and pass to `agentService.create(...)`. Then bind a hotkey through
+ * the existing item-shortcut UI (Cmd+K → Set Shortcut on the agent row).
+ */
+export const GRAMMAR_FIX_SYSTEM_PROMPT =
+  'You are a grammar and style assistant. The user gives you a piece of text ' +
+  'and you reply ONLY with the corrected version. Fix grammar, spelling, and ' +
+  'awkward phrasing. Preserve the user’s original tone, voice, language, and ' +
+  'formatting. Do not add preamble, commentary, or quotation marks — just the ' +
+  'corrected text and nothing else.';
+
+export function buildGrammarFixAgentInput(
+  providerId: string,
+  modelId: string,
+): AgentCreateInput {
+  return {
+    name: 'Grammar Fix',
+    description: 'Silent agent: replace selected text with the grammar-corrected version.',
+    systemPrompt: GRAMMAR_FIX_SYSTEM_PROMPT,
+    providerId,
+    modelId,
+    toolSelection: [],
+    silent: true,
+    inputSource: 'selection',
+    outputAction: 'replaceSelection',
+  };
+}

--- a/src/built-in-features/agents/dispatch.test.ts
+++ b/src/built-in-features/agents/dispatch.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Contract tests for `dispatchAgentCommand`.
+ *
+ * Two contracts live in this file:
+ *  1. Non-silent agents (`agent.silent === false`) navigate to the chat
+ *     view and set `agentsManager.currentAgentId`. Default behavior.
+ *  2. Silent agents (`agent.silent === true`) route to
+ *     `dispatchSilentAgentCommand` and never touch `agentsManager` or
+ *     `viewManager.navigateToView`. The launcher window stays
+ *     closed; the result lands wherever the agent's outputAction puts it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/ipc/commands', () => ({
+  replaceDynamicCommandsBuiltin: vi.fn().mockResolvedValue(undefined),
+  agentsList: vi.fn(),
+  agentsCreate: vi.fn(),
+  agentsUpdate: vi.fn(),
+  agentsDelete: vi.fn(),
+  agentsThreadsList: vi.fn(),
+  agentsThreadCreate: vi.fn(),
+  agentsThreadDelete: vi.fn(),
+  agentsMessagesList: vi.fn(),
+  agentsMessageInsert: vi.fn(),
+  agentsBackfillThreadTitles: vi.fn().mockResolvedValue(0),
+  agentsGet: vi.fn(),
+}));
+
+vi.mock('../../services/extension/viewManager.svelte', () => ({
+  viewManager: { navigateToView: vi.fn() },
+}));
+
+vi.mock('../../services/diagnostics/diagnosticsService.svelte', () => ({
+  diagnosticsService: { report: vi.fn() },
+}));
+
+// Mock the silent dispatcher so this test focuses purely on the routing
+// decision in `dispatchAgentCommand` — the silentDispatch internals are
+// covered by silentDispatch.test.ts.
+vi.mock('./silentDispatch', () => ({
+  dispatchSilentAgentCommand: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { AgentService } from './agentService.svelte';
+import { agentsManager } from './agentsManager.svelte';
+import { dispatchAgentCommand } from './dispatch';
+import { dispatchSilentAgentCommand } from './silentDispatch';
+import * as commands from '../../lib/ipc/commands';
+import { viewManager } from '../../services/extension/viewManager.svelte';
+import type { AgentDef } from './types';
+
+function makeAgent(over: Partial<AgentDef> = {}): AgentDef {
+  return {
+    id: 'agent-1',
+    name: 'Test Agent',
+    description: null,
+    systemPrompt: 'You are helpful.',
+    providerId: 'openai',
+    modelId: 'gpt-4o',
+    toolSelection: [],
+    silent: false,
+    inputSource: 'argument',
+    outputAction: 'replaceSelection',
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...over,
+  };
+}
+
+describe('dispatchAgentCommand — non-silent agents (default)', () => {
+  let service: AgentService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new AgentService();
+    agentsManager.currentAgentId = null;
+    agentsManager.currentThreadId = null;
+  });
+
+  it('navigates_to_AgentChatView_for_a_non_silent_agent', async () => {
+    const a1 = makeAgent({ id: 'agent-1', silent: false });
+    vi.mocked(commands.agentsList).mockResolvedValueOnce([a1] as never);
+    vi.mocked(commands.agentsThreadsList).mockResolvedValueOnce([] as never);
+    await service.init();
+
+    await dispatchAgentCommand('agent-1', undefined);
+
+    expect(viewManager.navigateToView).toHaveBeenCalledWith('agents/AgentChatView');
+    expect(agentsManager.currentAgentId).toBe('agent-1');
+    expect(dispatchSilentAgentCommand).not.toHaveBeenCalled();
+  });
+
+  it('throws_when_agent_not_found', async () => {
+    vi.mocked(commands.agentsList).mockResolvedValueOnce([] as never);
+    await service.init();
+
+    await expect(dispatchAgentCommand('unknown-id', undefined)).rejects.toThrow(
+      'unknown-id',
+    );
+  });
+});
+
+describe('dispatchAgentCommand — silent agents', () => {
+  let service: AgentService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new AgentService();
+    agentsManager.currentAgentId = null;
+    agentsManager.currentThreadId = null;
+  });
+
+  it('routes_to_dispatchSilentAgentCommand_when_agent_is_silent', async () => {
+    const a1 = makeAgent({ id: 'agent-1', silent: true });
+    vi.mocked(commands.agentsList).mockResolvedValueOnce([a1] as never);
+    await service.init();
+
+    await dispatchAgentCommand('agent-1', undefined);
+
+    expect(dispatchSilentAgentCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'agent-1' }),
+    );
+  });
+
+  it('does_not_navigate_to_AgentChatView_when_agent_is_silent', async () => {
+    const a1 = makeAgent({ id: 'agent-1', silent: true });
+    vi.mocked(commands.agentsList).mockResolvedValueOnce([a1] as never);
+    await service.init();
+
+    await dispatchAgentCommand('agent-1', undefined);
+
+    expect(viewManager.navigateToView).not.toHaveBeenCalled();
+  });
+
+  it('does_not_set_currentAgentId_when_agent_is_silent', async () => {
+    const a1 = makeAgent({ id: 'agent-1', silent: true });
+    vi.mocked(commands.agentsList).mockResolvedValueOnce([a1] as never);
+    await service.init();
+
+    await dispatchAgentCommand('agent-1', undefined);
+
+    expect(agentsManager.currentAgentId).toBeNull();
+  });
+});

--- a/src/built-in-features/agents/dispatch.ts
+++ b/src/built-in-features/agents/dispatch.ts
@@ -1,7 +1,21 @@
 import { getCurrentAgentService } from './agentService.svelte';
 import { agentsManager } from './agentsManager.svelte';
 import { viewManager } from '../../services/extension/viewManager.svelte';
+import { dispatchSilentAgentCommand } from './silentDispatch';
 
+/**
+ * Entry point invoked by the dynamic-command dispatcher when the user
+ * picks (or hotkeys) an agent row in the launcher.
+ *
+ * Routing:
+ *  - `agent.silent === false` → open the chat view (default, unchanged
+ *    flow).
+ *  - `agent.silent === true`  → hand off to `dispatchSilentAgentCommand`
+ *    which runs the agent headlessly and applies its `outputAction` to
+ *    the result. The launcher window stays closed; `agentsManager` and
+ *    `viewManager` are not touched. See `silentDispatch.ts` for the
+ *    Run-tracker suppression contract.
+ */
 export async function dispatchAgentCommand(
   dynamicId: string,
   _args?: unknown,
@@ -11,6 +25,12 @@ export async function dispatchAgentCommand(
   if (!agent) {
     throw new Error(`agent '${dynamicId}' not found`);
   }
+
+  if (agent.silent) {
+    await dispatchSilentAgentCommand({ agentId: agent.id });
+    return;
+  }
+
   agentsManager.currentAgentId = agent.id;
   const threads = await service.listThreads(agent.id);
   agentsManager.currentThreadId = threads[0]?.id ?? null;

--- a/src/built-in-features/agents/silentDispatch.test.ts
+++ b/src/built-in-features/agents/silentDispatch.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Contract tests for the silent-AI dispatcher.
+ *
+ * Hard rules these tests pin in place:
+ *  1. Successful silent runs never call `runService.startLocal` (no Run
+ *     row), never call `agentService.insertMessage` or `createThread`
+ *     (no thread / messages), and never touch
+ *     `agentsManager.currentAgentId` or `viewManager.navigateToView`.
+ *  2. `outputAction: 'replaceSelection'` writes to clipboard, hides the
+ *     window, simulates paste, then restores the previous clipboard
+ *     after a short delay.
+ *  3. `outputAction: 'copy'` writes to clipboard only — no paste, no
+ *     window hide, no clipboard restore.
+ *  4. `outputAction: 'hud'` calls `feedbackService.showHUD` with the
+ *     last non-empty line of the LLM response.
+ *  5. `inputSource: 'selection'` reads from `selectionService.getSelectedText()`.
+ *     Empty selection HUDs a warning and returns (no LLM call).
+ *  6. Provider / API failures surface through diagnostics + a system
+ *     notification, never as a thrown exception (the hotkey UX has
+ *     nowhere to show a thrown error).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Mocks (must be declared before importing the module under test) ──────────
+
+vi.mock('../../services/ai/providerRegistry', () => ({
+  getProvider: vi.fn(),
+}));
+
+vi.mock('../../services/ai/aiEngine', () => ({
+  streamChat: vi.fn(),
+}));
+
+vi.mock('../../services/settings/settingsService.svelte', () => ({
+  settingsService: {
+    getSettings: vi.fn(),
+  },
+}));
+
+vi.mock('./agentService.svelte', () => ({
+  agentService: {
+    getById: vi.fn(),
+    insertMessage: vi.fn(),
+    createThread: vi.fn(),
+    listThreads: vi.fn(),
+    listMessages: vi.fn(),
+  },
+}));
+
+vi.mock('../../lib/ipc/commands', () => ({
+  agentsGet: vi.fn(),
+  agentsToolsList: vi.fn(),
+  simulatePaste: vi.fn(),
+}));
+
+vi.mock('./toolDispatch', () => ({
+  invokeTool: vi.fn(),
+}));
+
+vi.mock('../../services/diagnostics/diagnosticsService.svelte', () => ({
+  diagnosticsService: { report: vi.fn() },
+}));
+
+vi.mock('../../services/feedback/feedbackService.svelte', () => ({
+  feedbackService: { showHUD: vi.fn() },
+}));
+
+vi.mock('../../services/notification/notificationService', () => ({
+  notificationService: { send: vi.fn() },
+}));
+
+vi.mock('../../services/window/windowService', () => ({
+  windowService: { hide: vi.fn(), show: vi.fn() },
+}));
+
+vi.mock('../../services/selection/selectionService', () => ({
+  selectionService: { getSelectedText: vi.fn() },
+}));
+
+vi.mock('../../services/run/runService.svelte', () => ({
+  runService: { startLocal: vi.fn() },
+}));
+
+vi.mock('../../services/extension/viewManager.svelte', () => ({
+  viewManager: { navigateToView: vi.fn() },
+}));
+
+vi.mock('tauri-plugin-clipboard-x-api', () => ({
+  readText: vi.fn(),
+  writeText: vi.fn(),
+}));
+
+vi.mock('../../services/log/logService', () => ({
+  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+
+import {
+  dispatchSilentAgentCommand,
+  lastNonEmptyLine,
+} from './silentDispatch';
+import { getProvider } from '../../services/ai/providerRegistry';
+import { streamChat } from '../../services/ai/aiEngine';
+import { settingsService } from '../../services/settings/settingsService.svelte';
+import { agentService } from './agentService.svelte';
+import * as commands from '../../lib/ipc/commands';
+import { feedbackService } from '../../services/feedback/feedbackService.svelte';
+import { notificationService } from '../../services/notification/notificationService';
+import { windowService } from '../../services/window/windowService';
+import { selectionService } from '../../services/selection/selectionService';
+import { runService } from '../../services/run/runService.svelte';
+import { viewManager } from '../../services/extension/viewManager.svelte';
+import { diagnosticsService } from '../../services/diagnostics/diagnosticsService.svelte';
+import { readText, writeText } from 'tauri-plugin-clipboard-x-api';
+import type { AgentDef } from './types';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeAgent(over: Partial<AgentDef> = {}): AgentDef {
+  return {
+    id: 'agent-1',
+    name: 'Grammar Fix',
+    description: null,
+    systemPrompt: 'Fix grammar. Reply only with the corrected text.',
+    providerId: 'openai',
+    modelId: 'gpt-4o',
+    toolSelection: [],
+    silent: true,
+    inputSource: 'argument',
+    outputAction: 'replaceSelection',
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...over,
+  };
+}
+
+const makeSettings = (apiKey = 'sk-test') => ({
+  ai: {
+    providers: {
+      openai: { enabled: true, apiKey },
+    },
+    temperature: 0.7,
+    maxTokens: 2048,
+    activeProviderId: 'openai',
+    activeModelId: 'gpt-4o',
+    allowExtensionUse: true,
+  },
+});
+
+const makePlugin = () => ({
+  id: 'openai' as const,
+  name: 'OpenAI',
+  requiresApiKey: true,
+  requiresBaseUrl: false,
+  optionalApiKey: false,
+  getModels: vi.fn(),
+  buildRequest: vi.fn(),
+  parseStream: vi.fn(),
+});
+
+function wireHappyPath(agent: AgentDef, responseText: string): void {
+  vi.mocked(agentService.getById).mockReturnValue(agent as never);
+  vi.mocked(getProvider).mockReturnValue(makePlugin() as never);
+  vi.mocked(settingsService.getSettings).mockReturnValue(makeSettings() as never);
+  vi.mocked(streamChat).mockImplementation(
+    async (_plugin, _config, _messages, _params, handlers) => {
+      handlers.onToken(responseText);
+      handlers.onDone();
+    },
+  );
+  vi.mocked(readText).mockResolvedValue('previous-clipboard');
+  vi.mocked(writeText).mockResolvedValue(undefined);
+  vi.mocked(commands.simulatePaste).mockResolvedValue(undefined);
+  vi.mocked(windowService.hide).mockResolvedValue(undefined);
+}
+
+// ── lastNonEmptyLine ──────────────────────────────────────────────────────────
+
+describe('lastNonEmptyLine', () => {
+  it('returns the only line for single-line text', () => {
+    expect(lastNonEmptyLine('hello world')).toBe('hello world');
+  });
+
+  it('returns the last non-empty line, ignoring trailing blanks', () => {
+    expect(lastNonEmptyLine('first\nsecond\n\n')).toBe('second');
+  });
+
+  it('handles CRLF line endings', () => {
+    expect(lastNonEmptyLine('a\r\nb\r\nc')).toBe('c');
+  });
+
+  it('trims whitespace within the returned line', () => {
+    expect(lastNonEmptyLine('foo\n   bar   ')).toBe('bar');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(lastNonEmptyLine('')).toBe('');
+  });
+});
+
+// ── No-promotion contract ─────────────────────────────────────────────────────
+
+describe('dispatchSilentAgentCommand — Run + thread suppression', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('never_calls_runService_startLocal_on_success', async () => {
+    wireHappyPath(makeAgent(), 'Corrected text');
+
+    await dispatchSilentAgentCommand({ agentId: 'agent-1', userText: 'helo wrld' });
+
+    expect(runService.startLocal).not.toHaveBeenCalled();
+  });
+
+  it('never_persists_thread_or_messages_on_success', async () => {
+    wireHappyPath(makeAgent(), 'Corrected text');
+
+    await dispatchSilentAgentCommand({ agentId: 'agent-1', userText: 'helo wrld' });
+
+    expect(agentService.createThread).not.toHaveBeenCalled();
+    expect(agentService.insertMessage).not.toHaveBeenCalled();
+    expect(agentService.listThreads).not.toHaveBeenCalled();
+  });
+
+  it('never_navigates_to_AgentChatView_on_success', async () => {
+    wireHappyPath(makeAgent(), 'Corrected text');
+
+    await dispatchSilentAgentCommand({ agentId: 'agent-1', userText: 'helo wrld' });
+
+    expect(viewManager.navigateToView).not.toHaveBeenCalled();
+  });
+});
+
+// ── Output actions ────────────────────────────────────────────────────────────
+
+describe('dispatchSilentAgentCommand — outputAction: replaceSelection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('writes_result_to_clipboard_then_hides_then_pastes', async () => {
+    wireHappyPath(makeAgent({ outputAction: 'replaceSelection' }), 'Hello world');
+
+    await dispatchSilentAgentCommand({ agentId: 'agent-1', userText: 'helo wrld' });
+
+    // writeText is called twice: once with the LLM output, once to restore.
+    // Verify the LLM output write happened.
+    expect(writeText).toHaveBeenCalledWith('Hello world');
+    expect(windowService.hide).toHaveBeenCalledTimes(1);
+    expect(commands.simulatePaste).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores_previous_clipboard_after_short_delay', async () => {
+    wireHappyPath(makeAgent({ outputAction: 'replaceSelection' }), 'Hello world');
+
+    await dispatchSilentAgentCommand({ agentId: 'agent-1', userText: 'helo wrld' });
+
+    // Before timers fire, only the result is on the clipboard.
+    expect(writeText).toHaveBeenCalledWith('Hello world');
+    expect(writeText).not.toHaveBeenCalledWith('previous-clipboard');
+
+    // Advance time past the restore delay.
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(writeText).toHaveBeenCalledWith('previous-clipboard');
+  });
+});
+
+describe('dispatchSilentAgentCommand — outputAction: copy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('writes_to_clipboard_but_does_not_paste_or_hide_window', async () => {
+    wireHappyPath(makeAgent({ outputAction: 'copy' }), 'COPY ME');
+
+    await dispatchSilentAgentCommand({ agentId: 'agent-1', userText: 'x' });
+
+    expect(writeText).toHaveBeenCalledWith('COPY ME');
+    expect(commands.simulatePaste).not.toHaveBeenCalled();
+    expect(windowService.hide).not.toHaveBeenCalled();
+  });
+});
+
+describe('dispatchSilentAgentCommand — outputAction: hud', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows_last_non_empty_line_of_response_in_HUD', async () => {
+    wireHappyPath(
+      makeAgent({ outputAction: 'hud' }),
+      'first line\nsecond line\n',
+    );
+
+    await dispatchSilentAgentCommand({ agentId: 'agent-1', userText: 'x' });
+
+    expect(feedbackService.showHUD).toHaveBeenCalledWith('second line');
+    // HUD never touches the clipboard or paste.
+    expect(commands.simulatePaste).not.toHaveBeenCalled();
+  });
+});
+
+// ── Input sources ─────────────────────────────────────────────────────────────
+
+describe('dispatchSilentAgentCommand — inputSource: selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reads_selection_via_selectionService_and_passes_it_to_the_LLM', async () => {
+    const agent = makeAgent({ inputSource: 'selection', outputAction: 'copy' });
+    wireHappyPath(agent, 'OK');
+    vi.mocked(selectionService.getSelectedText).mockResolvedValue('the cat sit on mat');
+
+    await dispatchSilentAgentCommand({ agentId: 'agent-1' });
+
+    expect(selectionService.getSelectedText).toHaveBeenCalled();
+    // streamChat should have received a user-role message with the selection.
+    const call = vi.mocked(streamChat).mock.calls[0];
+    const messages = call?.[2];
+    expect(messages).toBeDefined();
+    const userMsg = messages?.find((m) => m.role === 'user');
+    expect(userMsg?.content).toBe('the cat sit on mat');
+  });
+
+  it('shows_HUD_warning_and_skips_LLM_when_selection_is_empty', async () => {
+    const agent = makeAgent({ inputSource: 'selection' });
+    vi.mocked(agentService.getById).mockReturnValue(agent as never);
+    vi.mocked(selectionService.getSelectedText).mockResolvedValue('');
+
+    await dispatchSilentAgentCommand({ agentId: 'agent-1' });
+
+    expect(feedbackService.showHUD).toHaveBeenCalled();
+    expect(streamChat).not.toHaveBeenCalled();
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});
+
+// ── Failure handling ──────────────────────────────────────────────────────────
+
+describe('dispatchSilentAgentCommand — failures', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports_diagnostic_and_sends_notification_when_provider_errors', async () => {
+    const agent = makeAgent();
+    vi.mocked(agentService.getById).mockReturnValue(agent as never);
+    vi.mocked(getProvider).mockReturnValue(makePlugin() as never);
+    vi.mocked(settingsService.getSettings).mockReturnValue(makeSettings() as never);
+    vi.mocked(streamChat).mockImplementation(
+      async (_plugin, _config, _messages, _params, handlers) => {
+        handlers.onError('rate_limited: try again later');
+      },
+    );
+
+    // Must NOT throw — failures are surfaced via diagnostics/notification only.
+    await expect(
+      dispatchSilentAgentCommand({ agentId: 'agent-1', userText: 'x' }),
+    ).resolves.toBeUndefined();
+
+    expect(diagnosticsService.report).toHaveBeenCalled();
+    const reportCall = vi.mocked(diagnosticsService.report).mock.calls[0]?.[0] as {
+      kind?: string;
+      severity?: string;
+    };
+    expect(reportCall?.kind).toBe('silent_agent_failed');
+    expect(reportCall?.severity).toBe('warning');
+
+    expect(notificationService.send).toHaveBeenCalled();
+  });
+
+  it('reports_failure_when_api_key_is_missing', async () => {
+    const agent = makeAgent();
+    vi.mocked(agentService.getById).mockReturnValue(agent as never);
+    vi.mocked(getProvider).mockReturnValue(makePlugin() as never);
+    vi.mocked(settingsService.getSettings).mockReturnValue(makeSettings('') as never);
+
+    await dispatchSilentAgentCommand({ agentId: 'agent-1', userText: 'x' });
+
+    expect(notificationService.send).toHaveBeenCalled();
+    // No clipboard work should have happened.
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/src/built-in-features/agents/silentDispatch.ts
+++ b/src/built-in-features/agents/silentDispatch.ts
@@ -1,0 +1,510 @@
+/**
+ * Silent AI command dispatch.
+ *
+ * A "silent" agent runs headlessly: it captures input from the chosen
+ * source (selection / clipboard / argument / none), calls the LLM once
+ * (with tools if the agent has any), and applies the chosen output
+ * action to the final assistant message. The launcher window never
+ * opens, no chat thread is created, and no Run is promoted into
+ * `runService` — failures (and only failures) surface through
+ * diagnostics + a system notification.
+ *
+ * Run-tracker suppression mirrors `inline_scheduler.rs`: the inline
+ * scheduler bypasses `shellService.spawn` so its 30-second ticks
+ * don't flood `runService.unacknowledgedScriptResults`. Same idea
+ * here — a hotkey-driven grammar fix shouldn't pin a kept-Done row
+ * to the launcher every keystroke.
+ */
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
+import { readText, writeText } from 'tauri-plugin-clipboard-x-api';
+import { agentsGet, agentsToolsList, simulatePaste } from '../../lib/ipc/commands';
+import { getProvider } from '../../services/ai/providerRegistry';
+import { streamChat } from '../../services/ai/aiEngine';
+import { settingsService } from '../../services/settings/settingsService.svelte';
+import { diagnosticsService } from '../../services/diagnostics/diagnosticsService.svelte';
+import { feedbackService } from '../../services/feedback/feedbackService.svelte';
+import { notificationService } from '../../services/notification/notificationService';
+import { windowService } from '../../services/window/windowService';
+import { selectionService } from '../../services/selection/selectionService';
+import { logService } from '../../services/log/logService';
+import { extractErrorMessage } from '../../lib/errors';
+import { agentService } from './agentService.svelte';
+import { invokeTool } from './toolDispatch';
+import { encodeToolIdForWire } from './agentLoop';
+import type {
+  AgentDef,
+  SilentInputSource,
+  SilentOutputAction,
+} from './types';
+import type {
+  IProviderPlugin,
+  ChatMessage,
+  LoopMessage,
+  ProviderConfig,
+  ToolCall,
+} from '../../services/ai/IProviderPlugin';
+
+/**
+ * How long to wait between writing the clipboard / simulating paste and
+ * restoring the previous clipboard contents. The paste must complete
+ * before the restore, otherwise the user sees their original clipboard
+ * content pasted instead of the model output. macOS paste latency is
+ * tens of milliseconds in practice — 200ms is a safe margin.
+ */
+const CLIPBOARD_RESTORE_DELAY_MS = 200;
+
+/** Cap on tool-using silent agents — mirrors agentLoop's MAX_TURNS. */
+const MAX_TOOL_TURNS = 20;
+
+export interface SilentDispatchInput {
+  /** Agent id (already verified to be `silent: true` by the caller). */
+  agentId: string;
+  /** Optional explicit user text — overrides `agent.inputSource`. */
+  userText?: string;
+  /** Optional abort signal — lets the caller cancel mid-flight. */
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * Public entry point. Errors are logged + surfaced through diagnostics
+ * and a system notification but do not propagate to the caller — the
+ * silent UX has no way to display a thrown error to the user.
+ */
+export async function dispatchSilentAgentCommand(
+  input: SilentDispatchInput,
+): Promise<void> {
+  let resolvedAgent: AgentDef | null = null;
+  try {
+    const agent = await loadAgent(input.agentId);
+    resolvedAgent = agent;
+    if (!agent.silent) {
+      throw new Error(
+        `dispatchSilentAgentCommand called for non-silent agent '${agent.id}'`,
+      );
+    }
+
+    const userText = await captureInput(agent.inputSource, input.userText);
+    if (userText === null) {
+      // captureInput already surfaced a HUD warning ("No selection", etc).
+      return;
+    }
+
+    const result = await runSilentAgentTurn(agent, userText, input.abortSignal);
+    if (result === null) {
+      // Cancelled mid-flight.
+      return;
+    }
+    if (result.trim().length === 0) {
+      // Empty assistant response — treat as a failure so the user knows.
+      await reportFailure(agent, 'Agent returned empty response');
+      return;
+    }
+
+    await applyOutputAction(agent.outputAction, result);
+  } catch (err) {
+    const detail = extractErrorMessage(err);
+    logService.warn(`[silent-agents] dispatch failed: ${detail}`);
+    const target: Pick<AgentDef, 'id' | 'name'> = resolvedAgent
+      ? { id: resolvedAgent.id, name: resolvedAgent.name }
+      : { id: input.agentId, name: 'AI command' };
+    await reportFailure(target, detail);
+  }
+}
+
+// ── Input capture ────────────────────────────────────────────────────────────
+
+/**
+ * Returns the user text to send to the LLM, or `null` when the capture
+ * could not produce usable input (in which case a HUD warning is shown
+ * and the dispatcher should abort silently).
+ */
+async function captureInput(
+  source: SilentInputSource,
+  overrideUserText?: string,
+): Promise<string | null> {
+  if (overrideUserText !== undefined && overrideUserText.length > 0) {
+    return overrideUserText;
+  }
+
+  switch (source) {
+    case 'selection': {
+      try {
+        const text = await selectionService.getSelectedText();
+        if (!text || text.trim().length === 0) {
+          await feedbackService.showHUD('No selection');
+          return null;
+        }
+        return text;
+      } catch (err) {
+        logService.warn(`[silent-agents] selection capture failed: ${err}`);
+        await feedbackService.showHUD('Could not read selection');
+        return null;
+      }
+    }
+    case 'clipboard': {
+      try {
+        const text = await readText();
+        if (!text || text.trim().length === 0) {
+          await feedbackService.showHUD('Clipboard is empty');
+          return null;
+        }
+        return text;
+      } catch (err) {
+        logService.warn(`[silent-agents] clipboard capture failed: ${err}`);
+        await feedbackService.showHUD('Could not read clipboard');
+        return null;
+      }
+    }
+    case 'argument': {
+      // No override given — empty string is valid (lets agents whose
+      // system prompt is self-contained still run).
+      return '';
+    }
+    case 'none':
+      return '';
+  }
+}
+
+// ── Agent loop (ephemeral — no persistence, no runService) ────────────────────
+
+/**
+ * Single-turn LLM call (or tool loop if the agent has tools). Returns
+ * the final assistant text, or `null` when cancelled mid-flight.
+ */
+async function runSilentAgentTurn(
+  agent: AgentDef,
+  userText: string,
+  externalSignal?: AbortSignal,
+): Promise<string | null> {
+  const plugin = getProvider(agent.providerId as Parameters<typeof getProvider>[0]);
+  if (!plugin) {
+    throw new Error(`Provider '${agent.providerId}' is not registered`);
+  }
+
+  const settings = settingsService.getSettings();
+  const config = settings.ai.providers[
+    agent.providerId as keyof typeof settings.ai.providers
+  ];
+  if (!config?.apiKey) {
+    throw new Error(`API key for provider '${agent.providerId}' is not set`);
+  }
+
+  const controller = new AbortController();
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      controller.abort();
+    } else {
+      externalSignal.addEventListener('abort', () => controller.abort(), { once: true });
+    }
+  }
+  const isCancelled = () => controller.signal.aborted;
+
+  const toolSelection = agent.toolSelection ?? [];
+  if (toolSelection.length === 0) {
+    return runTextOnlySilent(
+      agent,
+      plugin,
+      config as ProviderConfig,
+      settings,
+      userText,
+      controller.signal,
+      isCancelled,
+    );
+  }
+  return runToolLoopSilent(
+    agent,
+    plugin,
+    config as ProviderConfig,
+    settings,
+    userText,
+    toolSelection,
+    controller.signal,
+    isCancelled,
+  );
+}
+
+async function runTextOnlySilent(
+  agent: AgentDef,
+  plugin: IProviderPlugin,
+  config: ProviderConfig,
+  settings: ReturnType<typeof settingsService.getSettings>,
+  userText: string,
+  signal: AbortSignal,
+  isCancelled: () => boolean,
+): Promise<string | null> {
+  const messages: ChatMessage[] = [];
+  if (agent.systemPrompt) {
+    messages.push({
+      id: `system-${agent.id}`,
+      role: 'system',
+      content: agent.systemPrompt,
+      timestamp: 0,
+    });
+  }
+  messages.push({
+    id: `user-${Date.now()}`,
+    role: 'user',
+    content: userText,
+    timestamp: Date.now(),
+  });
+
+  let accumulated = '';
+  let errorMessage: string | null = null;
+
+  await new Promise<void>((resolve, reject) => {
+    streamChat(
+      plugin,
+      config,
+      messages,
+      {
+        modelId: agent.modelId,
+        temperature: settings.ai.temperature,
+        maxTokens: settings.ai.maxTokens,
+      },
+      {
+        onToken: (token) => {
+          accumulated += token;
+        },
+        onDone: () => resolve(),
+        onError: (msg) => {
+          errorMessage = msg;
+          resolve();
+        },
+      },
+      signal,
+      `silent-agent-${agent.id}-${Date.now()}`,
+    ).catch(reject);
+  });
+
+  if (isCancelled()) return null;
+  if (errorMessage !== null) throw new Error(errorMessage);
+  return accumulated;
+}
+
+async function runToolLoopSilent(
+  agent: AgentDef,
+  plugin: IProviderPlugin,
+  config: ProviderConfig,
+  settings: ReturnType<typeof settingsService.getSettings>,
+  userText: string,
+  toolSelection: string[],
+  signal: AbortSignal,
+  isCancelled: () => boolean,
+): Promise<string | null> {
+  // Resolve selected tool descriptors. Anthropic rejects `:` / `.` in tool
+  // names so we wire-encode the FQID and map back when handling tool_use
+  // events — same logic as agentLoop.ts.
+  const allDescriptors = await agentsToolsList();
+  const selectedDescriptors = allDescriptors.filter((d) =>
+    toolSelection.includes(d.fullyQualifiedId),
+  );
+  const wireToFqid = new Map<string, string>();
+  const tools = selectedDescriptors.map((d) => {
+    const wireId = encodeToolIdForWire(d.fullyQualifiedId);
+    wireToFqid.set(wireId, d.fullyQualifiedId);
+    return {
+      id: wireId,
+      name: d.name,
+      description: d.description,
+      parameters: d.parameters,
+    };
+  });
+
+  const currentMessages: LoopMessage[] = [];
+  if (agent.systemPrompt) {
+    currentMessages.push({ role: 'system', content: agent.systemPrompt });
+  }
+  currentMessages.push({ role: 'user', content: userText });
+
+  const params = {
+    modelId: agent.modelId,
+    temperature: settings.ai.temperature,
+    maxTokens: settings.ai.maxTokens,
+  };
+
+  let finalText = '';
+
+  for (let turn = 0; turn < MAX_TOOL_TURNS; turn++) {
+    if (isCancelled()) return null;
+
+    const spec = plugin.buildToolRequest(currentMessages, config, params, tools);
+    if (!spec) {
+      throw new Error(`Provider '${agent.providerId}' does not support tools`);
+    }
+
+    const response = await tauriFetch(spec.url, {
+      method: 'POST',
+      headers: spec.headers as Record<string, string>,
+      body: JSON.stringify(spec.body),
+      signal,
+    });
+
+    if (!response.ok) {
+      const errText = await response.text().catch(() => `HTTP ${response.status}`);
+      let humanMsg = errText;
+      try {
+        const parsed = JSON.parse(errText) as { error?: { message?: string } };
+        if (parsed?.error?.message) humanMsg = parsed.error.message;
+      } catch {
+        /* keep raw text */
+      }
+      throw new Error(`API ${response.status}: ${humanMsg}`);
+    }
+    if (!response.body) {
+      throw new Error('No response body received.');
+    }
+
+    const reader = response.body.getReader();
+    let accumText = '';
+    const toolUses: ToolCall[] = [];
+    try {
+      for await (const ev of plugin.parseToolStream(reader)) {
+        if (isCancelled()) break;
+        if (ev.type === 'text') {
+          accumText += ev.text;
+        } else if (ev.type === 'tool_use') {
+          const resolvedFqid = wireToFqid.get(ev.name) ?? ev.name;
+          toolUses.push({ id: ev.id, name: resolvedFqid, input: ev.input });
+        } else if (ev.type === 'message_stop') {
+          break;
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    finalText = accumText;
+    const assistantLoopMsg: LoopMessage = { role: 'assistant', content: accumText };
+    if (toolUses.length > 0) assistantLoopMsg.toolUse = toolUses;
+    currentMessages.push(assistantLoopMsg);
+
+    if (toolUses.length === 0) {
+      return finalText;
+    }
+
+    for (const tu of toolUses) {
+      const output = await invokeTool(tu.name, tu.input, agent.id);
+      currentMessages.push({
+        role: 'tool',
+        content: JSON.stringify(output),
+        toolUseId: tu.id,
+      });
+    }
+    if (isCancelled()) return null;
+  }
+
+  throw new Error(`Silent agent loop exceeded max turns (${MAX_TOOL_TURNS})`);
+}
+
+// ── Output action ─────────────────────────────────────────────────────────────
+
+async function applyOutputAction(
+  action: SilentOutputAction,
+  result: string,
+): Promise<void> {
+  switch (action) {
+    case 'replaceSelection':
+    case 'paste':
+      await writeAndPaste(result);
+      return;
+    case 'copy':
+      await writeText(result);
+      return;
+    case 'hud': {
+      const line = lastNonEmptyLine(result);
+      await feedbackService.showHUD(line);
+      return;
+    }
+  }
+}
+
+/**
+ * Save the current clipboard, write the result, hide the launcher window
+ * (no-op if it isn't visible — silent agents may be invoked from the
+ * global hotkey while the launcher is closed), simulate Cmd+V, then
+ * restore the clipboard after a short delay so the paste completes
+ * before we overwrite the clipboard.
+ *
+ * The save-restore protects the user's clipboard from being trashed
+ * by the agent's output — they didn't ask for "copy", they asked for
+ * "paste in place".
+ */
+async function writeAndPaste(result: string): Promise<void> {
+  let savedClipboard: string | null = null;
+  try {
+    savedClipboard = await readText();
+  } catch {
+    // Some clipboard contents (images, files) can't be read as text;
+    // we still proceed but can't restore them. Acceptable trade-off.
+    savedClipboard = null;
+  }
+
+  await writeText(result);
+
+  try {
+    await windowService.hide();
+  } catch {
+    // Hide can fail if the window isn't visible. Paste still works.
+  }
+
+  await simulatePaste();
+
+  if (savedClipboard !== null) {
+    const toRestore = savedClipboard;
+    setTimeout(() => {
+      void writeText(toRestore).catch(() => {
+        /* clipboard restore is best-effort */
+      });
+    }, CLIPBOARD_RESTORE_DELAY_MS);
+  }
+}
+
+/**
+ * Last non-empty trimmed line in `text`, or the trimmed full text if no
+ * newlines / no non-empty lines. Used by the `hud` output action.
+ */
+export function lastNonEmptyLine(text: string): string {
+  const lines = text.split(/\r?\n/);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const t = lines[i].trim();
+    if (t.length > 0) return t;
+  }
+  return text.trim();
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function loadAgent(agentId: string): Promise<AgentDef> {
+  const cached = agentService.getById(agentId);
+  if (cached) return cached;
+  const fetched = await agentsGet(agentId);
+  if (!fetched) throw new Error(`Agent '${agentId}' not found`);
+  return fetched;
+}
+
+async function reportFailure(
+  agent: Pick<AgentDef, 'id' | 'name'>,
+  detail: string,
+): Promise<void> {
+  try {
+    await diagnosticsService.report({
+      source: 'frontend',
+      kind: 'silent_agent_failed',
+      severity: 'warning',
+      retryable: false,
+      developerDetail: detail,
+      context: { message: `${agent.name}: ${detail}`, agentId: agent.id },
+    });
+  } catch {
+    /* diagnostics is best-effort */
+  }
+
+  try {
+    await notificationService.send('agents', {
+      title: agent.name,
+      body: detail,
+    });
+  } catch (err) {
+    logService.warn(`[silent-agents] notification failed: ${err}`);
+  }
+}

--- a/src/built-in-features/agents/types.ts
+++ b/src/built-in-features/agents/types.ts
@@ -1,5 +1,17 @@
 export type MessageRole = 'user' | 'assistant' | 'tool'
 
+/**
+ * Where the silent-AI dispatcher pulls the input text from before calling
+ * the LLM. Meaningless when `AgentDef.silent === false`.
+ */
+export type SilentInputSource = 'selection' | 'clipboard' | 'argument' | 'none'
+
+/**
+ * What the silent-AI dispatcher does with the LLM's final assistant message.
+ * Meaningless when `AgentDef.silent === false`.
+ */
+export type SilentOutputAction = 'replaceSelection' | 'copy' | 'paste' | 'hud'
+
 export interface AgentDef {
   id: string
   name: string
@@ -8,6 +20,15 @@ export interface AgentDef {
   providerId: string
   modelId: string
   toolSelection: string[]
+  /**
+   * When true, dispatching this agent skips the chat view, runs a single-turn
+   * loop headlessly, and applies `outputAction` to the result.
+   */
+  silent: boolean
+  /** Where to capture the user-text payload from. Ignored when silent=false. */
+  inputSource: SilentInputSource
+  /** What to do with the LLM's final text. Ignored when silent=false. */
+  outputAction: SilentOutputAction
   createdAt: number | null
   updatedAt: number | null
 }
@@ -36,6 +57,12 @@ export interface AgentCreateInput {
   providerId: string
   modelId: string
   toolSelection: string[]
+  /** Optional. Defaults to false in the Rust layer when omitted. */
+  silent?: boolean
+  /** Optional. Defaults to `'argument'` in the Rust layer when omitted. */
+  inputSource?: SilentInputSource
+  /** Optional. Defaults to `'replaceSelection'` in the Rust layer when omitted. */
+  outputAction?: SilentOutputAction
 }
 
 export interface AgentUpdateInput extends AgentCreateInput {


### PR DESCRIPTION
Adds a silent execution mode for agents so a user can bind a hotkey to
"Grammar Fix" (or any agent), select text in any app, and have the
LLM's response replace that selection in place — no chat view, no
confirm dialog, no launcher window. The Reddit ask the OP described
("one keystroke, done") becomes a single-toggle agent setting.

- Three new agent fields: silent, inputSource (selection / clipboard /
  argument / none), outputAction (replaceSelection / copy / paste /
  hud). Stored alongside existing agent rows via an idempotent ALTER
  TABLE guard so legacy installs upgrade on first launch with no
  migration shim.
- AgentEditView gains a toggle plus two dropdowns, greyed out when
  silent is false. Existing agents continue to open the chat view
  exactly as before.
- New silentDispatch entrypoint runs the agent loop headlessly. It
  bypasses runService.startLocal, never persists a thread or message,
  never navigates to AgentChatView, and is structurally incapable of
  polluting the kept-Done slice or the Scripts/Agents HUD chips —
  three dedicated tests pin those invariants. Mirrors the
  inline-script suppression pattern.
- replaceSelection saves the user's clipboard, writes the result,
  hides the launcher, simulates Cmd+V to drop into the previously-
  frontmost app, and restores the clipboard after a short delay.
  Read/write/paste reuse the existing selectionService,
  clipboardHistoryService, and simulate_paste primitives — no new
  Rust commands needed.
- Tool-using silent agents still iterate the agent loop until a final
  assistant message, then route through the outputAction. Failures
  surface as a system notification plus a silent_agent_failed
  diagnostic — successes are intentionally silent (that's the point).
- New docs/reference/silent-agents.md documents the three field
  choices, an end-to-end Grammar Fix example, and the hotkey-binding
  flow. Cross-linked from run-tracking.md.