### PR TITLE
feat: spinning HUD for silent AI commands

### DIFF
--- a/src-tauri/src/commands/hud.rs
+++ b/src-tauri/src/commands/hud.rs
@@ -3,16 +3,20 @@
 use tauri::AppHandle;
 
 use crate::error::AppError;
-use crate::hud_window::service;
+use crate::hud_window::{service, HudContent};
 
-/// Show the HUD with the given title for `duration_ms` milliseconds.
+/// Show the HUD with the given title.
+///
+/// `duration_ms` is ignored when `spinning=true` — spinning HUDs stay visible
+/// until an explicit `hide_hud` or a follow-up non-spinning `show_hud` call.
 #[tauri::command]
 pub fn show_hud(
     app_handle: AppHandle,
     title: String,
     duration_ms: u32,
+    spinning: bool,
 ) -> Result<(), AppError> {
-    service::show(&app_handle, title, duration_ms)
+    service::show(&app_handle, title, duration_ms, spinning)
 }
 
 /// Hide the HUD immediately.
@@ -21,13 +25,13 @@ pub fn hide_hud(app_handle: AppHandle) -> Result<(), AppError> {
     service::hide(&app_handle)
 }
 
-/// Returns the most recently set HUD title (or `null` if none).
+/// Returns the most recently set HUD content (or `null` if none).
 ///
-/// The HUD's Svelte route calls this on mount to recover the title that
+/// The HUD's Svelte route calls this on mount to recover the state that
 /// was emitted before its event listener attached. Without this fallback,
 /// the very first `show_hud` call would render an empty pill because the
 /// `hud:show` event fires before the lazy-loaded webview mounts.
 #[tauri::command]
-pub fn get_hud_title(app_handle: AppHandle) -> Result<Option<String>, AppError> {
-    service::current_title(&app_handle)
+pub fn get_hud_state(app_handle: AppHandle) -> Result<Option<HudContent>, AppError> {
+    service::current_state(&app_handle)
 }

--- a/src-tauri/src/hud_window/mod.rs
+++ b/src-tauri/src/hud_window/mod.rs
@@ -15,21 +15,32 @@
 pub mod service;
 
 use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
 use tauri::async_runtime::JoinHandle;
+
+/// Latest state of the HUD window. Held by `HudState.current` so the HUD's
+/// Svelte route can fetch it on mount via `get_hud_state` (the lazy-loaded
+/// HUD route may attach its `hud:show` listener after the first emit).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HudContent {
+    pub title: String,
+    /// When true, the HUD route renders a spinner alongside the title and
+    /// no auto-hide is scheduled — the HUD stays visible until an explicit
+    /// `hide_hud` or a follow-up `show_hud` call with `spinning=false`.
+    pub spinning: bool,
+}
 
 /// Tauri-managed state for the HUD window.
 ///
 /// - `auto_hide_task` holds the in-flight auto-hide timer (if any) so that
 ///   a second `show_hud` call can abort a pending hide before scheduling
 ///   its own.
-/// - `current_title` holds the most recent title so the HUD's Svelte route
-///   can fetch it on mount. This handles the first-show race: the HUD
-///   webview is lazy-loaded by Tauri (the window is declared with
-///   `visible: false`), so its `hud:show` event listener doesn't exist
-///   until after the first `show()`. Without this fallback, the title
-///   emitted before mount would be lost.
+/// - `current` holds the most recent {title, spinning} pair so the HUD's
+///   Svelte route can recover it on mount.
 #[derive(Default)]
 pub struct HudState {
     pub auto_hide_task: Mutex<Option<JoinHandle<()>>>,
-    pub current_title: Mutex<Option<String>>,
+    pub current: Mutex<Option<HudContent>>,
 }

--- a/src-tauri/src/hud_window/service.rs
+++ b/src-tauri/src/hud_window/service.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter, LogicalPosition, LogicalSize, Manager};
 
 use crate::error::AppError;
-use crate::hud_window::HudState;
+use crate::hud_window::{HudContent, HudState};
 
 /// Window label for the HUD webview, matching `tauri.conf.json`.
 pub const HUD_WINDOW_LABEL: &str = "hud";
@@ -29,49 +29,53 @@ const HUD_HEIGHT: f64 = 80.0;
 /// Margin between the HUD and the bottom edge of the active monitor (logical px).
 const HUD_BOTTOM_MARGIN: f64 = 80.0;
 
