### PR TITLE
fix: cross-webview sync for agents + shortcuts; auto-star first AI pr…

### DIFF
--- a/src-tauri/src/storage/commands.rs
+++ b/src-tauri/src/storage/commands.rs
@@ -1,7 +1,7 @@
 use super::DataStore;
 use crate::crypto::keystore::KeystoreState;
 use crate::error::AppError;
-use tauri::State;
+use tauri::{AppHandle, Emitter, State};
 
 // ── Clipboard ────────────────────────────────────────────────────────────────
 
@@ -234,9 +234,17 @@ pub async fn ext_cache_clear(
 pub fn shortcut_upsert(
     shortcut: super::shortcuts::ItemShortcut,
     store: State<'_, DataStore>,
+    app: AppHandle,
 ) -> Result<(), AppError> {
     let conn = store.conn()?;
-    super::shortcuts::upsert(&conn, &shortcut)
+    super::shortcuts::upsert(&conn, &shortcut)?;
+    // Broadcast so every webview's shortcutStore reloads. Without this,
+    // a shortcut added from the onboarding webview never lands in the
+    // main launcher's in-memory cache — `handleFiredShortcut` then logs
+    // "Received shortcut for unknown objectId" because the lookup misses
+    // even though Rust dispatched the event correctly.
+    let _ = app.emit("shortcuts:changed", ());
+    Ok(())
 }
 
 #[tauri::command]
@@ -251,7 +259,10 @@ pub fn shortcut_get_all(
 pub fn shortcut_remove(
     object_id: String,
     store: State<'_, DataStore>,
+    app: AppHandle,
 ) -> Result<(), AppError> {
     let conn = store.conn()?;
-    super::shortcuts::remove(&conn, &object_id)
+    super::shortcuts::remove(&conn, &object_id)?;
+    let _ = app.emit("shortcuts:changed", ());
+    Ok(())
 }

--- a/src/built-in-features/agents/agentsManager.svelte.ts
+++ b/src/built-in-features/agents/agentsManager.svelte.ts
@@ -1,3 +1,4 @@
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { agentsBackfillThreadTitles, replaceDynamicCommandsBuiltin } from '../../lib/ipc/commands';
 import { logService } from '../../services/log/logService';
 import type { DynamicCommandRegistration } from 'asyar-sdk/contracts';
@@ -30,6 +31,7 @@ export class AgentsManager {
   activeAbortController = $state<AbortController | null>(null);
   private service: AgentService;
   private started = false;
+  private agentsChangedUnlisten: UnlistenFn | null = null;
 
   constructor(service?: AgentService) {
     this.service = service ?? defaultAgentService;
@@ -60,11 +62,42 @@ export class AgentsManager {
     } catch (err) {
       logService.warn(`[agents] initial refresh failed: ${err}`);
     }
+
+    // Keep the dynamic command registry in sync with agents created or
+    // deleted from ANY webview — onboarding's AI setup, the new
+    // PickAiCommandHotkey step, an external Tauri call. Without this
+    // listener, agents created outside the edit/delete flow that
+    // explicitly call `manager.refresh()` would land in SQLite (and in
+    // `service.agents`) but never reach root-search.
+    //
+    // Order matters: we must await `service.refresh()` before our own
+    // `refresh()` so the registration uses the freshly-fetched agent
+    // list. The service's own `agents:changed` listener runs in parallel
+    // — we awaited the same operation explicitly so we don't race against
+    // it.
+    try {
+      this.agentsChangedUnlisten = await listen('agents:changed', () => {
+        void (async () => {
+          try {
+            await this.service.refresh();
+            await this.refresh();
+          } catch (err) {
+            logService.warn(`[agents] manager refresh on event failed: ${err}`);
+          }
+        })();
+      });
+    } catch (err) {
+      logService.warn(`[agents] failed to subscribe to agents:changed: ${err}`);
+    }
   }
 
   async stop(): Promise<void> {
     if (!this.started) return;
     this.started = false;
+    if (this.agentsChangedUnlisten) {
+      this.agentsChangedUnlisten();
+      this.agentsChangedUnlisten = null;
+    }
     await replaceDynamicCommandsBuiltin(AGENTS_EXTENSION_ID, []);
   }
 

--- a/src/built-in-features/agents/agentsManager.test.ts
+++ b/src/built-in-features/agents/agentsManager.test.ts
@@ -22,6 +22,31 @@ vi.mock('../../services/diagnostics/diagnosticsService.svelte', () => ({
   diagnosticsService: { report: vi.fn() },
 }));
 
+const mockListen = vi.hoisted(() => {
+  // Captures listener callbacks per event so tests can fire them
+  // synchronously without going through the real Tauri runtime.
+  const callbacks = new Map<string, Array<(payload: unknown) => void>>();
+  const listen = vi.fn(async (event: string, cb: (payload: unknown) => void) => {
+    if (!callbacks.has(event)) callbacks.set(event, []);
+    callbacks.get(event)!.push(cb);
+    return () => {
+      const arr = callbacks.get(event);
+      if (!arr) return;
+      const idx = arr.indexOf(cb);
+      if (idx >= 0) arr.splice(idx, 1);
+    };
+  });
+  const fire = (event: string, payload: unknown = {}) => {
+    const arr = callbacks.get(event);
+    if (!arr) return;
+    for (const cb of arr) cb(payload);
+  };
+  const reset = () => callbacks.clear();
+  return { listen, fire, reset };
+});
+
+vi.mock('@tauri-apps/api/event', () => ({ listen: mockListen.listen }));
+
 import { AgentsManager } from './agentsManager.svelte';
 import { AgentService } from './agentService.svelte';
 import * as commands from '../../lib/ipc/commands';
@@ -160,6 +185,74 @@ describe('AgentsManager', () => {
     // The registration id is the bare agent id — launcher derives cmd_agents_dyn_<id>
     expect(reg.id).toBe('uuid-abc-123');
     expect(reg.name).toBe('My Agent');
+  });
+
+  it('agents_changed_event_re_registers_dynamic_commands_with_current_service_agents', async () => {
+    // Symptom this test pins: after onboarding seeds agents via
+    // upsertDefaultAgent / seedGrammarFixAgent (neither of which calls
+    // manager.refresh explicitly), the new agents land in SQLite + the
+    // reactive service.agents but never reach Rust's dynamic command
+    // registry — so root-search misses them until the next app boot.
+    // Subscribing manager to `agents:changed` closes the gap.
+    mockListen.reset();
+
+    // Initial start with one agent — registers it.
+    vi.mocked(commands.agentsList).mockResolvedValueOnce([
+      makeAgent({ id: 'a1', name: 'Asyar Assistant' }),
+    ] as never);
+    await service.init();
+    await manager.start();
+
+    // Simulate a cross-webview create: another webview (or seedGrammarFixAgent
+    // in this one) wrote to SQLite, and the Rust event fired. The next
+    // agentsList call returns the broader set.
+    const updated = [
+      makeAgent({ id: 'a1', name: 'Asyar Assistant' }),
+      makeAgent({ id: 'a2', name: 'Grammar Fix' }),
+    ];
+    vi.mocked(commands.agentsList).mockResolvedValueOnce(updated as never);
+
+    vi.mocked(commands.replaceDynamicCommandsBuiltin).mockClear();
+
+    // Fire the Tauri event. Service's own listener will refresh
+    // service.agents asynchronously; the manager's new listener also fires
+    // and pushes the updated set to Rust.
+    mockListen.fire('agents:changed');
+
+    // Allow both listeners' async work to settle.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(commands.replaceDynamicCommandsBuiltin).toHaveBeenCalled();
+    const lastCall = vi.mocked(commands.replaceDynamicCommandsBuiltin).mock.calls.at(-1)!;
+    const regs = lastCall[1] as Array<{ id: string; name: string }>;
+    const ids = regs.map((r) => r.id);
+    expect(ids).toContain('a1');
+    expect(ids).toContain('a2');
+  });
+
+  it('stop_removes_the_agents_changed_listener', async () => {
+    mockListen.reset();
+    vi.mocked(commands.agentsList).mockResolvedValueOnce([] as never);
+    await service.init();
+    await manager.start();
+    await manager.stop();
+
+    vi.mocked(commands.replaceDynamicCommandsBuiltin).mockClear();
+    // Re-list call should still resolve; the listener should not still be
+    // pushing through after stop.
+    vi.mocked(commands.agentsList).mockResolvedValueOnce([
+      makeAgent({ id: 'late', name: 'Late' }),
+    ] as never);
+    mockListen.fire('agents:changed');
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    // Only the stop() call should appear (empty registration), not a
+    // post-stop event-triggered refresh.
+    const calls = vi.mocked(commands.replaceDynamicCommandsBuiltin).mock.calls;
+    for (const [, regs] of calls) {
+      expect((regs as Array<unknown>).length).toBe(0);
+    }
   });
 });
 

--- a/src/built-in-features/shortcuts/shortcutStore.svelte.test.ts
+++ b/src/built-in-features/shortcuts/shortcutStore.svelte.test.ts
@@ -7,6 +7,22 @@ vi.mock('../../lib/ipc/commands', () => ({
   shortcutRemove: vi.fn().mockResolvedValue(undefined),
 }));
 
+const mockListen = vi.hoisted(() => {
+  const callbacks = new Map<string, Array<(payload: unknown) => void>>();
+  const listen = vi.fn(async (event: string, cb: (payload: unknown) => void) => {
+    if (!callbacks.has(event)) callbacks.set(event, []);
+    callbacks.get(event)!.push(cb);
+    return () => {};
+  });
+  const fire = (event: string, payload: unknown = {}) => {
+    const arr = callbacks.get(event);
+    if (!arr) return;
+    for (const cb of arr) cb(payload);
+  };
+  return { listen, fire };
+});
+vi.mock('@tauri-apps/api/event', () => ({ listen: mockListen.listen }));
+
 import { shortcutStore, groupShortcutsBySection, type ItemShortcut } from './shortcutStore.svelte';
 import { shortcutGetAll } from '../../lib/ipc/commands';
 
@@ -72,6 +88,36 @@ describe('shortcutStore', () => {
       const callsBefore = vi.mocked(shortcutGetAll).mock.calls.length;
       await shortcutStore.reload();
       expect(vi.mocked(shortcutGetAll).mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+  });
+
+  describe('cross-webview sync via shortcuts:changed event', () => {
+    it('reloads from SQLite when Rust fires shortcuts:changed', async () => {
+      // Symptom this pins: onboarding's PickAiCommandHotkey step writes a
+      // shortcut from a SEPARATE webview. Without this listener, the main
+      // launcher's in-memory store stays empty and handleFiredShortcut
+      // logs "Received shortcut for unknown objectId" when the user hits
+      // the hotkey — even though Rust dispatched correctly.
+      vi.mocked(shortcutGetAll).mockResolvedValueOnce([] as any);
+      await shortcutStore.init();
+      expect(shortcutStore.shortcuts).toHaveLength(0);
+
+      // Simulate the cross-webview write: SQLite now has a new entry.
+      vi.mocked(shortcutGetAll).mockResolvedValueOnce([
+        makeShortcut('grammar-fix', {
+          objectId: 'cmd_agents_dyn_abc',
+          itemName: 'Grammar Fix',
+          shortcut: 'Cmd+Shift+L',
+        }),
+      ] as any);
+
+      mockListen.fire('shortcuts:changed');
+      // Let the async reload() complete.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      expect(shortcutStore.shortcuts).toHaveLength(1);
+      expect(shortcutStore.shortcuts[0].objectId).toBe('cmd_agents_dyn_abc');
     });
   });
 });

