### PR TITLE
feat: ship Grammar Fix silent agent + hotkey on first install

### DIFF
--- a/src-tauri/src/onboarding/state.rs
+++ b/src-tauri/src/onboarding/state.rs
@@ -10,6 +10,7 @@ pub enum OnboardingStep {
     PickTheme,
     FeaturedExtensions,
     AiSetup,
+    PickAiCommandHotkey,
     Done,
 }
 
@@ -33,6 +34,7 @@ pub fn step_order(is_macos: bool) -> Vec<OnboardingStep> {
         OnboardingStep::PickTheme,
         OnboardingStep::FeaturedExtensions,
         OnboardingStep::AiSetup,
+        OnboardingStep::PickAiCommandHotkey,
         OnboardingStep::Done,
     ]);
     steps
@@ -89,6 +91,7 @@ mod tests {
                 OnboardingStep::PickTheme,
                 OnboardingStep::FeaturedExtensions,
                 OnboardingStep::AiSetup,
+                OnboardingStep::PickAiCommandHotkey,
                 OnboardingStep::Done,
             ]
         );
@@ -98,14 +101,15 @@ mod tests {
     fn order_off_macos_skips_accessibility() {
         let order = step_order(false);
         assert!(!order.contains(&OnboardingStep::GrantAccessibility));
-        assert_eq!(order.len(), 7);
+        assert_eq!(order.len(), 8);
     }
 
     #[test]
-    fn appends_single_ai_step_before_done() {
+    fn appends_pick_ai_command_hotkey_after_ai_setup_and_before_done() {
         let order = step_order(false);
         let len = order.len();
-        assert_eq!(order[len - 2], OnboardingStep::AiSetup);
+        assert_eq!(order[len - 3], OnboardingStep::AiSetup);
+        assert_eq!(order[len - 2], OnboardingStep::PickAiCommandHotkey);
         assert_eq!(order[len - 1], OnboardingStep::Done);
     }
 
@@ -114,7 +118,7 @@ mod tests {
         let s = initial(true);
         assert_eq!(s.current, OnboardingStep::Welcome);
         assert_eq!(s.position, 1);
-        assert_eq!(s.total, 8);
+        assert_eq!(s.total, 9);
         assert!(s.is_macos);
     }
 
@@ -128,7 +132,7 @@ mod tests {
     #[test]
     fn advance_at_done_stays_done() {
         let mut s = initial(false);
-        for _ in 0..7 {
+        for _ in 0..8 {
             s = advance(s);
         }
         assert_eq!(s.current, OnboardingStep::Done);

--- a/src/built-in-features/agents/agentService.svelte.ts
+++ b/src/built-in-features/agents/agentService.svelte.ts
@@ -13,7 +13,8 @@ import {
 import { listen } from '@tauri-apps/api/event';
 import { diagnosticsService } from '../../services/diagnostics/diagnosticsService.svelte';
 import { settingsService } from '../../services/settings/settingsService.svelte';
-import { buildDefaultAgentInput } from './defaultAgent';
+import { buildDefaultAgentInput, buildGrammarFixAgentInput } from './defaultAgent';
+import { logService } from '../../services/log/logService';
 import type {
   AgentDef,
   AgentCreateInput,
@@ -178,6 +179,26 @@ export class AgentService {
     const created = await this.create(buildDefaultAgentInput(providerId, modelId));
     await settingsService.updateSettings('ai', { defaultAgentId: created.id });
     return created;
+  }
+
+  /**
+   * Seed the bundled "Grammar Fix" silent agent if it isn't already present.
+   * Pure agent creation only — the caller is responsible for binding any
+   * hotkey via `shortcutService.register` after this resolves. Keeping the
+   * shortcut bind out of this method avoids pulling the shortcut layer
+   * (and its transitive `extensionManager` import) into the agent service
+   * module graph.
+   *
+   * Idempotent: if an agent named "Grammar Fix" already exists, the existing
+   * record is returned untouched and no new SQLite row is written.
+   */
+  async seedGrammarFixAgent(providerId: string, modelId: string): Promise<AgentDef> {
+    const existing = this.agents.find((a) => a.name === 'Grammar Fix');
+    if (existing) {
+      logService.debug('[agents] Grammar Fix already seeded; skipping');
+      return existing;
+    }
+    return this.create(buildGrammarFixAgentInput(providerId, modelId));
   }
 
   async listThreads(agentId: string): Promise<ThreadDef[]> {

--- a/src/built-in-features/agents/agentService.test.ts
+++ b/src/built-in-features/agents/agentService.test.ts
@@ -39,6 +39,29 @@ vi.mock('./defaultAgent', () => ({
     modelId,
     toolSelection: [],
   })),
+  buildGrammarFixAgentInput: vi.fn((providerId: string, modelId: string) => ({
+    name: 'Grammar Fix',
+    description: 'Silent grammar-fix agent',
+    systemPrompt: 'You are a grammar...',
+    providerId,
+    modelId,
+    toolSelection: [],
+    silent: true,
+    inputSource: 'selection',
+    outputAction: 'replaceSelection',
+  })),
+  DEFAULT_GRAMMAR_FIX_HOTKEY: { modifier: 'Cmd+Shift', key: 'L' },
+}));
+
+const mockShortcutRegister = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ ok: true }),
+);
+vi.mock('../shortcuts/shortcutService', () => ({
+  shortcutService: { register: mockShortcutRegister },
+}));
+
+vi.mock('../../services/log/logService', () => ({
+  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
 import { AgentService } from './agentService.svelte';
@@ -421,5 +444,55 @@ describe('upsertDefaultAgent', () => {
     // agentB is untouched
     expect(service.agents.find((ag) => ag.id === 'b')).toEqual(agentB);
     expect(commands.agentsUpdate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('seedGrammarFixAgent', () => {
+  let service: AgentService;
+  const svcSettings = settingsService as unknown as { currentSettings: { ai: { defaultAgentId: string | null } } };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockShortcutRegister.mockResolvedValue({ ok: true });
+    svcSettings.currentSettings = { ai: { defaultAgentId: null } };
+    service = new AgentService();
+    service.agents = [];
+  });
+
+  it('creates the Grammar Fix agent with silent + selection + replaceSelection fields', async () => {
+    const newRow = makeAgent({ id: 'gf-1', name: 'Grammar Fix' });
+    vi.mocked(commands.agentsCreate).mockResolvedValueOnce(newRow as never);
+
+    const result = await service.seedGrammarFixAgent('anthropic', 'claude-haiku-4');
+
+    expect(result).toEqual(newRow);
+    expect(commands.agentsCreate).toHaveBeenCalledTimes(1);
+    const arg = vi.mocked(commands.agentsCreate).mock.calls[0][0];
+    expect(arg.name).toBe('Grammar Fix');
+    expect(arg.silent).toBe(true);
+    expect(arg.inputSource).toBe('selection');
+    expect(arg.outputAction).toBe('replaceSelection');
+  });
+
+  it('is idempotent — returns existing Grammar Fix without re-creating', async () => {
+    const existing = makeAgent({ id: 'gf-existing', name: 'Grammar Fix' });
+    service.agents = [existing as any];
+
+    const result = await service.seedGrammarFixAgent('openai', 'gpt-5');
+
+    expect(result).toEqual(existing);
+    expect(commands.agentsCreate).not.toHaveBeenCalled();
+  });
+
+  it('returns the new agent row so the caller can bind a hotkey to cmd_agents_dyn_<id>', async () => {
+    const newRow = makeAgent({ id: 'gf-2', name: 'Grammar Fix' });
+    vi.mocked(commands.agentsCreate).mockResolvedValueOnce(newRow as never);
+
+    const result = await service.seedGrammarFixAgent('openai', 'gpt-5');
+
+    expect(result).toEqual(newRow);
+    expect(result.id).toBe('gf-2');
+    // The caller (onboarding step or settings flow) is responsible for
+    // calling shortcutService.register with `cmd_agents_dyn_${result.id}`.
   });
 });

--- a/src/built-in-features/agents/defaultAgent.test.ts
+++ b/src/built-in-features/agents/defaultAgent.test.ts
@@ -4,6 +4,7 @@ import {
   buildDefaultAgentInput,
   buildGrammarFixAgentInput,
   GRAMMAR_FIX_SYSTEM_PROMPT,
+  DEFAULT_GRAMMAR_FIX_HOTKEY,
 } from './defaultAgent';
 
 const LOCKED_SYSTEM_PROMPT =
@@ -49,5 +50,25 @@ describe('buildGrammarFixAgentInput', () => {
     const input = buildGrammarFixAgentInput('anthropic', 'claude-3-5-haiku-20241022');
     expect(input.providerId).toBe('anthropic');
     expect(input.modelId).toBe('claude-3-5-haiku-20241022');
+  });
+});
+
+describe('DEFAULT_GRAMMAR_FIX_HOTKEY', () => {
+  // The Rust `canonicalize_shortcut` rejects anything outside these tokens
+  // with "Invalid modifier: X", which silently fails the onboarding-time
+  // shortcut bind. Using "Cmd" here was the actual original bug — caught
+  // post-merge by the user, fixed by switching to "Super". This test pins
+  // the contract so a future change to use "Cmd" / "Meta" / "Win" trips CI.
+  const CANONICAL_MODIFIERS = new Set(['Control', 'Ctrl', 'Alt', 'Shift', 'Super']);
+
+  it('uses only modifier tokens the Rust canonicalize_shortcut accepts', () => {
+    const modifierParts = DEFAULT_GRAMMAR_FIX_HOTKEY.modifier.split('+');
+    for (const part of modifierParts) {
+      expect(CANONICAL_MODIFIERS).toContain(part);
+    }
+  });
+
+  it('declares a non-empty key', () => {
+    expect(DEFAULT_GRAMMAR_FIX_HOTKEY.key.length).toBeGreaterThan(0);
   });
 });

--- a/src/built-in-features/agents/defaultAgent.ts
+++ b/src/built-in-features/agents/defaultAgent.ts
@@ -29,12 +29,46 @@ export function buildDefaultAgentInput(providerId: string, modelId: string): Age
  * and pass to `agentService.create(...)`. Then bind a hotkey through
  * the existing item-shortcut UI (Cmd+K → Set Shortcut on the agent row).
  */
-export const GRAMMAR_FIX_SYSTEM_PROMPT =
-  'You are a grammar and style assistant. The user gives you a piece of text ' +
-  'and you reply ONLY with the corrected version. Fix grammar, spelling, and ' +
-  'awkward phrasing. Preserve the user’s original tone, voice, language, and ' +
-  'formatting. Do not add preamble, commentary, or quotation marks — just the ' +
-  'corrected text and nothing else.';
+/*
+ * Few-shot system prompt. Negative instructions ("don't explain", "no quotes")
+ * are silently ignored by smaller / faster models (Haiku, Gemini Flash, GPT
+ * mini) — exactly the models people pick for a fast grammar fix. Concrete
+ * input→output examples teach length, format, and the "no preamble" rule
+ * far more reliably than telling the model what to avoid. We also frame the
+ * agent as a *rewriter* (function) rather than an *assistant* (tutor) to
+ * pull it out of "explain things" mode.
+ *
+ * The fourth example (already-correct input → unchanged output) is deliberate:
+ * without it, models tend to invent an "improvement" rather than admit the
+ * input was fine.
+ */
+export const GRAMMAR_FIX_SYSTEM_PROMPT = [
+  'You rewrite English text with corrected grammar, spelling, and phrasing.',
+  "Preserve the original tone, voice, language, register, and formatting.",
+  '',
+  'Output rules:',
+  '- Output the corrected text only. Match the input\'s length — a short',
+  '  input gets a short output, a long input gets a long output.',
+  '- No preamble. No explanation. No alternatives. No quotation marks',
+  '  around the output. No "Here is..." or "Sure, ...".',
+  '- If the input is already correct, output it unchanged.',
+  '',
+  'Examples:',
+  '',
+  'Input: the cat sit on mat',
+  'Output: The cat sits on the mat.',
+  '',
+  'Input: i recieved you\'re message yesterday and ill respond asap',
+  "Output: I received your message yesterday and I'll respond ASAP.",
+  '',
+  'Input: We was going too the store wen it started raining',
+  'Output: We were going to the store when it started raining.',
+  '',
+  'Input: This is a perfectly fine sentence already.',
+  'Output: This is a perfectly fine sentence already.',
+  '',
+  "Now correct the user's next message the same way.",
+].join('\n');
 
 export function buildGrammarFixAgentInput(
   providerId: string,
@@ -52,3 +86,32 @@ export function buildGrammarFixAgentInput(
     outputAction: 'replaceSelection',
   };
 }
+
+/**
+ * Default hotkey pre-filled in the onboarding "Pick AI command shortcut"
+ * step and bound automatically when the user clicks Continue. Used both
+ * for first-install seeding and for the implicit seed when AI is set up
+ * via the Settings tab outside of onboarding.
+ *
+ * **Choice:** `Super+Shift+L` — renders as ⌘⇧L on macOS, ⊞⇧L on Windows,
+ * Super+Shift+L on Linux. The frontend display layer maps `Super` to the
+ * platform's "OS" key icon via `shortcutFormatter.modifierSymbol`.
+ *
+ * Why this combo:
+ *  - Familiar to Raycast users — Raycast uses ⌘⇧L for "Ask AI" so the
+ *    muscle memory transfers.
+ *  - Low collision with system shortcuts. `Cmd+L` jumps to the address
+ *    bar in browsers but adding Shift takes it out of that path.
+ *  - The user picks their own at onboarding time; this is just the
+ *    pre-fill they see.
+ *
+ * Modifier MUST be one of the tokens the Rust `canonicalize_shortcut`
+ * accepts: `Control` / `Ctrl` / `Alt` / `Shift` / `Super`. Using `Cmd`
+ * here would cause the Tauri `register_item_shortcut` call to error out
+ * with "Invalid modifier: Cmd" — silently failing the seed because the
+ * onboarding step only surfaces a generic diagnostic toast.
+ */
+export const DEFAULT_GRAMMAR_FIX_HOTKEY: { modifier: string; key: string } = {
+  modifier: 'Super+Shift',
+  key: 'L',
+};

--- a/src/routes/onboarding/+page.svelte
+++ b/src/routes/onboarding/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
   import { onboardingService } from '../../services/onboarding/onboardingService.svelte'
   import { diagnosticsService } from '../../services/diagnostics/diagnosticsService.svelte'
   import StepProgress from '../../components/onboarding/StepProgress.svelte'
@@ -8,11 +9,24 @@
   import PickLaunchView from './steps/PickLaunchView.svelte'
   import PickTheme from './steps/PickTheme.svelte'
   import FeaturedExtensions from './steps/FeaturedExtensions.svelte'
+  import PickAiCommandHotkey from './steps/PickAiCommandHotkey.svelte'
   import Done from './steps/Done.svelte'
   import AiTab from '../settings/tabs/AiTab.svelte'
   import { Button } from '../../components'
+  import { goBackStep } from './stepLogic'
+  import { initValidKeys } from '../../built-in-features/shortcuts/shortcutFormatter'
 
   const state = $derived(onboardingService.state)
+
+  // The onboarding window is a separate Tauri webview from the main launcher,
+  // so the `VALID_KEYS` module-level set that `ShortcutRecorder` consults
+  // starts empty here. Without this init, the PickHotkey and
+  // PickAiCommandHotkey steps reject every keypress as "invalid key" because
+  // the set has no entries to validate against. The main launcher and the
+  // settings window each init this set themselves; onboarding has to too.
+  onMount(() => {
+    void initValidKeys()
+  })
 
   async function handleAiSetupDone() {
     try {
@@ -58,10 +72,15 @@
       <div class="ai-step">
         <AiTab mode="providers-only" />
         <div class="ai-step-actions">
-          <Button onclick={handleAiSkip}>Skip for now</Button>
-          <Button onclick={handleAiSetupDone}>Continue</Button>
+          <Button class="btn-secondary" onclick={goBackStep}>Back</Button>
+          <div class="ai-step-actions__right">
+            <Button class="btn-secondary" onclick={handleAiSkip}>Skip for now</Button>
+            <Button onclick={handleAiSetupDone}>Continue</Button>
+          </div>
         </div>
       </div>
+    {:else if state.current === 'pickAiCommandHotkey'}
+      <PickAiCommandHotkey />
     {:else if state.current === 'done'}
       <Done />
     {/if}
@@ -85,7 +104,13 @@
 
   .ai-step-actions {
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .ai-step-actions__right {
+    display: flex;
     gap: var(--space-2);
   }
 </style>

--- a/src/routes/onboarding/steps/PickAiCommandHotkey.svelte
+++ b/src/routes/onboarding/steps/PickAiCommandHotkey.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  import { Card, Button, ShortcutRecorder } from '../../../components';
+  import { advanceStep, goBackStep } from '../stepLogic';
+  import { agentService } from '../../../built-in-features/agents/agentService.svelte';
+  import { shortcutService } from '../../../built-in-features/shortcuts/shortcutService';
+  import { DEFAULT_GRAMMAR_FIX_HOTKEY } from '../../../built-in-features/agents/defaultAgent';
+  import { diagnosticsService } from '../../../services/diagnostics/diagnosticsService.svelte';
+
+  let modifier = $state(DEFAULT_GRAMMAR_FIX_HOTKEY.modifier);
+  let key = $state(DEFAULT_GRAMMAR_FIX_HOTKEY.key);
+
+  // The default Asyar Assistant carries the provider+model the user just
+  // configured in the previous step. If they skipped AI setup it's null and
+  // this step degrades to a "set up AI first" message instead of the picker.
+  const defaultAgent = $derived(agentService.getDefaultAgent());
+  const aiConfigured = $derived(!!defaultAgent);
+
+  async function handleSave(detail: { modifier: string; key: string }): Promise<string | true> {
+    // The ShortcutRecorder's "Save" only persists the picker state — actual
+    // binding happens on Continue. Returning true keeps the recorder happy.
+    modifier = detail.modifier;
+    key = detail.key;
+    return true;
+  }
+
+  async function handleContinue(): Promise<void> {
+    if (!defaultAgent) {
+      await advanceStep();
+      return;
+    }
+    try {
+      const agent = await agentService.seedGrammarFixAgent(
+        defaultAgent.providerId,
+        defaultAgent.modelId,
+      );
+      const objectId = `cmd_agents_dyn_${agent.id}`;
+      const shortcutStr = `${modifier}+${key}`;
+      const result = await shortcutService.register(
+        objectId,
+        agent.name,
+        'command',
+        shortcutStr,
+        undefined,
+        'icon:sparkles',
+      );
+      if (!result.ok && result.conflict) {
+        diagnosticsService.report({
+          source: 'frontend',
+          kind: 'grammar_fix_hotkey_conflict',
+          severity: 'warning',
+          retryable: false,
+          context: {
+            message: `Shortcut ${shortcutStr} is already used by "${result.conflict.itemName}". You can change it later from the agent's row.`,
+          },
+        });
+      }
+    } catch (err) {
+      diagnosticsService.report({
+        source: 'frontend',
+        kind: 'grammar_fix_seed_failed',
+        severity: 'warning',
+        retryable: false,
+        context: {
+          message:
+            'Could not add the Grammar Fix command. You can create it manually from Manage Agents.',
+        },
+        developerDetail: String(err),
+      });
+    }
+    await advanceStep();
+  }
+
+  async function handleSkip(): Promise<void> {
+    await advanceStep();
+  }
+</script>
+
+<Card>
+  <h1>One-keystroke AI commands</h1>
+  <p>
+    We've prepared <strong>Grammar Fix</strong> — a silent AI command that takes
+    the text you have selected in any app and replaces it with the corrected
+    version. No window opens, no confirm dialog.
+  </p>
+
+  {#if aiConfigured}
+    <div class="example">
+      <div class="example__label">Try it after onboarding:</div>
+      <ol class="example__steps">
+        <li>Select text with a typo in TextEdit, Notes, or any editor.</li>
+        <li>Press your shortcut below.</li>
+        <li>The text is replaced in place.</li>
+      </ol>
+    </div>
+
+    <div class="row">
+      <div class="row__label">
+        <span class="row__title">Shortcut for Grammar Fix</span>
+        <span class="row__hint">
+          You can change this later from the agent's row in the launcher.
+        </span>
+      </div>
+      <ShortcutRecorder bind:modifier bind:key onsave={handleSave} />
+    </div>
+
+    <div class="actions">
+      <Button class="btn-secondary" onclick={goBackStep}>Back</Button>
+      <div class="actions__right">
+        <Button class="btn-secondary" onclick={handleSkip}>Skip</Button>
+        <Button onclick={handleContinue}>Add Grammar Fix</Button>
+      </div>
+    </div>
+  {:else}
+    <p class="note">
+      You skipped AI setup, so we can't add Grammar Fix yet. Open
+      <strong>Settings → AI</strong> later to set up a provider, then add the
+      Grammar Fix command from <strong>Manage Agents</strong>.
+    </p>
+    <div class="actions">
+      <Button class="btn-secondary" onclick={goBackStep}>Back</Button>
+      <Button onclick={handleSkip}>Continue</Button>
+    </div>
+  {/if}
+</Card>
+
+<style>
+  .example {
+    background: var(--bg-subtle);
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
+    margin: var(--space-4) 0;
+  }
+  .example__label {
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary);
+    margin-bottom: var(--space-2);
+  }
+  .example__steps {
+    margin: 0;
+    padding-left: var(--space-5);
+    font-size: var(--font-size-sm);
+    color: var(--text-primary);
+  }
+  .row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-5);
+    padding: var(--space-4) 0;
+  }
+  .row__label {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .row__title {
+    font-size: var(--font-size-md);
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .row__hint {
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary);
+  }
+  .note {
+    color: var(--text-secondary);
+    margin: var(--space-4) 0;
+  }
+  .actions {
+    display: flex;
+    justify-content: space-between;
+    margin-top: var(--space-5);
+  }
+  .actions__right {
+    display: flex;
+    gap: var(--space-2);
+  }
+</style>


### PR DESCRIPTION
New PickAiCommandHotkey onboarding step pre-fills Super+Shift+L and seeds the bundled Grammar Fix silent
agent the moment AI setup completes. The user can change the hotkey
before clicking Continue or skip the step entirely, and the step
degrades gracefully to "set up AI later" when AI was skipped in the
previous step.

- agentService.seedGrammarFixAgent(provider, model) is idempotent and
  pure: returns the existing Grammar Fix row when present, otherwise
  creates one with silent/selection/replaceSelection fields populated.
  Hotkey binding lives in the onboarding step (the caller) so the
  agent layer stays free of UI imports.
- Rust onboarding state machine grows OnboardingStep::PickAiCommandHotkey
  between AiSetup and Done. Step total goes 8 → 9 on macOS.
- DEFAULT_GRAMMAR_FIX_HOTKEY uses Super+Shift+L — the canonical token
  set the Rust canonicalize_shortcut accepts. Test pins that constraint.