-/// Show the HUD with the given title for `duration_ms` milliseconds.
+/// Show the HUD with the given title.
 ///
-/// 1. Stores the title in `HudState.current_title` so the HUD route can
+/// 1. Stores `{title, spinning}` in `HudState.current` so the HUD route can
 ///    read it on mount (handles the first-show race where the listener
 ///    isn't attached yet).
 /// 2. Positions the HUD window at the bottom-center of the monitor that
 ///    currently contains the mouse cursor.
-/// 3. Emits the `hud:show` event with the title (the HUD's Svelte route
-///    listens and renders subsequent updates without remounting).
+/// 3. Emits the `hud:show` event with the content payload.
 /// 4. Shows the window.
-/// 5. Cancels any pending auto-hide and schedules a new one.
-pub fn show(app: &AppHandle, title: String, duration_ms: u32) -> Result<(), AppError> {
-    log::info!("[hud] show(title={title:?}, duration_ms={duration_ms})");
+/// 5. When `spinning=false`, cancels any pending auto-hide and schedules
+///    a new one for `duration_ms`. When `spinning=true`, cancels any
+///    pending auto-hide and does NOT schedule a new one — the HUD stays
+///    visible until an explicit `hide_hud` or a follow-up non-spinning
+///    `show_hud` call replaces the state.
+pub fn show(
+    app: &AppHandle,
+    title: String,
+    duration_ms: u32,
+    spinning: bool,
+) -> Result<(), AppError> {
+    log::info!("[hud] show(title={title:?}, duration_ms={duration_ms}, spinning={spinning})");
     let window = app
         .get_webview_window(HUD_WINDOW_LABEL)
         .ok_or_else(|| AppError::NotFound("hud window".to_string()))?;
 
     let state = app.state::<HudState>();
+    let content = HudContent {
+        title,
+        spinning,
+    };
 
-    // Store the title BEFORE showing the window so a fresh mount of the
-    // HUD route can fetch it via `get_hud_title`.
     {
         let mut slot = state
-            .current_title
+            .current
             .lock()
             .map_err(|_| AppError::Lock)?;
-        *slot = Some(title.clone());
+        *slot = Some(content.clone());
     }
 
-    // Position at bottom-center of the cursor's monitor.
     position_at_bottom_center(&window)?;
 
-    // Emit the title to the HUD route. If the route is already mounted
-    // (subsequent calls), this updates the title in-place. If the route
-    // hasn't mounted yet (first call), this event is lost — but the
-    // route's `onMount` falls back to reading `current_title` via the
-    // `get_hud_title` command.
-    app.emit_to(HUD_WINDOW_LABEL, "hud:show", title)
+    app.emit_to(HUD_WINDOW_LABEL, "hud:show", &content)
         .map_err(|e| AppError::Platform(format!("emit hud:show failed: {e}")))?;
 
     let _ = window.show();
 
-    // Cancel any pending auto-hide and schedule a new one.
+    // Cancel any pending auto-hide; only re-schedule when not spinning.
     {
         let mut slot = state
             .auto_hide_task
@@ -80,24 +84,23 @@ pub fn show(app: &AppHandle, title: String, duration_ms: u32) -> Result<(), AppE
         if let Some(prev) = slot.take() {
             prev.abort();
         }
-        let app_for_task = app.clone();
-        let handle = tauri::async_runtime::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(duration_ms as u64)).await;
-            let _ = hide(&app_for_task);
-        });
-        *slot = Some(handle);
+        if !spinning {
+            let app_for_task = app.clone();
+            let handle = tauri::async_runtime::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(duration_ms as u64)).await;
+                let _ = hide(&app_for_task);
+            });
+            *slot = Some(handle);
+        }
     }
 
     Ok(())
 }
 