--- a/src/built-in-features/shortcuts/shortcutStore.svelte.ts
+++ b/src/built-in-features/shortcuts/shortcutStore.svelte.ts
@@ -1,3 +1,4 @@
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import {
   shortcutUpsert,
   shortcutGetAll,
@@ -40,6 +41,7 @@ class ShortcutStoreClass {
   shortcuts = $state<ItemShortcut[]>([]);
   isCapturing = $state(false);
   #initialized = false;
+  #changedUnlisten: UnlistenFn | null = null;
   #subscribers = new Set<(event: ShortcutStoreChangeEvent) => void>();
 
   subscribe(callback: (event: ShortcutStoreChangeEvent) => void): () => void {
@@ -68,6 +70,20 @@ class ShortcutStoreClass {
       this.shortcuts = data as ItemShortcut[];
     } catch {
       // Keep empty default
+    }
+
+    // Cross-webview sync: Rust fires `shortcuts:changed` after every
+    // `shortcut_upsert` / `shortcut_remove` so each webview's in-memory
+    // cache stays current. Without this, a shortcut bound from the
+    // onboarding webview never lands in the main launcher's lookup, and
+    // pressing the hotkey logs "Received shortcut for unknown objectId"
+    // because handleFiredShortcut sees a stale empty list.
+    try {
+      this.#changedUnlisten = await listen('shortcuts:changed', () => {
+        void this.reload();
+      });
+    } catch (err) {
+      logService.warn(`[ShortcutStore] failed to subscribe shortcuts:changed: ${err}`);
     }
   }
 