-/// Returns the most recently set HUD title, if any.
-pub fn current_title(app: &AppHandle) -> Result<Option<String>, AppError> {
+/// Returns the most recently set HUD content, if any.
+pub fn current_state(app: &AppHandle) -> Result<Option<HudContent>, AppError> {
     let state = app.state::<HudState>();
-    let slot = state
-        .current_title
-        .lock()
-        .map_err(|_| AppError::Lock)?;
+    let slot = state.current.lock().map_err(|_| AppError::Lock)?;
     Ok(slot.clone())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -203,7 +203,7 @@ pub fn run() {
             commands::hide,
             commands::show_hud,
             commands::hide_hud,
-            commands::get_hud_title,
+            commands::get_hud_state,
             commands::simulate_paste,
             commands::update_global_shortcut,
             commands::get_persisted_shortcut,

--- a/src/built-in-features/agents/silentDispatch.test.ts
+++ b/src/built-in-features/agents/silentDispatch.test.ts
@@ -61,8 +61,17 @@ vi.mock('../../services/diagnostics/diagnosticsService.svelte', () => ({
   diagnosticsService: { report: vi.fn() },
 }));
 
+const mockSpinnerReplace = vi.hoisted(() => vi.fn(async () => {}));
+const mockSpinnerDismiss = vi.hoisted(() => vi.fn(async () => {}));
+const mockShowHUDSpinning = vi.hoisted(() =>
+  vi.fn(() => ({ replace: mockSpinnerReplace, dismiss: mockSpinnerDismiss })),
+);
+
 vi.mock('../../services/feedback/feedbackService.svelte', () => ({
-  feedbackService: { showHUD: vi.fn() },
+  feedbackService: {
+    showHUD: vi.fn(async () => {}),
+    showHUDSpinning: mockShowHUDSpinning,
+  },
 }));
 
 vi.mock('../../services/notification/notificationService', () => ({
@@ -305,7 +314,7 @@ describe('dispatchSilentAgentCommand — outputAction: hud', () => {
     vi.useRealTimers();
   });
 
-  it('shows_last_non_empty_line_of_response_in_HUD', async () => {
+  it('replaces_the_spinning_HUD_with_the_last_non_empty_line', async () => {
     wireHappyPath(
       makeAgent({ outputAction: 'hud' }),
       'first line\nsecond line\n',
@@ -313,7 +322,12 @@ describe('dispatchSilentAgentCommand — outputAction: hud', () => {
 
     await dispatchSilentAgentCommand({ agentId: 'agent-1', userText: 'x' });
 
-    expect(feedbackService.showHUD).toHaveBeenCalledWith('second line');
+    // Spinner-up at dispatch start, then replaced with the response line.
+    expect(mockShowHUDSpinning).toHaveBeenCalledTimes(1);
+    expect(mockSpinnerReplace).toHaveBeenCalledWith(
+      'second line',
+      expect.objectContaining({ spinning: false }),
+    );
     // HUD never touches the clipboard or paste.
     expect(commands.simulatePaste).not.toHaveBeenCalled();
   });

--- a/src/built-in-features/agents/silentDispatch.ts
+++ b/src/built-in-features/agents/silentDispatch.ts
@@ -22,7 +22,7 @@ import { getProvider } from '../../services/ai/providerRegistry';
 import { streamChat } from '../../services/ai/aiEngine';
 import { settingsService } from '../../services/settings/settingsService.svelte';
 import { diagnosticsService } from '../../services/diagnostics/diagnosticsService.svelte';
-import { feedbackService } from '../../services/feedback/feedbackService.svelte';
+import { feedbackService, type HudSpinnerHandle } from '../../services/feedback/feedbackService.svelte';
 import { notificationService } from '../../services/notification/notificationService';
 import { windowService } from '../../services/window/windowService';
 import { selectionService } from '../../services/selection/selectionService';
@@ -74,6 +74,7 @@ export async function dispatchSilentAgentCommand(
   input: SilentDispatchInput,
 ): Promise<void> {
   let resolvedAgent: AgentDef | null = null;
+  let spinner: HudSpinnerHandle | null = null;
   try {
     const agent = await loadAgent(input.agentId);
     resolvedAgent = agent;
@@ -83,30 +84,46 @@ export async function dispatchSilentAgentCommand(
       );
     }
 
+    // Spinner up immediately so the user knows their hotkey was captured —
+    // input capture + LLM call together can take 1-3 seconds during which
+    // the launcher window is intentionally hidden.
+    spinner = feedbackService.showHUDSpinning(`✨ ${agent.name}…`);
+
     const userText = await captureInput(agent.inputSource, input.userText);
     if (userText === null) {
-      // captureInput already surfaced a HUD warning ("No selection", etc).
+      // captureInput already surfaced a HUD warning ("No selection", etc),
+      // which replaces our spinner. Don't dismiss — the warning would vanish.
+      spinner = null;
       return;
     }
 
     const result = await runSilentAgentTurn(agent, userText, input.abortSignal);
     if (result === null) {
-      // Cancelled mid-flight.
+      // Cancelled mid-flight — dismiss the spinner; no error toast needed
+      // (the user did the cancelling).
+      await spinner.dismiss();
+      spinner = null;
       return;
     }
     if (result.trim().length === 0) {
-      // Empty assistant response — treat as a failure so the user knows.
+      await spinner.replace('⚠️ Empty response', { spinning: false, durationMs: 3000 });
+      spinner = null;
       await reportFailure(agent, 'Agent returned empty response');
       return;
     }
 
-    await applyOutputAction(agent.outputAction, result);
+    await applyOutputAction(agent.outputAction, result, spinner);
+    spinner = null;
   } catch (err) {
     const detail = extractErrorMessage(err);
     logService.warn(`[silent-agents] dispatch failed: ${detail}`);
     const target: Pick<AgentDef, 'id' | 'name'> = resolvedAgent
       ? { id: resolvedAgent.id, name: resolvedAgent.name }
       : { id: input.agentId, name: 'AI command' };
+    if (spinner) {
+      await spinner.replace(`⚠️ ${target.name} failed`, { spinning: false, durationMs: 3000 });
+      spinner = null;
+    }
     await reportFailure(target, detail);
   }
 }
@@ -401,18 +418,25 @@ async function runToolLoopSilent(
 async function applyOutputAction(
   action: SilentOutputAction,
   result: string,
+  spinner: HudSpinnerHandle,
 ): Promise<void> {
   switch (action) {
     case 'replaceSelection':
     case 'paste':
+      // The text appearing in the user's app IS the feedback — dismiss the
+      // spinner so the HUD pill doesn't linger over a successful paste.
+      await spinner.dismiss();
       await writeAndPaste(result);
       return;
     case 'copy':
       await writeText(result);
+      await spinner.replace('✓ Copied', { spinning: false, durationMs: 1500 });
       return;
     case 'hud': {
       const line = lastNonEmptyLine(result);
-      await feedbackService.showHUD(line);
+      // Swap the spinner pill in place for the result line; auto-hides
+      // after the default HUD duration.
+      await spinner.replace(line, { spinning: false });
       return;
     }
   }

--- a/src/lib/ipc/commands.ts
+++ b/src/lib/ipc/commands.ts
@@ -293,12 +293,21 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
 
   // ── HUD ───────────────────────────────────────────────────────────────────────
 
-  export async function getHudTitle(): Promise<string | null> {
-    return invoke<string | null>('get_hud_title');
+  export interface HudContent {
+    title: string;
+    spinning: boolean;
   }
 
-  export async function showHud(args: { title: string; durationMs: number }): Promise<void> {
-    return invoke('show_hud', { title: args.title, durationMs: args.durationMs });
+  export async function getHudState(): Promise<HudContent | null> {
+    return invoke<HudContent | null>('get_hud_state');
+  }
+
+  export async function showHud(args: { title: string; durationMs: number; spinning: boolean }): Promise<void> {
+    return invoke('show_hud', {
+      title: args.title,
+      durationMs: args.durationMs,
+      spinning: args.spinning,
+    });
   }
 
   export async function hideHud(): Promise<void> {

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -1,29 +1,33 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-  import { getHudTitle } from '../../lib/ipc/commands';
+  import { getHudState, type HudContent } from '../../lib/ipc/commands';
   import '../../resources/styles/style.css';
 
   let title = $state<string | null>(null);
+  let spinning = $state<boolean>(false);
   let unlisten: UnlistenFn | null = null;
 
   onMount(async () => {
-    // Belt: recover the most recently set title from Rust state in case
-    // the `hud:show` event was emitted before this listener attached.
-    // (The HUD window is eagerly initialized at app startup, so on the
-    // very first `show_hud` call this fallback is what populates the
-    // pill before the listener takes over for subsequent calls.)
+    // Belt: recover the most recently set state from Rust in case the
+    // `hud:show` event was emitted before this listener attached. (The
+    // HUD window is eagerly initialized at app startup; on the very
+    // first `show_hud` call this fallback is what populates the pill
+    // before the listener takes over for subsequent calls.)
     try {
-      const initial = await getHudTitle();
-      if (initial) title = initial;
+      const initial = await getHudState();
+      if (initial) {
+        title = initial.title;
+        spinning = initial.spinning;
+      }
     } catch (err) {
-      console.error('[hud] get_hud_title failed:', err);
+      console.error('[hud] get_hud_state failed:', err);
     }
 
-    // Suspenders: live updates for every subsequent `show_hud` call.
     try {
-      unlisten = await listen<string>('hud:show', (event) => {
-        title = event.payload;
+      unlisten = await listen<HudContent>('hud:show', (event) => {
+        title = event.payload.title;
+        spinning = event.payload.spinning;
       });
     } catch (err) {
       console.error('[hud] listen hud:show failed:', err);
@@ -44,7 +48,12 @@
 
 <div class="hud-root">
   {#if title}
-    <div class="hud-pill">{title}</div>
+    <div class="hud-pill">
+      {#if spinning}
+        <span class="hud-spinner" aria-hidden="true"></span>
+      {/if}
+      <span class="hud-title">{title}</span>
+    </div>
   {/if}
 </div>
 
@@ -93,6 +102,9 @@
     backdrop-filter: blur(60px) saturate(200%);
     -webkit-backdrop-filter: blur(60px) saturate(200%);
     border-radius: 9999px;
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
     /*
       No box-shadow. The combination of an OS window shadow on a
       rectangular Tauri window + a CSS box-shadow on a pill that's
@@ -123,5 +135,30 @@
     background: rgba(68, 56, 58, 0.94);
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
+  }
+
+  /*
+    Spinner — concentric ring with one accent arc that rotates. Color and
+    weight intentionally match the pill's text so the spinner reads as
+    part of the title row, not a separate decoration.
+  */
+  .hud-spinner {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.25);
+    border-top-color: rgba(255, 255, 255, 0.95);
+    animation: hud-spin 0.85s linear infinite;
+  }
+
+  .hud-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  @keyframes hud-spin {
+    to { transform: rotate(360deg); }
   }
 </style>

--- a/src/services/feedback/feedbackService.svelte.ts
+++ b/src/services/feedback/feedbackService.svelte.ts
@@ -23,6 +23,24 @@ interface ActiveDialog {
 /** Default HUD visibility duration. */
 const DEFAULT_HUD_DURATION_MS = 1500;
 
+/**
+ * Live handle on a spinning HUD. Returned by `showHUDSpinning`. The HUD stays
+ * visible until you call `.dismiss()` or `.replace(...)`. `.replace(title)`
+ * by default flips the HUD to a non-spinning state and schedules auto-hide,
+ * which is the usual transition on success ("Done") or failure ("Error: …").
+ */
+export interface HudSpinnerHandle {
+  /**
+   * Replace the displayed title. By default the spinner stops and the HUD
+   * is auto-hidden after `durationMs` (default 1500ms). Pass `spinning: true`
+   * to keep the spinner visible (e.g. progress phases like "Reading…" →
+   * "Thinking…").
+   */
+  replace(title: string, options?: { spinning?: boolean; durationMs?: number }): Promise<void>;
+  /** Hide the HUD now. */
+  dismiss(): Promise<void>;
+}
+
 
 class FeedbackService implements IFeedbackService {
   activeToast = $state<ActiveToast | null>(null);
@@ -72,13 +90,40 @@ class FeedbackService implements IFeedbackService {
     // Show the HUD window first (Rust positions it, displays the title, schedules
     // auto-hide), then hide the main launcher window. The HUD lives in its own
     // Tauri window, so it survives the main launcher hide.
-    await commands.showHud({ title, durationMs: DEFAULT_HUD_DURATION_MS });
+    await commands.showHud({ title, durationMs: DEFAULT_HUD_DURATION_MS, spinning: false });
     try {
       await commands.hideWindow();
     } catch {
       // hideWindow can fail if called from a context where the main window is
       // already hidden (e.g. settings window). The HUD still shows correctly.
     }
+  }
+
+  /**
+   * Show a HUD with a spinner that stays visible until dismissed or replaced.
+   * Use for headless operations whose duration the user can't see — silent AI
+   * commands, long-running shell-script triggers, anything where the launcher
+   * window is hidden and the user needs a "this is running" signal.
+   *
+   * Returns a handle so the caller can drive lifecycle transitions:
+   *   - `handle.replace('Done')` flips to a non-spinning HUD that auto-hides.
+   *   - `handle.replace('Working...', { spinning: true })` updates the
+   *     title without stopping the spinner (e.g. multi-phase progress).
+   *   - `handle.dismiss()` hides the HUD immediately (useful when the
+   *     visible result is the feedback — e.g. text replaced in place).
+   */
+  showHUDSpinning(title: string): HudSpinnerHandle {
+    void commands.showHud({ title, durationMs: 0, spinning: true });
+    return {
+      replace: async (newTitle, options) => {
+        const spinning = options?.spinning ?? false;
+        const durationMs = options?.durationMs ?? DEFAULT_HUD_DURATION_MS;
+        await commands.showHud({ title: newTitle, durationMs, spinning });
+      },
+      dismiss: async () => {
+        await commands.hideHud();
+      },
+    };
   }
 
   async confirmAlert(options: ConfirmAlertOptions): Promise<boolean> {

--- a/src/services/feedback/feedbackService.test.ts
+++ b/src/services/feedback/feedbackService.test.ts
@@ -129,7 +129,7 @@ describe('confirmAlert', () => {
 })
 
 describe('showHUD', () => {
-  it('invokes commands.showHud with the title and a default duration', async () => {
+  it('invokes commands.showHud with the title, a default duration, and spinning:false', async () => {
     const commands = await import('../../lib/ipc/commands')
     const showHud = commands.showHud as ReturnType<typeof vi.fn>
     showHud.mockClear()
@@ -139,5 +139,57 @@ describe('showHUD', () => {
     expect(arg.title).toBe('Brightness up')
     expect(typeof arg.durationMs).toBe('number')
     expect(arg.durationMs).toBeGreaterThan(0)
+    expect(arg.spinning).toBe(false)
+  })
+})
+
+describe('showHUDSpinning', () => {
+  it('immediately calls showHud with spinning:true and no auto-hide duration', async () => {
+    const commands = await import('../../lib/ipc/commands')
+    const showHud = commands.showHud as ReturnType<typeof vi.fn>
+    showHud.mockClear()
+    feedbackService.showHUDSpinning('Asking Grammar Fix…')
+    // Allow the fire-and-forget showHud call to settle.
+    await Promise.resolve()
+    expect(showHud).toHaveBeenCalledTimes(1)
+    const arg = showHud.mock.calls[0][0]
+    expect(arg.title).toBe('Asking Grammar Fix…')
+    expect(arg.spinning).toBe(true)
+    // durationMs is irrelevant when spinning, but the IPC contract still
+    // requires a number — assert a defined value to pin the schema.
+    expect(typeof arg.durationMs).toBe('number')
+  })
+
+  it('handle.replace flips to a non-spinning HUD that auto-hides after the default duration', async () => {
+    const commands = await import('../../lib/ipc/commands')
+    const showHud = commands.showHud as ReturnType<typeof vi.fn>
+    const handle = feedbackService.showHUDSpinning('Asking…')
+    await Promise.resolve()
+    showHud.mockClear()
+    await handle.replace('✓ Copied')
+    expect(showHud).toHaveBeenCalledTimes(1)
+    const arg = showHud.mock.calls[0][0]
+    expect(arg.title).toBe('✓ Copied')
+    expect(arg.spinning).toBe(false)
+    expect(arg.durationMs).toBeGreaterThan(0)
+  })
+
+  it('handle.replace honors an explicit spinning:true override (multi-phase progress)', async () => {
+    const commands = await import('../../lib/ipc/commands')
+    const showHud = commands.showHud as ReturnType<typeof vi.fn>
+    const handle = feedbackService.showHUDSpinning('Reading…')
+    await Promise.resolve()
+    showHud.mockClear()
+    await handle.replace('Thinking…', { spinning: true })
+    expect(showHud.mock.calls[0][0].spinning).toBe(true)
+  })
+
+  it('handle.dismiss calls hideHud', async () => {
+    const commands = await import('../../lib/ipc/commands')
+    const hideHud = commands.hideHud as ReturnType<typeof vi.fn>
+    hideHud.mockClear()
+    const handle = feedbackService.showHUDSpinning('Asking…')
+    await handle.dismiss()
+    expect(hideHud).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Silent AI commands run with the launcher window hidden — a 1-3 second