--- a/src/routes/settings/tabs/AiTab.svelte
+++ b/src/routes/settings/tabs/AiTab.svelte
@@ -124,6 +124,34 @@
     }
   }
 
+  /**
+   * Auto-star the just-configured provider when there is no current default
+   * agent. Runs right after a model selection persists, so the user only
+   * had to choose a provider and a model to end up with a working default —
+   * no extra "click the star" step.
+   *
+   * Intentionally a NO-OP when a default already exists, so adding a
+   * second provider never silently swaps the user's preferred default
+   * out from under them. They still have to click the star to switch.
+   */
+  async function maybeAutoSetAsDefault(id: ProviderId, modelId: string) {
+    if (agentService.getDefaultAgent()) return;
+    try {
+      await agentService.upsertDefaultAgent(id, modelId);
+    } catch (err) {
+      diagnosticsService.report({
+        source: 'frontend',
+        kind: 'manual',
+        severity: 'warning',
+        retryable: false,
+        context: {
+          message: 'Could not auto-set the default AI agent. You can pick it manually with the star.',
+        },
+        developerDetail: String(err),
+      });
+    }
+  }
+
   async function removeProvider(id: ProviderId) {
     const wasDefault = isDefault(id);
     // Clear config for this provider
@@ -365,6 +393,8 @@
                           developerDetail: String(err),
                         });
                       }
+                    } else {
+                      await maybeAutoSetAsDefault(providerId, val);
                     }
                   }}
                 >
@@ -404,6 +434,8 @@
                               developerDetail: String(err),
                             });
                           }
+                        } else {
+                          await maybeAutoSetAsDefault(providerId, val);
                         }
                       }
                     }}


### PR DESCRIPTION
…ovider

Three related cleanups exposed by the new onboarding flow:

1) agents:changed now keeps the dynamic command registry in sync.
   agentsManager.start() registered the initial agent list and never
   listened for further changes. Agents created via paths that don't
   call manager.refresh() explicitly — onboarding's upsertDefaultAgent,
   PickAiCommandHotkey's seedGrammarFixAgent, or any cross-webview
   Tauri call — landed in SQLite (and in service.agents, so Manage
   Agents showed them) but never reached Rust's dynamic command
   registry. Root search missed them until the next app boot.
   Manager now subscribes to agents:changed for the duration of
   start() → stop() and re-pushes the registry after awaiting
   service.refresh().

2) shortcuts:changed now propagates cross-webview shortcut writes.
   shortcut_upsert / shortcut_remove persisted to SQLite but emitted
   no Tauri event, so each webview's in-memory shortcutStore was a
   stale snapshot from app boot. A shortcut bound from the onboarding
   webview never landed in the main launcher's cache; the OS hotkey
   fired, Rust dispatched user-shortcut-fired, but handleFiredShortcut
   logged "Received shortcut for unknown objectId" because the lookup
   missed. Rust now emits shortcuts:changed after every upsert/remove
   and shortcutStore reloads on the event.

3) AiTab auto-stars the first provider when no default agent exists.
   Adding the very first provider gives Asyar everything it needs to
   build a default agent — the extra "click the star" step was the
   thing keeping the onboarding Grammar Fix step from finding a
   provider+model to seed against. After persisting a model
   selection, if no default agent exists, upsertDefaultAgent runs
   automatically. Adding a second provider doesn't swap the user's
   existing default out — the guard only fires when nothing is
   starred.