### PR TITLE
feat(clipboard): scale to 50,000 items with paged loading and FTS search

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "gdk",
  "globset",
  "gtk",
+ "hmac",
  "icns",
  "keyring",
  "libc",
@@ -2608,6 +2609,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,7 @@ tauri-plugin-clipboard-x = "2"
 window-vibrancy = "0.6"
 fuzzy-matcher = "0.3.7" # Added for better fuzzy search
 sha2 = "0.10"
+hmac = "0.12"
 aes-gcm = "0.10"
 argon2 = "0.5"
 bip39 = { version = "2.0", default-features = false, features = ["std"] }

--- a/src-tauri/examples/clipboard_perf.rs
+++ b/src-tauri/examples/clipboard_perf.rs
@@ -1,0 +1,106 @@
+//! Throwaway perf runner — not part of the test suite.
+//!
+//! Run with:
+//!   cargo run --example clipboard_perf --release -- 10000
+//!   cargo run --example clipboard_perf --release -- 50000
+
+use asyar_lib::storage::clipboard::{
+    init_table, list_initial, list_older, record_capture_with_fts, search, ClipboardItem,
+};
+use asyar_lib::storage::clipboard_fts::{mark_ready, rebuild_from_disk, ClipboardFts};
+use rusqlite::Connection;
+use std::time::Instant;
+
+fn key() -> [u8; 32] {
+    [0xAB; 32]
+}
+
+fn now_ms() -> f64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as f64
+}
+
+fn make_text_item(i: u32, base_ms: f64) -> ClipboardItem {
+    // Spread items across the past 30 days so none fall outside the 90-day
+    // age-cleanup window. Items are ordered newest-first (highest created_at
+    // for i=0) so list_initial returns the most-recent window.
+    let spread_ms = 30.0 * 24.0 * 60.0 * 60.0 * 1000.0; // 30 days in ms
+    ClipboardItem {
+        id: format!("perf-{i}"),
+        item_type: "text".into(),
+        content: Some(format!(
+            "perf body number {i} the quick brown fox jumps over the lazy dog"
+        )),
+        preview: Some(format!("perf body number {i}")),
+        // i=0 → base_ms (now), i=N-1 → base_ms - spread_ms
+        created_at: base_ms - (i as f64 / 10000.0) * spread_ms,
+        favorite: false,
+        metadata: None,
+        source_app: None,
+        redacted_kinds: None,
+    }
+}
+
+fn main() {
+    let n: u32 = std::env::args()
+        .nth(1)
+        .expect("usage: clipboard_perf <N>")
+        .parse()
+        .unwrap();
+
+    let conn = Connection::open_in_memory().unwrap();
+    init_table(&conn).unwrap();
+    asyar_lib::storage::cloud_sync_state::init_table(&conn).unwrap();
+    let fts = ClipboardFts::new_in_memory().unwrap();
+    let key = key();
+    let base_ms = now_ms();
+
+    // Seed.
+    let t = Instant::now();
+    for i in 0..n {
+        record_capture_with_fts(&conn, &make_text_item(i, base_ms), None, &key, &fts).unwrap();
+    }
+    eprintln!("seed {n} rows: {:.0} ms", t.elapsed().as_millis());
+
+    // Rebuild (cold-start simulation).
+    let fts2 = ClipboardFts::new_in_memory().unwrap();
+    let t = Instant::now();
+    rebuild_from_disk(&conn, &fts2, &key).unwrap();
+    mark_ready();
+    eprintln!("rebuild {n} rows: {:.0} ms", t.elapsed().as_millis());
+
+    // list_initial.
+    let t = Instant::now();
+    let page = list_initial(&conn, 100, &key).unwrap();
+    eprintln!(
+        "list_initial(100) of {n}: {:.2} ms ({} rows)",
+        t.elapsed().as_secs_f64() * 1000.0,
+        page.recent.len()
+    );
+
+    // list_older one page.
+    if let Some(cursor) = page.next_cursor {
+        let t = Instant::now();
+        let older = list_older(&conn, &cursor, 200, &key).unwrap();
+        eprintln!(
+            "list_older(200) of {n}: {:.2} ms ({} rows)",
+            t.elapsed().as_secs_f64() * 1000.0,
+            older.items.len()
+        );
+    } else {
+        eprintln!("list_older(200) of {n}: SKIPPED (no more rows)");
+    }
+
+    // search.
+    let t = Instant::now();
+    let res = search(&conn, &fts2, "perf", 200, &key).unwrap();
+    eprintln!(
+        "search('perf') of {n}: {:.2} ms ({} hits, state={})",
+        t.elapsed().as_secs_f64() * 1000.0,
+        res.items.len(),
+        res.index_state
+    );
+}

--- a/src-tauri/examples/seed_clipboard.rs
+++ b/src-tauri/examples/seed_clipboard.rs
@@ -1,0 +1,139 @@
+//! Stress-test seed: bulk-insert N synthetic rows into the real launcher
+//! clipboard DB so you can open the launcher and see how 30k items feels.
+//!
+//! Run with:
+//!   1. Quit Asyar first (SQLite WAL locks conflict otherwise).
+//!   2. cargo run --example seed_clipboard --release -- 30000
+//!
+//! Optional second arg: a path to the SQLite db (defaults to the
+//! platform's Asyar data file).
+//!
+//! Skips `cleanup` and FTS upsert during seeding for speed. The next
+//! launcher start rebuilds the FTS index from the seeded rows (~300-900ms
+//! background task) and ages-cleanup runs naturally from then on.
+
+use asyar_lib::crypto::keystore::{KEYCHAIN_ACCOUNT, KEYCHAIN_SERVICE};
+use asyar_lib::storage::clipboard::{add_item, init_table, ClipboardItem};
+use asyar_lib::storage::cloud_sync_state;
+use keyring::Entry;
+use rusqlite::Connection;
+use std::path::PathBuf;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+fn default_db_path() -> PathBuf {
+    if cfg!(target_os = "macos") {
+        let home = std::env::var("HOME").expect("HOME not set");
+        PathBuf::from(home)
+            .join("Library/Application Support/org.asyar.app/asyar_data.db")
+    } else if cfg!(target_os = "linux") {
+        let home = std::env::var("HOME").expect("HOME not set");
+        PathBuf::from(home).join(".local/share/org.asyar.app/asyar_data.db")
+    } else if cfg!(target_os = "windows") {
+        let appdata = std::env::var("APPDATA").expect("APPDATA not set");
+        PathBuf::from(appdata).join("org.asyar.app/asyar_data.db")
+    } else {
+        panic!("unsupported platform");
+    }
+}
+
+fn load_master_key() -> [u8; 32] {
+    let entry = Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT)
+        .expect("keychain entry construction");
+    let value = entry
+        .get_password()
+        .expect("master key not found in OS keychain — launch Asyar at least once to generate one");
+    // The keystore stores the 32-byte key as base64. Match the launcher's load_or_create logic:
+    use base64::Engine;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(value.as_bytes())
+        .expect("master key is not base64 — keychain entry corrupted?");
+    assert_eq!(bytes.len(), 32, "master key must be 32 bytes, got {}", bytes.len());
+    let mut k = [0u8; 32];
+    k.copy_from_slice(&bytes);
+    k
+}
+
+fn now_ms() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as f64
+}
+
+// A handful of templates so search has variety to chew on.
+const TEMPLATES: &[&str] = &[
+    "https://example.com/article/{n}",
+    "let result = process_batch({n});",
+    "Meeting notes for sprint {n}: review tasks, plan retro.",
+    "TODO: refactor module {n} before next release.",
+    "Order #{n} shipped today — tracking 1Z999AA10123456784.",
+    "function calculate({n}) {{ return n * 2; }}",
+    "Reminder: review PR #{n} — security fix.",
+    "{n}@asyar.org",
+    "The quick brown fox jumps over {n} lazy dogs.",
+    "API response code: 200 OK, payload size {n} bytes.",
+    "git checkout -b feature/{n}-improvements",
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit {n}.",
+];
+
+fn make_item(i: u32, base_time: f64) -> ClipboardItem {
+    let template = TEMPLATES[(i as usize) % TEMPLATES.len()];
+    let body = template.replace("{n}", &i.to_string());
+    let preview: String = body.chars().take(100).collect();
+    ClipboardItem {
+        id: format!("seed-{i}"),
+        item_type: "text".to_string(),
+        content: Some(body),
+        preview: Some(preview),
+        // Newest items first — spread across the last 30 days.
+        created_at: base_time - (i as f64) * 60_000.0,
+        favorite: i % 1000 == 0, // ~0.1% favorited
+        metadata: None,
+        source_app: Some(serde_json::json!({
+            "name": "Seed Tool",
+            "bundleId": "dev.seed.clipboard",
+        })),
+        redacted_kinds: None,
+    }
+}
+
+fn main() {
+    let n: u32 = std::env::args()
+        .nth(1)
+        .expect("usage: seed_clipboard <N> [db_path]")
+        .parse()
+        .expect("N must be a positive integer");
+
+    let db_path: PathBuf = std::env::args()
+        .nth(2)
+        .map(PathBuf::from)
+        .unwrap_or_else(default_db_path);
+
+    if !db_path.exists() {
+        panic!(
+            "DB not found at {} — launch Asyar at least once to create it",
+            db_path.display()
+        );
+    }
+    eprintln!("DB: {}", db_path.display());
+
+    eprintln!("Reading master key from OS keychain ({KEYCHAIN_SERVICE}/{KEYCHAIN_ACCOUNT})…");
+    let key = load_master_key();
+
+    let conn = Connection::open(&db_path).expect("open SQLite");
+    init_table(&conn).expect("init clipboard table");
+    cloud_sync_state::init_table(&conn).expect("init cloud-sync journal");
+
+    let base = now_ms();
+    let t = Instant::now();
+    let tx = conn.unchecked_transaction().expect("begin tx");
+    for i in 0..n {
+        add_item(&tx, &make_item(i, base), &key).expect("add_item");
+        if i % 5000 == 0 && i > 0 {
+            eprintln!("  …seeded {i}");
+        }
+    }
+    tx.commit().expect("commit");
+    eprintln!("Done: {n} rows in {:.1}s.", t.elapsed().as_secs_f64());
+    eprintln!("Next launcher start will rebuild the FTS index automatically (~1s background).");
+}

--- a/src-tauri/src/crypto/hmac.rs
+++ b/src-tauri/src/crypto/hmac.rs
@@ -1,0 +1,80 @@
+//! Deterministic keyed MAC for indexed lookup of encrypted-at-rest values.
+//!
+//! Distinct from `cipher` (random-nonce AES-GCM): same (key, message)
+//! always produces the same 32-byte output. Used by clipboard dedup to
+//! avoid an O(N) decrypt-and-compare scan per capture.
+
+use ::hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// HMAC-SHA256(key, message) → 32 raw bytes. Deterministic and constant-time
+/// for the verify path (we don't currently verify, but this keeps the door
+/// open if a use case appears).
+pub fn hmac_sha256(key: &[u8; 32], message: &[u8]) -> [u8; 32] {
+    let mut mac =
+        HmacSha256::new_from_slice(key).expect("HMAC-SHA256 accepts any 32-byte key");
+    mac.update(message);
+    mac.finalize().into_bytes().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_key() -> [u8; 32] {
+        let mut k = [0u8; 32];
+        for (i, b) in k.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        k
+    }
+
+    #[test]
+    fn same_inputs_produce_same_output() {
+        let key = test_key();
+        let a = hmac_sha256(&key, b"hello");
+        let b = hmac_sha256(&key, b"hello");
+        assert_eq!(a, b, "HMAC must be deterministic");
+    }
+
+    #[test]
+    fn different_message_produces_different_output() {
+        let key = test_key();
+        let a = hmac_sha256(&key, b"hello");
+        let b = hmac_sha256(&key, b"world");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn different_key_produces_different_output() {
+        let k1 = test_key();
+        let mut k2 = test_key();
+        k2[0] ^= 0xFF;
+        let a = hmac_sha256(&k1, b"same message");
+        let b = hmac_sha256(&k2, b"same message");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn known_answer_pins_the_algorithm() {
+        let key = test_key();
+        let out = hmac_sha256(&key, b"asyar-clipboard-hmac-test");
+        // Computed once from the same (key, message). Pinning this byte-for-byte
+        // catches a silent swap of the hash function or HMAC construction.
+        let expected: [u8; 32] = [
+            119, 183, 107, 219, 96, 141, 147, 239, 25, 229, 141, 134, 186, 200,
+            166, 253, 120, 248, 171, 200, 172, 165, 237, 59, 129, 251, 146, 82,
+            42, 242, 121, 93,
+        ];
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn empty_message_still_produces_output() {
+        let key = test_key();
+        let out = hmac_sha256(&key, b"");
+        assert_eq!(out.len(), 32);
+    }
+}

--- a/src-tauri/src/crypto/mod.rs
+++ b/src-tauri/src/crypto/mod.rs
@@ -7,6 +7,7 @@
 //! and `docs/superpowers/specs/2026-05-04-e2ee-cloud-sync.md`.
 
 pub mod cipher;
+pub mod hmac;
 pub mod keystore;
 pub mod kdf;
 pub mod mnemonic;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -320,15 +320,16 @@ pub fn run() {
             commands::get_theme_definition,
             commands::get_valid_shortcut_keys,
             // Storage: clipboard
-            storage::commands::clipboard_add_item,
-            storage::commands::clipboard_get_all,
-            storage::commands::clipboard_get_recent,
+            storage::commands::clipboard_list_initial,
+            storage::commands::clipboard_list_older,
+            storage::commands::clipboard_search,
+            storage::commands::clipboard_get_item,
+            storage::commands::clipboard_export_for_sync,
+            storage::commands::clipboard_count,
+            storage::commands::clipboard_record_capture,
             storage::commands::clipboard_toggle_favorite,
             storage::commands::clipboard_delete_item,
             storage::commands::clipboard_clear_non_favorites,
-            storage::commands::clipboard_find_duplicate,
-            storage::commands::clipboard_cleanup,
-            storage::commands::clipboard_record_capture,
             // Storage: snippets
             storage::commands::snippet_upsert,
             storage::commands::snippet_get_all,
@@ -865,6 +866,41 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     app.manage(std::sync::Arc::clone(&extension_state_service));
 
     app.manage(data_store);
+
+    // Clipboard FTS: build the in-memory index and spawn a background task
+    // that decrypts every row, feeds the FTS, and backfills content_hash for
+    // legacy rows. Emits `clipboard:fts-ready` when done so the frontend can
+    // flip from an "indexing" state to live search results.
+    {
+        let fts = std::sync::Arc::new(
+            crate::storage::clipboard_fts::ClipboardFts::new_in_memory()
+                .expect("Clipboard FTS in-memory DB must initialise"),
+        );
+        app.manage(fts.clone());
+
+        let conn_arc = app.state::<storage::DataStore>().conn_arc();
+        let master_key: [u8; 32] = *app
+            .state::<crate::crypto::keystore::KeystoreState>()
+            .master_key();
+        let app_handle = app.handle().clone();
+        let fts_for_task = fts.clone();
+        tauri::async_runtime::spawn(async move {
+            let result = tokio::task::spawn_blocking(move || {
+                let conn = match conn_arc.lock() {
+                    Ok(c) => c,
+                    Err(_) => return false,
+                };
+                crate::storage::clipboard_fts::rebuild_from_disk(&conn, &fts_for_task, &master_key)
+                    .is_ok()
+            })
+            .await
+            .unwrap_or(false);
+            if result {
+                crate::storage::clipboard_fts::mark_ready();
+                let _ = app_handle.emit("clipboard:fts-ready", ());
+            }
+        });
+    }
 
     // MCP: populate bundled sidecar paths before seeding servers so that
     // npx/node/uvx/python commands resolve to the bundled binaries when

--- a/src-tauri/src/storage/clipboard.rs
+++ b/src-tauri/src/storage/clipboard.rs
@@ -1,5 +1,6 @@
 use crate::crypto::cipher;
 use crate::error::AppError;
+use crate::storage::clipboard_fts::ClipboardFts;
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -48,6 +49,111 @@ pub struct ClipboardItem {
     pub redacted_kinds: Option<Vec<String>>,
 }
 
+/// Hot-path list payload — decrypts `preview` only, never `content`.
+/// Returned by all paged-list and search IPCs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClipboardListItem {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub item_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preview: Option<String>,
+    pub created_at: f64,
+    pub favorite: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_app: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redacted_kinds: Option<Vec<String>>,
+}
+
+/// Opaque pagination cursor. Comparisons use tuple semantics
+/// `(created_at, id)` — both fields are required to disambiguate
+/// rows that share a millisecond timestamp.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Cursor {
+    pub created_at: f64,
+    pub id: String,
+}
+
+/// Return type for `list_initial`: all favorites plus the newest `limit`
+/// non-favorites, with an optional cursor for fetching older rows.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitialPage {
+    pub favorites: Vec<ClipboardListItem>,
+    pub recent: Vec<ClipboardListItem>,
+    pub next_cursor: Option<Cursor>,
+}
+
+/// Return type for `list_older`: the next page of non-favorites strictly
+/// older than the supplied cursor, with an optional cursor for the page
+/// after that.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OlderPage {
+    pub items: Vec<ClipboardListItem>,
+    pub next_cursor: Option<Cursor>,
+}
+
+/// Counts returned by [`count`]. Used by sync provider summaries to
+/// decide whether a full export is needed without materialising rows.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClipboardCount {
+    pub total: u32,
+    pub favorites: u32,
+}
+
+/// Return type for [`export_for_sync`]: a page of full `ClipboardItem`
+/// rows (content decrypted) plus an optional cursor for the next page.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportPage {
+    pub items: Vec<ClipboardItem>,
+    pub next_cursor: Option<Cursor>,
+}
+
+/// Return type for [`delete_item`]: carries the decrypted image cache-file
+/// path so the TS layer can unlink it without a separate list scan.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteResult {
+    /// Decrypted `content` of an image row, which is the cache file path,
+    /// so the TS layer can unlink it. `None` for non-image rows.
+    pub image_content_path: Option<String>,
+}
+
+/// Return type for [`clear_non_favorites`]: ids that were removed and
+/// the decrypted image-cache paths for any image rows among them.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClearResult {
+    pub removed_ids: Vec<String>,
+    pub removed_image_paths: Vec<String>,
+}
+
+/// Return type for [`record_capture`]: the id of the newly inserted item and
+/// the ids of any items evicted by the age/count cleanup that followed.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaptureResult {
+    pub inserted_id: String,
+    pub evicted_ids: Vec<String>,
+}
+
+/// Return type for [`search`]: FTS5-ranked list items and the index state.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchResult {
+    pub items: Vec<ClipboardListItem>,
+    /// `"ready"` once the FTS rebuild has completed; `"indexing"` before.
+    pub index_state: &'static str,
+}
+
 fn encode_redacted_kinds(kinds: &Option<Vec<String>>) -> Option<String> {
     kinds
         .as_ref()
@@ -58,6 +164,22 @@ fn encode_redacted_kinds(kinds: &Option<Vec<String>>) -> Option<String> {
 fn decode_redacted_kinds(raw: Option<String>) -> Option<Vec<String>> {
     raw.filter(|s| !s.is_empty())
         .map(|s| s.split(',').map(|p| p.to_string()).collect())
+}
+
+/// Deterministic dedup hash for a (type, content) pair under the
+/// master key. Returns `None` for image rows or rows with no content —
+/// these never participate in the text-dedup index.
+fn compute_content_hash(
+    item_type: &str,
+    content: Option<&str>,
+    master_key: &[u8; 32],
+) -> Option<Vec<u8>> {
+    if item_type == "image" {
+        return None;
+    }
+    let needle = content?;
+    let message = format!("{item_type}\n{needle}");
+    Some(crate::crypto::hmac::hmac_sha256(master_key, message.as_bytes()).to_vec())
 }
 
 pub fn init_table(conn: &Connection) -> Result<(), AppError> {
@@ -71,10 +193,11 @@ pub fn init_table(conn: &Connection) -> Result<(), AppError> {
             favorite INTEGER NOT NULL DEFAULT 0,
             metadata TEXT
         );
-        CREATE INDEX IF NOT EXISTS idx_clipboard_created_at
-            ON clipboard_items(created_at DESC);
-        CREATE INDEX IF NOT EXISTS idx_clipboard_favorite
-            ON clipboard_items(favorite);",
+        -- Replace single-column indices from earlier schema versions.
+        DROP INDEX IF EXISTS idx_clipboard_created_at;
+        DROP INDEX IF EXISTS idx_clipboard_favorite;
+        CREATE INDEX IF NOT EXISTS idx_clipboard_fav_created_id
+            ON clipboard_items(favorite, created_at DESC, id DESC);",
     )
     .map_err(|e| AppError::Database(format!("Failed to init clipboard table: {e}")))?;
 
@@ -114,6 +237,36 @@ pub fn init_table(conn: &Connection) -> Result<(), AppError> {
         .map_err(|e| AppError::Database(format!("Failed to add redacted_kinds column: {e}")))?;
     }
 
+    // Migration: add content_hash column if it doesn't exist yet. Nullable
+    // for migrated rows; the FTS rebuild task backfills values as it
+    // decrypts each row at process start.
+    let content_hash_exists: bool = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('clipboard_items') WHERE name='content_hash'",
+            [],
+            |row| row.get::<_, i32>(0),
+        )
+        .map(|c| c > 0)
+        .unwrap_or(false);
+
+    if !content_hash_exists {
+        conn.execute(
+            "ALTER TABLE clipboard_items ADD COLUMN content_hash BLOB",
+            [],
+        )
+        .map_err(|e| AppError::Database(format!("Failed to add content_hash column: {e}")))?;
+    }
+
+    // idx_clipboard_hash must be created after the content_hash ALTER TABLE
+    // guard above — the column doesn't exist on upgrade installs until that
+    // migration runs. Do NOT move this into the execute_batch block.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_clipboard_hash
+            ON clipboard_items(item_type, content_hash)",
+        [],
+    )
+    .map_err(|e| AppError::Database(format!("Failed to create idx_clipboard_hash: {e}")))?;
+
     Ok(())
 }
 
@@ -127,11 +280,12 @@ pub fn add_item(
 ) -> Result<(), AppError> {
     let encrypted_content = encrypt_opt(item.content.as_deref(), master_key)?;
     let encrypted_preview = encrypt_opt(item.preview.as_deref(), master_key)?;
+    let content_hash = compute_content_hash(&item.item_type, item.content.as_deref(), master_key);
 
     conn.execute(
         "INSERT OR REPLACE INTO clipboard_items
-            (id, item_type, content, preview, created_at, favorite, metadata, source_app, redacted_kinds)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            (id, item_type, content, preview, created_at, favorite, metadata, source_app, redacted_kinds, content_hash)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
         params![
             item.id,
             item.item_type,
@@ -142,6 +296,7 @@ pub fn add_item(
             item.metadata.as_ref().map(|m| serde_json::to_string(m).unwrap_or_default()),
             item.source_app.as_ref().map(|m| serde_json::to_string(m).unwrap_or_default()),
             encode_redacted_kinds(&item.redacted_kinds),
+            content_hash,
         ],
     )
     .map_err(|e| AppError::Database(format!("Failed to add clipboard item: {e}")))?;
@@ -163,26 +318,7 @@ pub fn get_all(conn: &Connection, master_key: &[u8; 32]) -> Result<Vec<Clipboard
         .map_err(|e| AppError::Database(format!("Failed to prepare query: {e}")))?;
 
     let items = stmt
-        .query_map([], |row| {
-            let metadata_str: Option<String> = row.get(6)?;
-            let source_app_str: Option<String> = row.get(7)?;
-            let redacted_kinds_str: Option<String> = row.get(8)?;
-            let raw_content: Option<String> = row.get(2)?;
-            let raw_preview: Option<String> = row.get(3)?;
-            Ok(ClipboardItem {
-                id: row.get(0)?,
-                item_type: row.get(1)?,
-                content: decrypt_opt(raw_content, master_key),
-                preview: decrypt_opt(raw_preview, master_key),
-                created_at: row.get(4)?,
-                favorite: row.get::<_, i32>(5)? != 0,
-                metadata: metadata_str
-                    .and_then(|s| serde_json::from_str(&s).ok()),
-                source_app: source_app_str
-                    .and_then(|s| serde_json::from_str(&s).ok()),
-                redacted_kinds: decode_redacted_kinds(redacted_kinds_str),
-            })
-        })
+        .query_map([], row_to_item_factory(master_key))
         .map_err(|e| AppError::Database(format!("Failed to query clipboard items: {e}")))?
         .filter_map(|r| r.ok())
         .collect();
@@ -200,25 +336,6 @@ pub fn get_recent(
 ) -> Result<Vec<ClipboardItem>, AppError> {
     let select_cols = "SELECT id, item_type, content, preview, created_at, favorite, metadata, source_app, redacted_kinds";
 
-    let map_row = |row: &rusqlite::Row<'_>| -> rusqlite::Result<ClipboardItem> {
-        let metadata_str: Option<String> = row.get(6)?;
-        let source_app_str: Option<String> = row.get(7)?;
-        let redacted_kinds_str: Option<String> = row.get(8)?;
-        let raw_content: Option<String> = row.get(2)?;
-        let raw_preview: Option<String> = row.get(3)?;
-        Ok(ClipboardItem {
-            id: row.get(0)?,
-            item_type: row.get(1)?,
-            content: decrypt_opt(raw_content, master_key),
-            preview: decrypt_opt(raw_preview, master_key),
-            created_at: row.get(4)?,
-            favorite: row.get::<_, i32>(5)? != 0,
-            metadata: metadata_str.and_then(|s| serde_json::from_str(&s).ok()),
-            source_app: source_app_str.and_then(|s| serde_json::from_str(&s).ok()),
-            redacted_kinds: decode_redacted_kinds(redacted_kinds_str),
-        })
-    };
-
     // Favorites — all of them, newest first.
     let mut fav_stmt = conn
         .prepare(&format!(
@@ -226,7 +343,7 @@ pub fn get_recent(
         ))
         .map_err(|e| AppError::Database(format!("Failed to prepare get_recent favorites query: {e}")))?;
     let mut items: Vec<ClipboardItem> = fav_stmt
-        .query_map([], map_row)
+        .query_map([], row_to_item_factory(master_key))
         .map_err(|e| AppError::Database(format!("Failed to query favorites: {e}")))?
         .filter_map(|r| r.ok())
         .collect();
@@ -238,13 +355,247 @@ pub fn get_recent(
         ))
         .map_err(|e| AppError::Database(format!("Failed to prepare get_recent non-favorites query: {e}")))?;
     let non_favs: Vec<ClipboardItem> = non_fav_stmt
-        .query_map(rusqlite::params![limit as i64], map_row)
+        .query_map(rusqlite::params![limit as i64], row_to_item_factory(master_key))
         .map_err(|e| AppError::Database(format!("Failed to query non-favorites: {e}")))?
         .filter_map(|r| r.ok())
         .collect();
 
     items.extend(non_favs);
     Ok(items)
+}
+
+/// First-page load: all favorites (newest-first) plus the newest `limit`
+/// non-favorites. Returns a `Cursor` pointing at the oldest non-favorite
+/// in the page when more older rows exist.
+pub fn list_initial(
+    conn: &Connection,
+    limit: usize,
+    master_key: &[u8; 32],
+) -> Result<InitialPage, AppError> {
+    let favorites: Vec<ClipboardListItem> = conn
+        .prepare(&format!(
+            "{LIST_SELECT_COLS} FROM clipboard_items \
+              WHERE favorite = 1 ORDER BY created_at DESC, id DESC"
+        ))
+        .map_err(|e| AppError::Database(format!("Failed to prepare favorites query: {e}")))?
+        .query_map([], list_row_to_item_factory(master_key))
+        .map_err(|e| AppError::Database(format!("Failed to query favorites: {e}")))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    // Fetch limit + 1 to detect whether more older rows exist.
+    let probe_limit = (limit as i64).saturating_add(1);
+    let mut probe: Vec<ClipboardListItem> = conn
+        .prepare(&format!(
+            "{LIST_SELECT_COLS} FROM clipboard_items \
+              WHERE favorite = 0 ORDER BY created_at DESC, id DESC LIMIT ?1"
+        ))
+        .map_err(|e| AppError::Database(format!("Failed to prepare recent query: {e}")))?
+        .query_map(params![probe_limit], list_row_to_item_factory(master_key))
+        .map_err(|e| AppError::Database(format!("Failed to query recent: {e}")))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let has_more = probe.len() > limit;
+    probe.truncate(limit);
+    let next_cursor = if has_more {
+        probe.last().map(|row| Cursor {
+            created_at: row.created_at,
+            id: row.id.clone(),
+        })
+    } else {
+        None
+    };
+
+    Ok(InitialPage {
+        favorites,
+        recent: probe,
+        next_cursor,
+    })
+}
+
+/// Older page: strictly less than `(cursor.created_at, cursor.id)` in
+/// the `(created_at DESC, id DESC)` ordering. Favorites are excluded
+/// from older pages (they all live in the initial page).
+pub fn list_older(
+    conn: &Connection,
+    cursor: &Cursor,
+    limit: usize,
+    master_key: &[u8; 32],
+) -> Result<OlderPage, AppError> {
+    let probe_limit = (limit as i64).saturating_add(1);
+    let mut probe: Vec<ClipboardListItem> = conn
+        .prepare(&format!(
+            "{LIST_SELECT_COLS} FROM clipboard_items \
+              WHERE favorite = 0 \
+                AND (created_at < ?1 OR (created_at = ?1 AND id < ?2)) \
+              ORDER BY created_at DESC, id DESC LIMIT ?3"
+        ))
+        .map_err(|e| AppError::Database(format!("Failed to prepare list_older query: {e}")))?
+        .query_map(
+            params![cursor.created_at, cursor.id, probe_limit],
+            list_row_to_item_factory(master_key),
+        )
+        .map_err(|e| AppError::Database(format!("Failed to query list_older: {e}")))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let has_more = probe.len() > limit;
+    probe.truncate(limit);
+    let next_cursor = if has_more {
+        probe.last().map(|row| Cursor {
+            created_at: row.created_at,
+            id: row.id.clone(),
+        })
+    } else {
+        None
+    };
+
+    Ok(OlderPage {
+        items: probe,
+        next_cursor,
+    })
+}
+
+/// FTS5-backed search. Returns items in bm25 rank order joined to
+/// `clipboard_items` for the row payload. Capped at `limit` results
+/// (no pagination — refine the query for more).
+pub fn search(
+    conn: &Connection,
+    fts: &ClipboardFts,
+    query: &str,
+    limit: usize,
+    master_key: &[u8; 32],
+) -> Result<SearchResult, AppError> {
+    if !crate::storage::clipboard_fts::is_ready() {
+        return Ok(SearchResult {
+            items: Vec::new(),
+            index_state: "indexing",
+        });
+    }
+
+    let ids = fts.search(query, limit)?;
+    if ids.is_empty() {
+        return Ok(SearchResult {
+            items: Vec::new(),
+            index_state: "ready",
+        });
+    }
+
+    // Per-id PK lookup in ranked order; preserves the bm25 ordering FTS
+    // returned. At limit=200 this is ~0.5 ms total.
+    let mut items: Vec<ClipboardListItem> = Vec::with_capacity(ids.len());
+    let select_one = format!(
+        "{LIST_SELECT_COLS} FROM clipboard_items WHERE id = ?1"
+    );
+    let mut stmt = conn
+        .prepare(&select_one)
+        .map_err(|e| AppError::Database(format!("search lookup prepare: {e}")))?;
+    for id in ids {
+        if let Ok(item) = stmt.query_row(params![id], list_row_to_item_factory(master_key)) {
+            items.push(item);
+        }
+    }
+
+    Ok(SearchResult {
+        items,
+        index_state: "ready",
+    })
+}
+
+/// Iterate every row (favorites + non-favorites) newest-first in pages.
+/// Returns full `ClipboardItem` (content decrypted) — sync needs the
+/// plaintext to encrypt under the per-item sync envelope.
+pub fn export_for_sync(
+    conn: &Connection,
+    cursor: Option<&Cursor>,
+    limit: usize,
+    master_key: &[u8; 32],
+) -> Result<ExportPage, AppError> {
+    let probe_limit = (limit as i64).saturating_add(1);
+    let select = "SELECT id, item_type, content, preview, created_at, favorite, \
+                         metadata, source_app, redacted_kinds FROM clipboard_items";
+
+    let mut probe: Vec<ClipboardItem> = match cursor {
+        Some(c) => conn
+            .prepare(&format!(
+                "{select} WHERE (created_at < ?1 OR (created_at = ?1 AND id < ?2)) \
+                   ORDER BY created_at DESC, id DESC LIMIT ?3"
+            ))
+            .map_err(|e| AppError::Database(format!("export_for_sync prepare: {e}")))?
+            .query_map(
+                params![c.created_at, c.id, probe_limit],
+                row_to_item_factory(master_key),
+            )
+            .map_err(|e| AppError::Database(format!("export_for_sync query: {e}")))?
+            .filter_map(|r| r.ok())
+            .collect(),
+        None => conn
+            .prepare(&format!(
+                "{select} ORDER BY created_at DESC, id DESC LIMIT ?1"
+            ))
+            .map_err(|e| AppError::Database(format!("export_for_sync prepare: {e}")))?
+            .query_map(params![probe_limit], row_to_item_factory(master_key))
+            .map_err(|e| AppError::Database(format!("export_for_sync query: {e}")))?
+            .filter_map(|r| r.ok())
+            .collect(),
+    };
+
+    let has_more = probe.len() > limit;
+    probe.truncate(limit);
+    let next_cursor = if has_more {
+        probe.last().map(|row| Cursor {
+            created_at: row.created_at,
+            id: row.id.clone(),
+        })
+    } else {
+        None
+    };
+
+    Ok(ExportPage {
+        items: probe,
+        next_cursor,
+    })
+}
+
+/// Single-row full decrypt by id. Returns `None` if the row is gone.
+/// Used by the lazy-decrypt path: list queries return preview-only
+/// `ClipboardListItem`; on paste/detail open, the TS layer calls this
+/// to fetch the full content for one row.
+pub fn get_item(
+    conn: &Connection,
+    id: &str,
+    master_key: &[u8; 32],
+) -> Result<Option<ClipboardItem>, AppError> {
+    let result = conn.query_row(
+        "SELECT id, item_type, content, preview, created_at, favorite,
+                metadata, source_app, redacted_kinds
+           FROM clipboard_items WHERE id = ?1",
+        params![id],
+        row_to_item_factory(master_key),
+    );
+    match result {
+        Ok(item) => Ok(Some(item)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(AppError::Database(format!("Failed to get item {id}: {e}"))),
+    }
+}
+
+/// Total and favorites-only counts. Cheap (two `COUNT(*)` queries with
+/// indexed lookups) and used by sync provider summaries to avoid
+/// materialising the whole table.
+pub fn count(conn: &Connection) -> Result<ClipboardCount, AppError> {
+    let total: u32 = conn
+        .query_row("SELECT COUNT(*) FROM clipboard_items", [], |r| r.get(0))
+        .map_err(|e| AppError::Database(format!("Failed to count clipboard items: {e}")))?;
+    let favorites: u32 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM clipboard_items WHERE favorite = 1",
+            [],
+            |r| r.get(0),
+        )
+        .map_err(|e| AppError::Database(format!("Failed to count favorites: {e}")))?;
+    Ok(ClipboardCount { total, favorites })
 }
 
 /// Toggle the favorite status of an item. Returns the new favorite value.
@@ -277,83 +628,200 @@ fn delete_and_tombstone(conn: &Connection, id: &str) -> Result<(), AppError> {
     Ok(())
 }
 
-/// Delete a single clipboard item.
-pub fn delete_item(conn: &Connection, id: &str) -> Result<(), AppError> {
-    delete_and_tombstone(conn, id)
+/// Delete a single clipboard item. Returns a [`DeleteResult`] carrying
+/// the decrypted image-cache path when the deleted row was an image, so
+/// the TS layer can unlink the file without a separate list scan.
+pub fn delete_item(
+    conn: &Connection,
+    id: &str,
+    master_key: &[u8; 32],
+) -> Result<DeleteResult, AppError> {
+    // Look up image path (if any) before deletion so the TS layer can
+    // unlink the cache file. One indexed PK lookup; no full table scan.
+    let image_content_path: Option<String> = {
+        let row = conn.query_row(
+            "SELECT item_type, content FROM clipboard_items WHERE id = ?1",
+            params![id],
+            |r| {
+                let item_type: String = r.get(0)?;
+                let raw_content: Option<String> = r.get(1)?;
+                Ok((item_type, raw_content))
+            },
+        );
+        match row {
+            Ok((it_type, raw)) if it_type == "image" => decrypt_opt(raw, master_key),
+            _ => None,
+        }
+    };
+
+    delete_and_tombstone(conn, id)?;
+    Ok(DeleteResult { image_content_path })
 }
 
-/// Delete all non-favorite items.
-pub fn clear_non_favorites(conn: &Connection) -> Result<(), AppError> {
-    let ids: Vec<String> = {
-        let mut stmt = conn
-            .prepare("SELECT id FROM clipboard_items WHERE favorite = 0")
-            .map_err(|e| AppError::Database(format!("Failed to prepare clear query: {e}")))?;
-        let collected: Vec<String> = stmt
-            .query_map([], |row| row.get(0))
-            .map_err(|e| AppError::Database(format!("Failed to query non-favorites: {e}")))?
-            .filter_map(|r| r.ok())
-            .collect();
-        collected
-    };
-    for id in ids {
+/// FTS-aware wrapper: delete a row from disk and from the FTS index.
+pub fn delete_item_with_fts(
+    conn: &Connection,
+    id: &str,
+    master_key: &[u8; 32],
+    fts: &ClipboardFts,
+) -> Result<DeleteResult, AppError> {
+    let res = delete_item(conn, id, master_key)?;
+    fts.delete(id)?;
+    Ok(res)
+}
+
+/// Delete all non-favorite items. Returns a [`ClearResult`] with the ids
+/// removed and decrypted image-cache paths for any image rows, so the TS
+/// layer can unlink those files without a separate list scan.
+pub fn clear_non_favorites(
+    conn: &Connection,
+    master_key: &[u8; 32],
+) -> Result<ClearResult, AppError> {
+    let rows: Vec<(String, String, Option<String>)> = conn
+        .prepare(
+            "SELECT id, item_type, content FROM clipboard_items WHERE favorite = 0",
+        )
+        .map_err(|e| AppError::Database(format!("clear_non_favorites prepare: {e}")))?
+        .query_map([], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?, r.get::<_, Option<String>>(2)?))
+        })
+        .map_err(|e| AppError::Database(format!("clear_non_favorites query: {e}")))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let mut removed_ids = Vec::with_capacity(rows.len());
+    let mut removed_image_paths = Vec::new();
+    for (id, item_type, raw_content) in rows {
+        if item_type == "image" {
+            if let Some(path) = decrypt_opt(raw_content, master_key) {
+                removed_image_paths.push(path);
+            }
+        }
         delete_and_tombstone(conn, &id)?;
+        removed_ids.push(id);
     }
-    Ok(())
+    Ok(ClearResult {
+        removed_ids,
+        removed_image_paths,
+    })
 }
 
-/// Remove items older than max_age_ms that are not favorited, and enforce a max item count.
-pub fn cleanup(conn: &Connection, max_age_ms: f64, max_items: usize) -> Result<(), AppError> {
-    let cutoff = js_sys_now() - max_age_ms;
+/// FTS-aware wrapper: clear all non-favorite rows on disk and drop their
+/// FTS index entries.
+pub fn clear_non_favorites_with_fts(
+    conn: &Connection,
+    master_key: &[u8; 32],
+    fts: &ClipboardFts,
+) -> Result<ClearResult, AppError> {
+    let res = clear_non_favorites(conn, master_key)?;
+    fts.delete_many(&res.removed_ids)?;
+    Ok(res)
+}
 
-    // Enumerate and remove expired non-favorite items
-    let age_ids: Vec<String> = {
-        let mut stmt = conn
-            .prepare(
-                "SELECT id FROM clipboard_items WHERE favorite = 0 AND created_at < ?1",
-            )
-            .map_err(|e| AppError::Database(format!("Failed to prepare age-cleanup query: {e}")))?;
-        let collected: Vec<String> = stmt
-            .query_map(params![cutoff], |row| row.get(0))
-            .map_err(|e| AppError::Database(format!("Failed to query expired items: {e}")))?
-            .filter_map(|r| r.ok())
-            .collect();
-        collected
-    };
+/// Remove items older than `max_age_ms` (non-favorites only) and enforce a
+/// max-item cap. Returns the ids of every evicted row so callers can drop
+/// their FTS index entries in the same logical operation.
+pub fn cleanup(
+    conn: &Connection,
+    max_age_ms: f64,
+    max_items: usize,
+) -> Result<Vec<String>, AppError> {
+    let cutoff = js_sys_now() - max_age_ms;
+    let mut evicted: Vec<String> = Vec::new();
+
+    // Age-based eviction.
+    let age_ids: Vec<String> = conn
+        .prepare("SELECT id FROM clipboard_items WHERE favorite = 0 AND created_at < ?1")
+        .map_err(|e| AppError::Database(format!("cleanup age prepare: {e}")))?
+        .query_map(params![cutoff], |row| row.get::<_, String>(0))
+        .map_err(|e| AppError::Database(format!("cleanup age query: {e}")))?
+        .filter_map(|r| r.ok())
+        .collect();
     for id in age_ids {
         delete_and_tombstone(conn, &id)?;
+        evicted.push(id);
     }
 
-    // Enumerate overflow rows: everything NOT in the newest max_items
-    let overflow_ids: Vec<String> = {
-        let mut stmt = conn
-            .prepare(
-                "SELECT id FROM clipboard_items WHERE id NOT IN (
-                    SELECT id FROM clipboard_items ORDER BY created_at DESC LIMIT ?1
-                )",
-            )
-            .map_err(|e| AppError::Database(format!("Failed to prepare max-items query: {e}")))?;
-        let collected: Vec<String> = stmt
-            .query_map(params![max_items as i64], |row| row.get(0))
-            .map_err(|e| AppError::Database(format!("Failed to query overflow items: {e}")))?
-            .filter_map(|r| r.ok())
-            .collect();
-        collected
-    };
+    // Count-based eviction: anything beyond the newest `max_items` (across
+    // favorites + non-favorites) gets evicted.
+    let overflow_ids: Vec<String> = conn
+        .prepare(
+            "SELECT id FROM clipboard_items
+              WHERE id NOT IN (
+                  SELECT id FROM clipboard_items ORDER BY created_at DESC, id DESC LIMIT ?1
+              )",
+        )
+        .map_err(|e| AppError::Database(format!("cleanup overflow prepare: {e}")))?
+        .query_map(params![max_items as i64], |row| row.get::<_, String>(0))
+        .map_err(|e| AppError::Database(format!("cleanup overflow query: {e}")))?
+        .filter_map(|r| r.ok())
+        .collect();
     for id in overflow_ids {
         delete_and_tombstone(conn, &id)?;
+        evicted.push(id);
     }
 
-    Ok(())
+    Ok(evicted)
+}
+
+/// Row → ClipboardItem mapper used by every read path. Centralised so the
+/// decrypt-and-deserialise logic lives in one place. SELECT must project
+/// columns in this exact order:
+///   id, item_type, content, preview, created_at, favorite,
+///   metadata, source_app, redacted_kinds
+fn row_to_item_factory(
+    master_key: &[u8; 32],
+) -> impl Fn(&rusqlite::Row<'_>) -> rusqlite::Result<ClipboardItem> + '_ {
+    move |row| {
+        let metadata_str: Option<String> = row.get(6)?;
+        let source_app_str: Option<String> = row.get(7)?;
+        let redacted_kinds_str: Option<String> = row.get(8)?;
+        let raw_content: Option<String> = row.get(2)?;
+        let raw_preview: Option<String> = row.get(3)?;
+        Ok(ClipboardItem {
+            id: row.get(0)?,
+            item_type: row.get(1)?,
+            content: decrypt_opt(raw_content, master_key),
+            preview: decrypt_opt(raw_preview, master_key),
+            created_at: row.get(4)?,
+            favorite: row.get::<_, i32>(5)? != 0,
+            metadata: metadata_str.and_then(|s| serde_json::from_str(&s).ok()),
+            source_app: source_app_str.and_then(|s| serde_json::from_str(&s).ok()),
+            redacted_kinds: decode_redacted_kinds(redacted_kinds_str),
+        })
+    }
+}
+
+/// Row → ClipboardListItem mapper. SELECT must project columns in this exact order:
+///   id, item_type, preview, created_at, favorite,
+///   metadata, source_app, redacted_kinds
+fn list_row_to_item_factory(
+    master_key: &[u8; 32],
+) -> impl Fn(&rusqlite::Row<'_>) -> rusqlite::Result<ClipboardListItem> + '_ {
+    move |row| {
+        let metadata_str: Option<String> = row.get(5)?;
+        let source_app_str: Option<String> = row.get(6)?;
+        let redacted_kinds_str: Option<String> = row.get(7)?;
+        let raw_preview: Option<String> = row.get(2)?;
+        Ok(ClipboardListItem {
+            id: row.get(0)?,
+            item_type: row.get(1)?,
+            preview: decrypt_opt(raw_preview, master_key),
+            created_at: row.get(3)?,
+            favorite: row.get::<_, i32>(4)? != 0,
+            metadata: metadata_str.and_then(|s| serde_json::from_str(&s).ok()),
+            source_app: source_app_str.and_then(|s| serde_json::from_str(&s).ok()),
+            redacted_kinds: decode_redacted_kinds(redacted_kinds_str),
+        })
+    }
 }
 
 /// Find duplicate by content+type or by id+type(image).
 ///
-/// Encryption is non-deterministic (random nonce per write), so two
-/// encryptions of the same plaintext produce different ciphertext and
-/// the previous SQL `WHERE content = ?` cannot match. For text-like
-/// item types we now scan all rows of that type, decrypt their
-/// `content`, and compare against the requested plaintext. Volume is
-/// bounded by `MAX_HISTORY_ITEMS = 1000` so this is sub-millisecond.
+/// For text-like types a single indexed equality on `content_hash` replaces
+/// the former O(N) decrypt-scan. Rows with a NULL `content_hash` (legacy rows
+/// inserted before the hash column existed) are not matched — the backfill
+/// task will populate them on next startup.
 ///
 /// For images, `content` is the cache file path (not free text); the
 /// duplicate match is still by `id`, unchanged.
@@ -365,28 +833,14 @@ pub fn find_duplicate(
     master_key: &[u8; 32],
 ) -> Result<Option<ClipboardItem>, AppError> {
     if item_type == "image" {
+        // Image dedup is still by id; content for an image row is the cache
+        // file path, not free text, and content_hash is NULL for image rows.
         let result = conn.query_row(
-            "SELECT id, item_type, content, preview, created_at, favorite, metadata, source_app, redacted_kinds
-             FROM clipboard_items WHERE item_type = ?1 AND id = ?2",
+            "SELECT id, item_type, content, preview, created_at, favorite,
+                    metadata, source_app, redacted_kinds
+               FROM clipboard_items WHERE item_type = ?1 AND id = ?2",
             params![item_type, id],
-            |row| {
-                let metadata_str: Option<String> = row.get(6)?;
-                let source_app_str: Option<String> = row.get(7)?;
-                let redacted_kinds_str: Option<String> = row.get(8)?;
-                let raw_content: Option<String> = row.get(2)?;
-                let raw_preview: Option<String> = row.get(3)?;
-                Ok(ClipboardItem {
-                    id: row.get(0)?,
-                    item_type: row.get(1)?,
-                    content: decrypt_opt(raw_content, master_key),
-                    preview: decrypt_opt(raw_preview, master_key),
-                    created_at: row.get(4)?,
-                    favorite: row.get::<_, i32>(5)? != 0,
-                    metadata: metadata_str.and_then(|s| serde_json::from_str(&s).ok()),
-                    source_app: source_app_str.and_then(|s| serde_json::from_str(&s).ok()),
-                    redacted_kinds: decode_redacted_kinds(redacted_kinds_str),
-                })
-            },
+            row_to_item_factory(master_key),
         );
         return match result {
             Ok(item) => Ok(Some(item)),
@@ -399,43 +853,23 @@ pub fn find_duplicate(
         Some(c) => c,
         None => return Ok(None),
     };
+    let hash =
+        crate::crypto::hmac::hmac_sha256(master_key, format!("{item_type}\n{needle}").as_bytes());
 
-    // Scan all rows of this item_type, decrypt-compare. Bounded by
-    // `MAX_HISTORY_ITEMS` so this is sub-millisecond in practice.
-    let mut stmt = conn
-        .prepare(
-            "SELECT id, item_type, content, preview, created_at, favorite, metadata, source_app, redacted_kinds
-             FROM clipboard_items WHERE item_type = ?1",
-        )
-        .map_err(|e| AppError::Database(format!("Failed to prepare find_duplicate query: {e}")))?;
-
-    let candidates = stmt
-        .query_map(params![item_type], |row| {
-            let metadata_str: Option<String> = row.get(6)?;
-            let source_app_str: Option<String> = row.get(7)?;
-            let redacted_kinds_str: Option<String> = row.get(8)?;
-            let raw_content: Option<String> = row.get(2)?;
-            let raw_preview: Option<String> = row.get(3)?;
-            Ok(ClipboardItem {
-                id: row.get(0)?,
-                item_type: row.get(1)?,
-                content: decrypt_opt(raw_content, master_key),
-                preview: decrypt_opt(raw_preview, master_key),
-                created_at: row.get(4)?,
-                favorite: row.get::<_, i32>(5)? != 0,
-                metadata: metadata_str.and_then(|s| serde_json::from_str(&s).ok()),
-                source_app: source_app_str.and_then(|s| serde_json::from_str(&s).ok()),
-                redacted_kinds: decode_redacted_kinds(redacted_kinds_str),
-            })
-        })
-        .map_err(|e| AppError::Database(format!("Failed to query find_duplicate: {e}")))?;
-
-    for candidate in candidates.flatten() {
-        if candidate.content.as_deref() == Some(needle) {
-            return Ok(Some(candidate));
-        }
+    let result = conn.query_row(
+        "SELECT id, item_type, content, preview, created_at, favorite,
+                metadata, source_app, redacted_kinds
+           FROM clipboard_items
+          WHERE item_type = ?1 AND content_hash = ?2
+          LIMIT 1",
+        params![item_type, &hash[..]],
+        row_to_item_factory(master_key),
+    );
+    match result {
+        Ok(item) => Ok(Some(item)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(AppError::Database(format!("Failed to find duplicate: {e}"))),
     }
-    Ok(None)
 }
 
 /// Cloud-sync category identifier for clipboard items.
@@ -444,21 +878,27 @@ const CLIPBOARD_CATEGORY: &str = "clipboard";
 /// MAX age: 90 days in milliseconds (matches TS-side constant).
 const MAX_HISTORY_AGE_MS: f64 = 90.0 * 24.0 * 60.0 * 60.0 * 1000.0;
 /// Maximum number of history items to keep.
-const MAX_HISTORY_ITEMS: usize = 1000;
+const MAX_HISTORY_ITEMS: usize = 50_000;
+
+/// Shared SELECT column list for `ClipboardListItem` queries. Columns must
+/// match the index expectations of `list_row_to_item_factory` exactly:
+///   0=id, 1=item_type, 2=preview, 3=created_at, 4=favorite,
+///   5=metadata, 6=source_app, 7=redacted_kinds
+const LIST_SELECT_COLS: &str =
+    "SELECT id, item_type, preview, created_at, favorite, metadata, source_app, redacted_kinds";
 
 /// Atomically record a new clipboard capture:
 /// 1. Find any duplicate (same content+type; same id for images).
 /// 2. If found: inherit its favorite status, then delete it.
 /// 3. Insert the new item.
 /// 4. Enforce age and count limits.
-/// 5. Return all items ordered newest-first.
+/// 5. Return the inserted id and the ids of any evicted items.
 pub fn record_capture(
     conn: &Connection,
     item: &ClipboardItem,
     icon_cache_dir: Option<&Path>,
     master_key: &[u8; 32],
-) -> Result<Vec<ClipboardItem>, AppError> {
-    // 0. Enrich source_app with iconUrl if a path and cache dir are available
+) -> Result<CaptureResult, AppError> {
     let mut new_item = item.clone();
     if let Some(cache_dir) = icon_cache_dir {
         if let Some(source_app_val) = new_item.source_app.as_mut() {
@@ -471,17 +911,13 @@ pub fn record_capture(
                     crate::application::service::extract_app_icon(&path_str, cache_dir)
                 {
                     if let Some(obj) = source_app_val.as_object_mut() {
-                        obj.insert(
-                            "iconUrl".to_string(),
-                            serde_json::Value::String(icon_url),
-                        );
+                        obj.insert("iconUrl".to_string(), serde_json::Value::String(icon_url));
                     }
                 }
             }
         }
     }
 
-    // 1. Find duplicate
     let duplicate = find_duplicate(
         conn,
         &new_item.item_type,
@@ -493,17 +929,54 @@ pub fn record_capture(
         if dup.favorite {
             new_item.favorite = true;
         }
-        delete_item(conn, &dup.id)?;
+        // We discard the returned DeleteResult here — the captured item
+        // is the same one being re-inserted, so its image path (if any)
+        // remains valid.
+        let _ = delete_item(conn, &dup.id, master_key)?;
     }
 
-    // 3. Insert
     add_item(conn, &new_item, master_key)?;
+    let evicted_ids = cleanup(conn, MAX_HISTORY_AGE_MS, MAX_HISTORY_ITEMS)?;
 
-    // 4. Cleanup
-    cleanup(conn, MAX_HISTORY_AGE_MS, MAX_HISTORY_ITEMS)?;
+    Ok(CaptureResult {
+        inserted_id: new_item.id,
+        evicted_ids,
+    })
+}
 
-    // 5. Return full list
-    get_all(conn, master_key)
+/// FTS-aware wrapper: insert the new row's content into the FTS index
+/// and delete any dedup-replaced + cleanup-evicted rows from it. Use this
+/// from IPC handlers; the bare `record_capture` exists for unit tests
+/// that don't need the in-memory FTS connection.
+pub fn record_capture_with_fts(
+    conn: &Connection,
+    item: &ClipboardItem,
+    icon_cache_dir: Option<&Path>,
+    master_key: &[u8; 32],
+    fts: &ClipboardFts,
+) -> Result<CaptureResult, AppError> {
+    // Look up the dup id (if any) BEFORE record_capture deletes it, so
+    // we can drop its FTS row.
+    let dup = find_duplicate(
+        conn,
+        &item.item_type,
+        item.content.as_deref(),
+        &item.id,
+        master_key,
+    )?;
+    if let Some(d) = &dup {
+        fts.delete(&d.id)?;
+    }
+    let res = record_capture(conn, item, icon_cache_dir, master_key)?;
+    // New row is in the DB now — index it.
+    fts.upsert(
+        &res.inserted_id,
+        item.preview.as_deref(),
+        item.content.as_deref(),
+    )?;
+    // Evicted ids from cleanup must come out of FTS too.
+    fts.delete_many(&res.evicted_ids)?;
+    Ok(res)
 }
 
 /// JavaScript-compatible timestamp (milliseconds since epoch).
@@ -685,7 +1158,7 @@ mod tests {
         add_item(&conn, &make_item("1", "hello", false), &key).unwrap();
         add_item(&conn, &make_item("2", "world", false), &key).unwrap();
 
-        delete_item(&conn, "1").unwrap();
+        let _ = delete_item(&conn, "1", &key).unwrap();
         let items = get_all(&conn, &key).unwrap();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].id, "2");
@@ -699,7 +1172,7 @@ mod tests {
         add_item(&conn, &make_item("2", "world", true), &key).unwrap();
         add_item(&conn, &make_item("3", "foo", false), &key).unwrap();
 
-        clear_non_favorites(&conn).unwrap();
+        let _ = clear_non_favorites(&conn, &key).unwrap();
         let items = get_all(&conn, &key).unwrap();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].id, "2");
@@ -810,13 +1283,16 @@ mod tests {
         new_item.created_at = 2000.0;
 
         let result = record_capture(&conn, &new_item, None, &key).unwrap();
+        let items = get_all(&conn, &key).unwrap();
 
-        // Only one item in history
-        assert_eq!(result.len(), 1);
+        // The inserted id is the new item
+        assert_eq!(result.inserted_id, "2");
+        // Only one item in history (duplicate was replaced)
+        assert_eq!(items.len(), 1);
         // The new item is at the top (newest)
-        assert_eq!(result[0].id, "2");
+        assert_eq!(items[0].id, "2");
         // favorite was inherited from the original
-        assert!(result[0].favorite, "favorite should be preserved from the duplicate");
+        assert!(items[0].favorite, "favorite should be preserved from the duplicate");
     }
 
     #[test]
@@ -831,10 +1307,13 @@ mod tests {
         item_b.created_at = 2000.0;
 
         let result = record_capture(&conn, &item_b, None, &key).unwrap();
+        let items = get_all(&conn, &key).unwrap();
 
+        // The inserted id is the new item
+        assert_eq!(result.inserted_id, "2");
         // Only one item — the duplicate was removed and the new one inserted
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].id, "2");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "2");
     }
 
     #[test]
@@ -852,10 +1331,13 @@ mod tests {
         new_item.created_at = 2000.0;
 
         let result = record_capture(&conn, &new_item, None, &key).unwrap();
+        let items = get_all(&conn, &key).unwrap();
 
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].id, "2"); // newest first
-        assert_eq!(result[1].id, "1");
+        // The inserted id is the new item
+        assert_eq!(result.inserted_id, "2");
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].id, "2"); // newest first
+        assert_eq!(items[1].id, "1");
     }
 
     #[test]
@@ -935,7 +1417,7 @@ mod tests {
         let key = test_key();
         add_item(&conn, &make_item("42", "some text", false), &key).unwrap();
 
-        delete_item(&conn, "42").unwrap();
+        let _ = delete_item(&conn, "42", &key).unwrap();
 
         let row = journal_row(&conn, "42");
         assert!(row.is_some(), "journal row must exist after delete");
@@ -953,7 +1435,7 @@ mod tests {
         add_item(&conn, &make_item("20", "favorited", true), &key).unwrap();
         add_item(&conn, &make_item("30", "non-fav b", false), &key).unwrap();
 
-        clear_non_favorites(&conn).unwrap();
+        let _ = clear_non_favorites(&conn, &key).unwrap();
 
         // Non-favorites are tombstoned
         for id in &["10", "30"] {
@@ -1180,5 +1662,499 @@ mod tests {
 
         let items = get_recent(&conn, 10, &key).unwrap();
         assert_eq!(items.len(), 0, "empty table must yield empty result");
+    }
+
+    #[test]
+    fn init_table_adds_content_hash_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Pre-create with the old schema (no content_hash column).
+        conn.execute_batch(
+            "CREATE TABLE clipboard_items (
+                id TEXT PRIMARY KEY,
+                item_type TEXT NOT NULL,
+                content TEXT,
+                preview TEXT,
+                created_at REAL NOT NULL,
+                favorite INTEGER NOT NULL DEFAULT 0,
+                metadata TEXT,
+                source_app TEXT,
+                redacted_kinds TEXT
+            );",
+        )
+        .unwrap();
+
+        init_table(&conn).unwrap();
+
+        let count: i32 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('clipboard_items') WHERE name='content_hash'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "content_hash column must be added");
+
+        // Idempotent — second call must not fail.
+        init_table(&conn).unwrap();
+    }
+
+    #[test]
+    fn add_item_populates_content_hash_for_text() {
+        let conn = setup();
+        let key = test_key();
+        add_item(&conn, &make_item("1", "hello world", false), &key).unwrap();
+
+        let hash: Option<Vec<u8>> = conn
+            .query_row(
+                "SELECT content_hash FROM clipboard_items WHERE id = '1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let hash = hash.expect("content_hash must be set");
+        assert_eq!(hash.len(), 32, "HMAC-SHA256 output is 32 bytes");
+
+        // Same content + same type + same key → same hash (deterministic).
+        add_item(&conn, &make_item("2", "hello world", true), &key).unwrap();
+        let hash2: Vec<u8> = conn
+            .query_row(
+                "SELECT content_hash FROM clipboard_items WHERE id = '2'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(hash, hash2);
+    }
+
+    #[test]
+    fn add_item_leaves_content_hash_null_for_images() {
+        let conn = setup();
+        let key = test_key();
+        let mut img = make_item("img-1", "/path/to/img.png", false);
+        img.item_type = "image".to_string();
+        add_item(&conn, &img, &key).unwrap();
+
+        let hash: Option<Vec<u8>> = conn
+            .query_row(
+                "SELECT content_hash FROM clipboard_items WHERE id = 'img-1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(hash.is_none(), "image rows have NULL content_hash");
+    }
+
+    #[test]
+    fn find_duplicate_uses_indexed_hash_not_decrypt_scan() {
+        let conn = setup();
+        let key = test_key();
+        // Insert 50 rows of the same type, all with distinct content.
+        for i in 0..50u32 {
+            add_item(&conn, &make_item(&i.to_string(), &format!("content-{i}"), false), &key).unwrap();
+        }
+        // The needle is row 42.
+        let found = find_duplicate(&conn, "text", Some("content-42"), "any-id", &key).unwrap();
+        assert!(found.is_some(), "hash lookup must match the row");
+        assert_eq!(found.unwrap().id, "42");
+
+        // A miss must return None.
+        let miss = find_duplicate(&conn, "text", Some("not present"), "any-id", &key).unwrap();
+        assert!(miss.is_none());
+    }
+
+    #[test]
+    fn find_duplicate_returns_none_for_legacy_null_hash_rows() {
+        let conn = setup();
+        let key = test_key();
+        // Insert a legacy row by going around add_item — content_hash stays NULL.
+        let encrypted = crate::crypto::cipher::encrypt("legacy content", &key).unwrap();
+        conn.execute(
+            "INSERT INTO clipboard_items
+                (id, item_type, content, preview, created_at, favorite)
+             VALUES ('legacy', 'text', ?1, NULL, 1.0, 0)",
+            params![encrypted],
+        )
+        .unwrap();
+
+        // Hash-lookup miss is expected — the row exists but has no hash yet.
+        let found = find_duplicate(&conn, "text", Some("legacy content"), "any", &key).unwrap();
+        assert!(found.is_none(),
+            "rows with NULL content_hash must not match (rebuild will backfill)");
+    }
+
+    #[test]
+    fn init_table_creates_composite_and_hash_indices() {
+        let conn = setup();
+        // The composite + hash indices must exist after init_table.
+        let names: Vec<String> = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='clipboard_items'")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+
+        assert!(names.contains(&"idx_clipboard_fav_created_id".to_string()),
+            "composite index must exist; got {names:?}");
+        assert!(names.contains(&"idx_clipboard_hash".to_string()),
+            "content_hash index must exist; got {names:?}");
+        // Legacy indices are gone.
+        assert!(!names.contains(&"idx_clipboard_created_at".to_string()),
+            "legacy idx_clipboard_created_at must be removed");
+        assert!(!names.contains(&"idx_clipboard_favorite".to_string()),
+            "legacy idx_clipboard_favorite must be removed");
+    }
+
+    #[test]
+    fn list_item_excludes_content_decrypt() {
+        let conn = setup();
+        let key = test_key();
+        let mut item = make_item("1", "secret content body", false);
+        item.preview = Some("short preview".into());
+        add_item(&conn, &item, &key).unwrap();
+
+        let row: ClipboardListItem = conn
+            .query_row(
+                "SELECT id, item_type, preview, created_at, favorite,
+                        metadata, source_app, redacted_kinds
+                   FROM clipboard_items WHERE id = '1'",
+                [],
+                list_row_to_item_factory(&key),
+            )
+            .unwrap();
+
+        assert_eq!(row.id, "1");
+        assert_eq!(row.preview.as_deref(), Some("short preview"));
+        // ClipboardListItem has no `content` field — this is the compile-time guarantee.
+    }
+
+    #[test]
+    fn list_initial_returns_all_favorites_plus_n_newest_non_favorites_with_cursor() {
+        let conn = setup();
+        let key = test_key();
+
+        // 2 favorites at older timestamps.
+        let mut fa = make_item("fa", "fav a", true); fa.created_at = 500.0;
+        let mut fb = make_item("fb", "fav b", true); fb.created_at = 600.0;
+        add_item(&conn, &fa, &key).unwrap();
+        add_item(&conn, &fb, &key).unwrap();
+        // 5 non-favorites with newer timestamps.
+        for i in 0..5u32 {
+            let mut nf = make_item(&format!("n{i}"), &format!("nf {i}"), false);
+            nf.created_at = 3000.0 + i as f64;
+            add_item(&conn, &nf, &key).unwrap();
+        }
+
+        let page = list_initial(&conn, 3, &key).unwrap();
+        assert_eq!(page.favorites.len(), 2);
+        assert_eq!(page.recent.len(), 3, "limit honoured for non-favorites");
+        // Cursor points at the oldest non-favorite in the page (n2 with created_at 3002).
+        let cursor = page.next_cursor.expect("more rows exist, cursor must be set");
+        assert_eq!(cursor.created_at, 3002.0);
+        assert_eq!(cursor.id, "n2");
+
+        // Page fits entirely → no cursor.
+        let full = list_initial(&conn, 10, &key).unwrap();
+        assert_eq!(full.recent.len(), 5);
+        assert!(full.next_cursor.is_none(), "no cursor when everything fits");
+    }
+
+    #[test]
+    fn list_older_returns_strictly_older_non_favorites() {
+        let conn = setup();
+        let key = test_key();
+        // 10 non-favorites with strictly increasing timestamps.
+        for i in 0..10u32 {
+            let mut nf = make_item(&format!("n{i}"), &format!("nf {i}"), false);
+            nf.created_at = 1000.0 + i as f64;
+            add_item(&conn, &nf, &key).unwrap();
+        }
+
+        let first = list_initial(&conn, 3, &key).unwrap();
+        assert_eq!(first.recent.len(), 3);
+        let cursor = first.next_cursor.unwrap();
+        let next = list_older(&conn, &cursor, 3, &key).unwrap();
+        assert_eq!(next.items.len(), 3);
+        // Combined ids of the two pages must be disjoint.
+        let first_ids: std::collections::HashSet<&str> =
+            first.recent.iter().map(|r| r.id.as_str()).collect();
+        for row in &next.items {
+            assert!(!first_ids.contains(row.id.as_str()),
+                "older page must not duplicate first-page rows");
+        }
+    }
+
+    #[test]
+    fn list_older_cursor_handles_duplicate_timestamps_via_id_tiebreaker() {
+        let conn = setup();
+        let key = test_key();
+        // Three rows at the exact same timestamp with different ids.
+        for id in ["a", "b", "c"] {
+            let mut nf = make_item(id, &format!("content {id}"), false);
+            nf.created_at = 5000.0;
+            add_item(&conn, &nf, &key).unwrap();
+        }
+        // Load 2, then ask for the 3rd via cursor.
+        let first = list_initial(&conn, 2, &key).unwrap();
+        assert_eq!(first.recent.len(), 2);
+        let cursor = first.next_cursor.unwrap();
+        let next = list_older(&conn, &cursor, 5, &key).unwrap();
+        assert_eq!(next.items.len(), 1, "exactly one row past the cursor");
+        // The remaining row must be the one with the smallest id.
+        let seen: std::collections::HashSet<String> = first.recent.iter().map(|r| r.id.clone())
+            .chain(next.items.iter().map(|r| r.id.clone()))
+            .collect();
+        assert_eq!(seen, ["a", "b", "c"].into_iter().map(String::from).collect());
+    }
+
+    #[test]
+    fn get_item_returns_full_decrypted_row_by_id() {
+        let conn = setup();
+        let key = test_key();
+        let mut it = make_item("solo", "full text body", false);
+        it.preview = Some("preview".into());
+        add_item(&conn, &it, &key).unwrap();
+
+        let got = get_item(&conn, "solo", &key).unwrap().unwrap();
+        assert_eq!(got.id, "solo");
+        assert_eq!(got.content.as_deref(), Some("full text body"));
+        assert_eq!(got.preview.as_deref(), Some("preview"));
+
+        let missing = get_item(&conn, "does-not-exist", &key).unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[test]
+    fn count_returns_total_and_favorites_without_loading_rows() {
+        let conn = setup();
+        let key = test_key();
+        for i in 0..5u32 {
+            add_item(&conn, &make_item(&i.to_string(), &format!("c{i}"), i % 2 == 0), &key).unwrap();
+        }
+        let c = count(&conn).unwrap();
+        assert_eq!(c.total, 5);
+        assert_eq!(c.favorites, 3, "ids 0/2/4 are favorites");
+    }
+
+    #[test]
+    fn export_for_sync_walks_all_rows_in_pages() {
+        let conn = setup();
+        let key = test_key();
+        for i in 0..7u32 {
+            let mut it = make_item(&i.to_string(), &format!("body {i}"), false);
+            it.created_at = 1000.0 + i as f64;
+            add_item(&conn, &it, &key).unwrap();
+        }
+
+        let mut all = Vec::new();
+        let mut cursor = None;
+        loop {
+            let page = export_for_sync(&conn, cursor.as_ref(), 3, &key).unwrap();
+            all.extend(page.items);
+            cursor = page.next_cursor;
+            if cursor.is_none() { break; }
+        }
+        assert_eq!(all.len(), 7);
+        // Content must be decrypted — sync needs plaintext.
+        assert!(all.iter().all(|i| i.content.is_some()));
+        // Order is newest-first.
+        let cas: Vec<f64> = all.iter().map(|i| i.created_at).collect();
+        let mut sorted = cas.clone();
+        sorted.sort_by(|a, b| b.partial_cmp(a).unwrap());
+        assert_eq!(cas, sorted);
+    }
+
+    #[test]
+    fn delete_item_returns_image_path_for_image_rows() {
+        let conn = setup();
+        let key = test_key();
+        let mut img = make_item("img-1", "/cache/img-1.png", false);
+        img.item_type = "image".to_string();
+        add_item(&conn, &img, &key).unwrap();
+
+        let res = delete_item(&conn, "img-1", &key).unwrap();
+        assert_eq!(res.image_content_path.as_deref(), Some("/cache/img-1.png"));
+    }
+
+    #[test]
+    fn delete_item_returns_none_for_text_rows() {
+        let conn = setup();
+        let key = test_key();
+        add_item(&conn, &make_item("t1", "text body", false), &key).unwrap();
+
+        let res = delete_item(&conn, "t1", &key).unwrap();
+        assert!(res.image_content_path.is_none());
+    }
+
+    #[test]
+    fn delete_item_with_missing_id_returns_none_and_tombstones() {
+        let conn = setup();
+        let key = test_key();
+
+        // No row exists with this id.
+        let res = delete_item(&conn, "ghost", &key).unwrap();
+        assert!(res.image_content_path.is_none(),
+            "no row, no image path");
+
+        // A tombstone is still written — current contract, intentional for
+        // cloud-sync idempotency on cross-device delete races.
+        let row = journal_row(&conn, "ghost");
+        assert!(row.is_some(),
+            "tombstone written even for a never-existing id");
+        let (is_tombstone, is_dirty, _) = row.unwrap();
+        assert!(is_tombstone);
+        assert!(is_dirty);
+    }
+
+    #[test]
+    fn clear_non_favorites_returns_removed_ids_and_image_paths() {
+        let conn = setup();
+        let key = test_key();
+        add_item(&conn, &make_item("t1", "text", false), &key).unwrap();
+        let mut img = make_item("img1", "/cache/img1.png", false);
+        img.item_type = "image".to_string();
+        add_item(&conn, &img, &key).unwrap();
+        add_item(&conn, &make_item("favtext", "fav body", true), &key).unwrap();
+
+        let res = clear_non_favorites(&conn, &key).unwrap();
+        let mut ids = res.removed_ids.clone();
+        ids.sort();
+        assert_eq!(ids, vec!["img1".to_string(), "t1".to_string()]);
+        assert_eq!(res.removed_image_paths, vec!["/cache/img1.png".to_string()]);
+    }
+
+    #[test]
+    fn record_capture_returns_inserted_id_only_not_full_list() {
+        let conn = setup();
+        let key = test_key();
+        for i in 0..5u32 {
+            add_item(&conn, &make_item(&format!("seed{i}"), &format!("body {i}"), false), &key).unwrap();
+        }
+
+        let mut new_item = make_item("fresh", "new body", false);
+        new_item.created_at = 9999.0;
+        let res = record_capture(&conn, &new_item, None, &key).unwrap();
+        assert_eq!(res.inserted_id, "fresh");
+        assert!(res.evicted_ids.is_empty(), "no eviction at 6 rows < MAX_HISTORY_ITEMS");
+    }
+
+    #[test]
+    fn cleanup_returns_evicted_ids() {
+        let conn = setup();
+        let key = test_key();
+        for i in 0..6u32 {
+            let mut it = make_item(&i.to_string(), &format!("body {i}"), false);
+            it.created_at = 1000.0 + i as f64;
+            add_item(&conn, &it, &key).unwrap();
+        }
+        // Keep only the 2 newest non-favorites.
+        let evicted = cleanup(&conn, MAX_HISTORY_AGE_MS, 2).unwrap();
+        let mut ids: Vec<String> = evicted.into_iter().collect();
+        ids.sort();
+        // Newest 2 survive (ids "4" and "5"), the other 4 are evicted (ids "0","1","2","3").
+        assert_eq!(ids, vec!["0".to_string(), "1".to_string(), "2".to_string(), "3".to_string()]);
+    }
+
+    fn setup_with_fts() -> (Connection, crate::storage::clipboard_fts::ClipboardFts) {
+        let conn = setup();
+        let fts = crate::storage::clipboard_fts::ClipboardFts::new_in_memory().unwrap();
+        (conn, fts)
+    }
+
+    #[test]
+    fn record_capture_inserts_into_fts() {
+        let (conn, fts) = setup_with_fts();
+        let key = test_key();
+        let mut item = make_item("c1", "searchable apple body", false);
+        item.preview = Some("preview apple".into());
+        record_capture_with_fts(&conn, &item, None, &key, &fts).unwrap();
+
+        let hits = fts.search("apple", 10).unwrap();
+        assert_eq!(hits, vec!["c1".to_string()]);
+    }
+
+    #[test]
+    fn delete_item_with_fts_removes_from_index() {
+        let (conn, fts) = setup_with_fts();
+        let key = test_key();
+        let item = make_item("c1", "banana body", false);
+        record_capture_with_fts(&conn, &item, None, &key, &fts).unwrap();
+        assert!(!fts.search("banana", 10).unwrap().is_empty());
+
+        delete_item_with_fts(&conn, "c1", &key, &fts).unwrap();
+        assert!(fts.search("banana", 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn clear_non_favorites_with_fts_clears_only_non_favorite_fts_rows() {
+        let (conn, fts) = setup_with_fts();
+        let key = test_key();
+        record_capture_with_fts(&conn, &make_item("nf", "carrot body", false), None, &key, &fts).unwrap();
+        let mut fav = make_item("favid", "carrot favorite", true);
+        fav.created_at = 2000.0;
+        record_capture_with_fts(&conn, &fav, None, &key, &fts).unwrap();
+
+        clear_non_favorites_with_fts(&conn, &key, &fts).unwrap();
+        let hits = fts.search("carrot", 10).unwrap();
+        assert_eq!(hits, vec!["favid".to_string()]);
+    }
+
+    #[test]
+    fn capture_dedup_replaces_old_fts_row() {
+        let (conn, fts) = setup_with_fts();
+        let key = test_key();
+        let mut old = make_item("old", "duplicate body", false);
+        old.created_at = 1000.0;
+        record_capture_with_fts(&conn, &old, None, &key, &fts).unwrap();
+
+        let mut new = make_item("new", "duplicate body", false);
+        new.created_at = 2000.0;
+        record_capture_with_fts(&conn, &new, None, &key, &fts).unwrap();
+
+        let hits = fts.search("duplicate", 10).unwrap();
+        assert_eq!(hits, vec!["new".to_string()],
+            "old row removed from FTS, new row inserted");
+    }
+
+    #[test]
+    fn max_history_items_is_fifty_thousand() {
+        assert_eq!(MAX_HISTORY_ITEMS, 50_000);
+    }
+
+    #[test]
+    fn search_returns_list_items_for_fts_matches() {
+        let (conn, fts) = setup_with_fts();
+        let key = test_key();
+        for i in 0..10u32 {
+            let mut it = make_item(&i.to_string(), &format!("body apple {i}"), false);
+            it.created_at = 1000.0 + i as f64;
+            record_capture_with_fts(&conn, &it, None, &key, &fts).unwrap();
+        }
+        let mut other = make_item("z", "body banana z", false);
+        other.created_at = 2000.0;
+        record_capture_with_fts(&conn, &other, None, &key, &fts).unwrap();
+
+        // Ready required.
+        crate::storage::clipboard_fts::mark_ready();
+
+        let res = search(&conn, &fts, "apple", 20, &key).unwrap();
+        assert_eq!(res.items.len(), 10);
+        assert!(res.items.iter().all(|i| i.id != "z"));
+        assert_eq!(res.index_state, "ready");
+
+        // Clean up for other tests.
+        crate::storage::clipboard_fts::FTS_READY
+            .store(false, std::sync::atomic::Ordering::Release);
+    }
+
+    #[test]
+    fn search_returns_empty_when_index_not_ready() {
+        let (conn, fts) = setup_with_fts();
+        let key = test_key();
+        crate::storage::clipboard_fts::FTS_READY
+            .store(false, std::sync::atomic::Ordering::Release);
+        let res = search(&conn, &fts, "anything", 20, &key).unwrap();
+        assert_eq!(res.index_state, "indexing");
+        assert!(res.items.is_empty());
     }
 }

--- a/src-tauri/src/storage/clipboard_fts.rs
+++ b/src-tauri/src/storage/clipboard_fts.rs
@@ -1,0 +1,454 @@
+//! In-memory FTS5 index over decrypted clipboard preview + content.
+//!
+//! Lives in a separate SQLite `:memory:` connection so the on-disk
+//! clipboard database stays opaque ciphertext while search still works.
+//! Rebuilt at process start (see `lib.rs::setup_app` — added in Task 17)
+//! by streaming every row of `clipboard_items`, decrypting, and inserting
+//! here. Kept in sync at steady state by every mutation in `storage::clipboard`.
+
+use crate::error::AppError;
+use rusqlite::{params, Connection};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+/// Set to `true` when `rebuild_from_disk` completes. Search queries
+/// arriving before this is true return `{ items: [], indexState:
+/// "indexing" }` so the UI can show a hint.
+pub static FTS_READY: AtomicBool = AtomicBool::new(false);
+
+pub fn is_ready() -> bool {
+    FTS_READY.load(Ordering::Acquire)
+}
+
+pub fn mark_ready() {
+    FTS_READY.store(true, Ordering::Release);
+}
+
+/// Walk every clipboard row newest-first, decrypt content + preview,
+/// insert into FTS, and backfill `content_hash` for rows where it's NULL.
+/// Idempotent on the FTS side (INSERT OR REPLACE) and on the hash-backfill
+/// side (only writes rows with NULL hash).
+///
+/// One disk read pass produces three outputs: FTS index entries, hash
+/// backfill for legacy rows, and a deterministic done-state.
+pub fn rebuild_from_disk(
+    conn: &Connection,
+    fts: &ClipboardFts,
+    master_key: &[u8; 32],
+) -> Result<(), AppError> {
+    use crate::crypto::cipher;
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, item_type, content, preview, content_hash \
+               FROM clipboard_items ORDER BY created_at DESC, id DESC",
+        )
+        .map_err(|e| AppError::Database(format!("FTS rebuild prepare: {e}")))?;
+
+    struct Row {
+        id: String,
+        item_type: String,
+        raw_content: Option<String>,
+        raw_preview: Option<String>,
+        existing_hash: Option<Vec<u8>>,
+    }
+
+    let rows: Vec<Row> = stmt
+        .query_map([], |r| {
+            Ok(Row {
+                id: r.get(0)?,
+                item_type: r.get(1)?,
+                raw_content: r.get(2)?,
+                raw_preview: r.get(3)?,
+                existing_hash: r.get(4)?,
+            })
+        })
+        .map_err(|e| AppError::Database(format!("FTS rebuild query: {e}")))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let mut hash_writes: Vec<(String, Vec<u8>)> = Vec::new();
+
+    for row in &rows {
+        let content = row.raw_content.as_ref().and_then(|v| {
+            if cipher::is_encrypted_value(v) {
+                cipher::decrypt(v, master_key).ok()
+            } else {
+                None
+            }
+        });
+        let preview = row.raw_preview.as_ref().and_then(|v| {
+            if cipher::is_encrypted_value(v) {
+                cipher::decrypt(v, master_key).ok()
+            } else {
+                None
+            }
+        });
+        fts.upsert(&row.id, preview.as_deref(), content.as_deref())?;
+
+        if row.existing_hash.is_none() && row.item_type != "image" {
+            if let Some(c) = content.as_deref() {
+                let hash = crate::crypto::hmac::hmac_sha256(
+                    master_key,
+                    format!("{}\n{}", row.item_type, c).as_bytes(),
+                );
+                hash_writes.push((row.id.clone(), hash.to_vec()));
+            }
+        }
+    }
+
+    // Batch the hash backfill in a single transaction so it's atomic.
+    if !hash_writes.is_empty() {
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| AppError::Database(format!("FTS rebuild hash tx: {e}")))?;
+        {
+            let mut stmt = tx
+                .prepare("UPDATE clipboard_items SET content_hash = ?1 WHERE id = ?2")
+                .map_err(|e| AppError::Database(format!("FTS rebuild hash prepare: {e}")))?;
+            for (id, hash) in &hash_writes {
+                stmt.execute(params![&hash[..], id])
+                    .map_err(|e| AppError::Database(format!("FTS rebuild hash row: {e}")))?;
+            }
+        }
+        tx.commit()
+            .map_err(|e| AppError::Database(format!("FTS rebuild hash commit: {e}")))?;
+    }
+
+    Ok(())
+}
+
+/// Hash a clipboard id (`String`) to a stable i64 used as the FTS rowid.
+/// Required because FTS5 rowids must be integers; clipboard ids are UUIDs.
+/// Collision rate at 50k entries is negligible (birthday bound ≈ 2^-32 over 50k inserts).
+pub fn rowid_for(id: &str) -> i64 {
+    use std::hash::{BuildHasher, BuildHasherDefault, Hasher};
+    let mut hasher = BuildHasherDefault::<std::collections::hash_map::DefaultHasher>::new()
+        .build_hasher();
+    hasher.write(id.as_bytes());
+    hasher.finish() as i64
+}
+
+pub struct ClipboardFts {
+    conn: Mutex<Connection>,
+}
+
+impl ClipboardFts {
+    pub fn new_in_memory() -> Result<Self, AppError> {
+        let conn = Connection::open_in_memory()
+            .map_err(|e| AppError::Database(format!("Failed to open FTS memory DB: {e}")))?;
+        conn.execute_batch(
+            "CREATE VIRTUAL TABLE fts_clipboard USING fts5(
+                clip_id UNINDEXED,
+                preview, content,
+                prefix='2 3',
+                tokenize='unicode61 remove_diacritics 2'
+            );",
+        )
+        .map_err(|e| AppError::Database(format!("Failed to create FTS table: {e}")))?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    /// Insert or replace the FTS row for a clipboard id.
+    pub fn upsert(&self, id: &str, preview: Option<&str>, content: Option<&str>) -> Result<(), AppError> {
+        let rowid = rowid_for(id);
+        let conn = self.conn.lock().map_err(|_| AppError::Lock)?;
+        conn.execute(
+            "INSERT OR REPLACE INTO fts_clipboard(rowid, clip_id, preview, content) \
+             VALUES (?1, ?2, ?3, ?4)",
+            params![rowid, id, preview.unwrap_or(""), content.unwrap_or("")],
+        )
+        .map_err(|e| AppError::Database(format!("FTS upsert: {e}")))?;
+        Ok(())
+    }
+
+    pub fn delete(&self, id: &str) -> Result<(), AppError> {
+        let rowid = rowid_for(id);
+        let conn = self.conn.lock().map_err(|_| AppError::Lock)?;
+        conn.execute("DELETE FROM fts_clipboard WHERE rowid = ?1", params![rowid])
+            .map_err(|e| AppError::Database(format!("FTS delete: {e}")))?;
+        Ok(())
+    }
+
+    /// Bulk delete used by cleanup / clear_non_favorites.
+    pub fn delete_many(&self, ids: &[String]) -> Result<(), AppError> {
+        let conn = self.conn.lock().map_err(|_| AppError::Lock)?;
+        let tx = conn.unchecked_transaction()
+            .map_err(|e| AppError::Database(format!("FTS delete_many tx: {e}")))?;
+        {
+            let mut stmt = tx
+                .prepare("DELETE FROM fts_clipboard WHERE rowid = ?1")
+                .map_err(|e| AppError::Database(format!("FTS delete_many prepare: {e}")))?;
+            for id in ids {
+                stmt.execute(params![rowid_for(id)])
+                    .map_err(|e| AppError::Database(format!("FTS delete_many row: {e}")))?;
+            }
+        }
+        tx.commit().map_err(|e| AppError::Database(format!("FTS delete_many commit: {e}")))?;
+        Ok(())
+    }
+
+    /// FTS5 MATCH with bm25 ranking. Returns the original clipboard ids
+    /// (strings, taken from the UNINDEXED `clip_id` column) ordered
+    /// best-match first. Caller JOINs to `clipboard_items` for the row
+    /// payload.
+    pub fn search(&self, query: &str, limit: usize) -> Result<Vec<String>, AppError> {
+        let sanitized = sanitize_for_fts5(query);
+        if sanitized.is_empty() {
+            return Ok(Vec::new());
+        }
+        let conn = self.conn.lock().map_err(|_| AppError::Lock)?;
+        let ids: Vec<String> = conn
+            .prepare(
+                "SELECT clip_id FROM fts_clipboard \
+                  WHERE fts_clipboard MATCH ?1 \
+                  ORDER BY bm25(fts_clipboard) LIMIT ?2",
+            )
+            .map_err(|e| AppError::Database(format!("FTS search prepare: {e}")))?
+            .query_map(params![sanitized, limit as i64], |row| row.get::<_, String>(0))
+            .map_err(|e| AppError::Database(format!("FTS search query: {e}")))?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(ids)
+    }
+}
+
+/// Turn a free-form user query into an FTS5 MATCH expression that does
+/// prefix matching on every token.
+///
+/// FTS5's MATCH operator treats query terms as **exact tokens** by
+/// default — `MATCH 'appl'` will not match a document containing
+/// `apple`. Without prefix matching, an as-you-type search appears
+/// broken: nothing matches until the user types a complete indexed
+/// word. Appending `*` to each token (`appl*`) enables prefix matching,
+/// so results refine smoothly as the user types.
+///
+/// Reserved FTS5 syntax characters (`" ( ) * : '`) are also dropped so
+/// arbitrary user input cannot trigger an FTS5 syntax error or change
+/// the query's logical structure. Multi-term queries combine with the
+/// implicit AND that FTS5 already uses between bareword tokens, e.g.
+/// `"apple pie"` → `apple* pie*` → rows containing both prefixes.
+fn sanitize_for_fts5(query: &str) -> String {
+    query
+        .chars()
+        .map(|c| match c {
+            '"' | '*' | '(' | ')' | ':' | '\'' => ' ',
+            _ => c,
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .map(|tok| format!("{tok}*"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rowid_is_deterministic() {
+        assert_eq!(rowid_for("abc"), rowid_for("abc"));
+        assert_ne!(rowid_for("abc"), rowid_for("abd"));
+    }
+
+    #[test]
+    fn upsert_then_search_matches() {
+        let fts = ClipboardFts::new_in_memory().unwrap();
+        fts.upsert("id-1", Some("greeting"), Some("hello world this is a test")).unwrap();
+        fts.upsert("id-2", Some("goodbye"), Some("farewell sweet world")).unwrap();
+
+        let hits = fts.search("hello", 10).unwrap();
+        assert_eq!(hits, vec!["id-1".to_string()]);
+        let hits = fts.search("world", 10).unwrap();
+        // Both rows match — order is by bm25; just assert both are present.
+        assert!(hits.contains(&"id-1".to_string()));
+        assert!(hits.contains(&"id-2".to_string()));
+    }
+
+    #[test]
+    fn delete_removes_row_from_search() {
+        let fts = ClipboardFts::new_in_memory().unwrap();
+        fts.upsert("id-1", None, Some("findable text")).unwrap();
+        assert_eq!(fts.search("findable", 10).unwrap(), vec!["id-1".to_string()]);
+        fts.delete("id-1").unwrap();
+        assert!(fts.search("findable", 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn delete_many_removes_all_specified_rows() {
+        let fts = ClipboardFts::new_in_memory().unwrap();
+        for i in 0..5u32 {
+            fts.upsert(&i.to_string(), None, Some(&format!("findable {i}"))).unwrap();
+        }
+        fts.delete_many(&["1".to_string(), "3".to_string()]).unwrap();
+        let hits = fts.search("findable", 10).unwrap();
+        assert_eq!(hits.len(), 3);
+        assert!(!hits.contains(&"1".to_string()));
+        assert!(!hits.contains(&"3".to_string()));
+    }
+
+    #[test]
+    fn empty_query_returns_empty() {
+        let fts = ClipboardFts::new_in_memory().unwrap();
+        fts.upsert("id-1", None, Some("anything")).unwrap();
+        assert!(fts.search("   ", 10).unwrap().is_empty());
+        assert!(fts.search("", 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn upsert_replaces_existing_row() {
+        let fts = ClipboardFts::new_in_memory().unwrap();
+        fts.upsert("id-1", None, Some("apple")).unwrap();
+        fts.upsert("id-1", None, Some("banana")).unwrap();
+        assert!(fts.search("apple", 10).unwrap().is_empty(), "old content gone after replace");
+        assert_eq!(fts.search("banana", 10).unwrap(), vec!["id-1".to_string()]);
+    }
+
+    #[test]
+    fn search_matches_partial_prefix_from_first_character() {
+        let fts = ClipboardFts::new_in_memory().unwrap();
+        fts.upsert("id-1", None, Some("apple pie recipe")).unwrap();
+        fts.upsert("id-2", None, Some("applied physics notes")).unwrap();
+        fts.upsert("id-3", None, Some("banana smoothie")).unwrap();
+
+        // Single-character query → "a*" → both "apple" and "applied"
+        // share that prefix; banana also starts with "b" so it is excluded.
+        let hits = fts.search("a", 10).unwrap();
+        assert_eq!(hits.len(), 2);
+        assert!(hits.contains(&"id-1".to_string()));
+        assert!(hits.contains(&"id-2".to_string()));
+
+        // Three-char prefix — still both.
+        let hits = fts.search("app", 10).unwrap();
+        assert_eq!(hits.len(), 2);
+
+        // Four-char prefix — both still match ("apple" and "applied" both
+        // start with "appl").
+        let hits = fts.search("appl", 10).unwrap();
+        assert_eq!(hits.len(), 2);
+
+        // Five-char prefix "apple" — only the "apple" row matches now;
+        // "applied" branches off at index 4 (appli…, not apple…).
+        let hits = fts.search("apple", 10).unwrap();
+        assert_eq!(hits, vec!["id-1".to_string()]);
+    }
+
+    #[test]
+    fn search_multi_token_query_prefix_matches_each_token() {
+        let fts = ClipboardFts::new_in_memory().unwrap();
+        fts.upsert("id-1", None, Some("quarterly report summary")).unwrap();
+        fts.upsert("id-2", None, Some("quarterly meeting agenda")).unwrap();
+        fts.upsert("id-3", None, Some("annual report")).unwrap();
+
+        // "quar rep" → "quar* rep*" — implicit AND, only id-1 has both prefixes.
+        let hits = fts.search("quar rep", 10).unwrap();
+        assert_eq!(hits, vec!["id-1".to_string()]);
+    }
+
+    #[test]
+    fn search_sanitizes_fts5_special_chars() {
+        let fts = ClipboardFts::new_in_memory().unwrap();
+        fts.upsert("id-1", None, Some("look here please")).unwrap();
+        // Without sanitization, these characters would either throw an
+        // FTS5 syntax error or shift the query's semantics.
+        for raw in ["(look)", "look*", "\"look\"", "look:here", "look'"] {
+            let hits = fts.search(raw, 10).unwrap();
+            assert!(
+                hits.contains(&"id-1".to_string()),
+                "query {raw:?} must still match the underlying token",
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod rebuild_tests {
+    use super::*;
+    use crate::storage::clipboard::{add_item, init_table, ClipboardItem};
+
+    fn test_key() -> [u8; 32] {
+        let mut k = [0u8; 32];
+        for (i, b) in k.iter_mut().enumerate() {
+            *b = (i * 11) as u8;
+        }
+        k
+    }
+
+    fn make_item(id: &str, content: &str) -> ClipboardItem {
+        ClipboardItem {
+            id: id.to_string(),
+            item_type: "text".into(),
+            content: Some(content.to_string()),
+            preview: Some(format!("preview {id}")),
+            created_at: 1000.0,
+            favorite: false,
+            metadata: None,
+            source_app: None,
+            redacted_kinds: None,
+        }
+    }
+
+    #[test]
+    fn rebuild_from_disk_indexes_every_row() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_table(&conn).unwrap();
+        crate::storage::cloud_sync_state::init_table(&conn).unwrap();
+        let key = test_key();
+        for i in 0..20u32 {
+            add_item(&conn, &make_item(&i.to_string(), &format!("apple {i}")), &key).unwrap();
+        }
+        let fts = ClipboardFts::new_in_memory().unwrap();
+        rebuild_from_disk(&conn, &fts, &key).unwrap();
+
+        let hits = fts.search("apple", 100).unwrap();
+        assert_eq!(hits.len(), 20);
+    }
+
+    #[test]
+    fn rebuild_backfills_null_content_hash_rows() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_table(&conn).unwrap();
+        crate::storage::cloud_sync_state::init_table(&conn).unwrap();
+        let key = test_key();
+        // Insert a row with NULL content_hash directly (simulating a legacy row).
+        let encrypted = crate::crypto::cipher::encrypt("legacy body", &key).unwrap();
+        conn.execute(
+            "INSERT INTO clipboard_items
+                (id, item_type, content, preview, created_at, favorite, content_hash)
+             VALUES ('legacy', 'text', ?1, NULL, 1.0, 0, NULL)",
+            rusqlite::params![encrypted],
+        )
+        .unwrap();
+
+        let fts = ClipboardFts::new_in_memory().unwrap();
+        rebuild_from_disk(&conn, &fts, &key).unwrap();
+
+        let hash: Option<Vec<u8>> = conn
+            .query_row(
+                "SELECT content_hash FROM clipboard_items WHERE id = 'legacy'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(hash.is_some(), "rebuild backfilled content_hash for legacy row");
+        assert_eq!(hash.unwrap().len(), 32);
+    }
+
+    #[test]
+    fn is_ready_flips_on_mark_ready() {
+        // Reset to a known state first (test isolation note: FTS_READY is
+        // a process-wide atomic; tests that run in parallel could
+        // interfere. Use #[serial] if the launcher has serial-test —
+        // otherwise accept that this test only checks the API surface
+        // and not the strict default).
+        FTS_READY.store(false, std::sync::atomic::Ordering::Release);
+        assert!(!is_ready());
+        mark_ready();
+        assert!(is_ready());
+        // Restore for other tests.
+        FTS_READY.store(false, std::sync::atomic::Ordering::Release);
+    }
+}

--- a/src-tauri/src/storage/commands.rs
+++ b/src-tauri/src/storage/commands.rs
@@ -1,37 +1,93 @@
 use super::DataStore;
 use crate::crypto::keystore::KeystoreState;
 use crate::error::AppError;
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, Emitter, Manager, State};
+use std::sync::Arc;
+use super::clipboard_fts::ClipboardFts;
 
 // ── Clipboard ────────────────────────────────────────────────────────────────
 
 #[tauri::command]
-pub fn clipboard_add_item(
-    item: super::clipboard::ClipboardItem,
-    store: State<'_, DataStore>,
-    keystore: State<'_, KeystoreState>,
-) -> Result<(), AppError> {
-    let conn = store.conn()?;
-    super::clipboard::add_item(&conn, &item, keystore.master_key())
-}
-
-#[tauri::command]
-pub fn clipboard_get_all(
-    store: State<'_, DataStore>,
-    keystore: State<'_, KeystoreState>,
-) -> Result<Vec<super::clipboard::ClipboardItem>, AppError> {
-    let conn = store.conn()?;
-    super::clipboard::get_all(&conn, keystore.master_key())
-}
-
-#[tauri::command]
-pub fn clipboard_get_recent(
+pub fn clipboard_list_initial(
     limit: u32,
     store: State<'_, DataStore>,
     keystore: State<'_, KeystoreState>,
-) -> Result<Vec<super::clipboard::ClipboardItem>, AppError> {
+) -> Result<super::clipboard::InitialPage, AppError> {
     let conn = store.conn()?;
-    super::clipboard::get_recent(&conn, limit as usize, keystore.master_key())
+    super::clipboard::list_initial(&conn, limit as usize, keystore.master_key())
+}
+
+#[tauri::command]
+pub fn clipboard_list_older(
+    cursor: super::clipboard::Cursor,
+    limit: u32,
+    store: State<'_, DataStore>,
+    keystore: State<'_, KeystoreState>,
+) -> Result<super::clipboard::OlderPage, AppError> {
+    let conn = store.conn()?;
+    super::clipboard::list_older(&conn, &cursor, limit as usize, keystore.master_key())
+}
+
+#[tauri::command]
+pub fn clipboard_search(
+    query: String,
+    limit: u32,
+    store: State<'_, DataStore>,
+    keystore: State<'_, KeystoreState>,
+    fts: State<'_, Arc<ClipboardFts>>,
+) -> Result<super::clipboard::SearchResult, AppError> {
+    let conn = store.conn()?;
+    super::clipboard::search(&conn, fts.inner(), &query, limit as usize, keystore.master_key())
+}
+
+#[tauri::command]
+pub fn clipboard_get_item(
+    id: String,
+    store: State<'_, DataStore>,
+    keystore: State<'_, KeystoreState>,
+) -> Result<Option<super::clipboard::ClipboardItem>, AppError> {
+    let conn = store.conn()?;
+    super::clipboard::get_item(&conn, &id, keystore.master_key())
+}
+
+#[tauri::command]
+pub fn clipboard_export_for_sync(
+    cursor: Option<super::clipboard::Cursor>,
+    limit: u32,
+    store: State<'_, DataStore>,
+    keystore: State<'_, KeystoreState>,
+) -> Result<super::clipboard::ExportPage, AppError> {
+    let conn = store.conn()?;
+    super::clipboard::export_for_sync(&conn, cursor.as_ref(), limit as usize, keystore.master_key())
+}
+
+#[tauri::command]
+pub fn clipboard_count(store: State<'_, DataStore>) -> Result<super::clipboard::ClipboardCount, AppError> {
+    let conn = store.conn()?;
+    super::clipboard::count(&conn)
+}
+
+#[tauri::command]
+pub fn clipboard_record_capture(
+    app: tauri::AppHandle,
+    item: super::clipboard::ClipboardItem,
+    store: State<'_, DataStore>,
+    keystore: State<'_, KeystoreState>,
+    fts: State<'_, Arc<ClipboardFts>>,
+) -> Result<super::clipboard::CaptureResult, AppError> {
+    let cache_dir = app
+        .path()
+        .app_data_dir()
+        .map(|p| p.join("icon_cache"))
+        .unwrap_or_else(|_| std::path::PathBuf::from("/tmp/asyar_icon_cache"));
+    let conn = store.conn()?;
+    super::clipboard::record_capture_with_fts(
+        &conn,
+        &item,
+        Some(&cache_dir),
+        keystore.master_key(),
+        fts.inner(),
+    )
 }
 
 #[tauri::command]
@@ -47,56 +103,21 @@ pub fn clipboard_toggle_favorite(
 pub fn clipboard_delete_item(
     id: String,
     store: State<'_, DataStore>,
-) -> Result<(), AppError> {
+    keystore: State<'_, KeystoreState>,
+    fts: State<'_, Arc<ClipboardFts>>,
+) -> Result<super::clipboard::DeleteResult, AppError> {
     let conn = store.conn()?;
-    super::clipboard::delete_item(&conn, &id)
+    super::clipboard::delete_item_with_fts(&conn, &id, keystore.master_key(), fts.inner())
 }
 
 #[tauri::command]
 pub fn clipboard_clear_non_favorites(
     store: State<'_, DataStore>,
-) -> Result<(), AppError> {
-    let conn = store.conn()?;
-    super::clipboard::clear_non_favorites(&conn)
-}
-
-#[tauri::command]
-pub fn clipboard_find_duplicate(
-    item_type: String,
-    content: Option<String>,
-    id: String,
-    store: State<'_, DataStore>,
     keystore: State<'_, KeystoreState>,
-) -> Result<Option<super::clipboard::ClipboardItem>, AppError> {
+    fts: State<'_, Arc<ClipboardFts>>,
+) -> Result<super::clipboard::ClearResult, AppError> {
     let conn = store.conn()?;
-    super::clipboard::find_duplicate(&conn, &item_type, content.as_deref(), &id, keystore.master_key())
-}
-
-#[tauri::command]
-pub fn clipboard_cleanup(
-    max_age_ms: f64,
-    max_items: usize,
-    store: State<'_, DataStore>,
-) -> Result<(), AppError> {
-    let conn = store.conn()?;
-    super::clipboard::cleanup(&conn, max_age_ms, max_items)
-}
-
-#[tauri::command]
-pub fn clipboard_record_capture(
-    app: tauri::AppHandle,
-    item: super::clipboard::ClipboardItem,
-    store: State<'_, DataStore>,
-    keystore: State<'_, KeystoreState>,
-) -> Result<Vec<super::clipboard::ClipboardItem>, AppError> {
-    use tauri::Manager;
-    let cache_dir = app
-        .path()
-        .app_data_dir()
-        .map(|p| p.join("icon_cache"))
-        .unwrap_or_else(|_| std::path::PathBuf::from("/tmp/asyar_icon_cache"));
-    let conn = store.conn()?;
-    super::clipboard::record_capture(&conn, &item, Some(&cache_dir), keystore.master_key())
+    super::clipboard::clear_non_favorites_with_fts(&conn, keystore.master_key(), fts.inner())
 }
 
 // ── Snippets ─────────────────────────────────────────────────────────────────

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -1,5 +1,6 @@
 pub mod agents;
 pub mod clipboard;
+pub mod clipboard_fts;
 pub mod mcp_audit;
 pub mod mcp_permissions;
 pub mod mcp_servers;

--- a/src/built-in-features/clipboard-history/DefaultView.svelte
+++ b/src/built-in-features/clipboard-history/DefaultView.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { onMount, onDestroy, tick } from "svelte";
-  import { clipboardViewState } from "./state.svelte";
+  import { clipboardViewState, onViewActivated, onSearchChanged, onScrolledToEnd, fetchFullItemForId, visibleItems } from "./state.svelte";
+  import { clipboardHistoryStore } from "../../services/clipboard/stores/clipboardHistoryStore.svelte";
+  import { listen } from "@tauri-apps/api/event";
   import { fetchRawHtml } from "./urlFetcher";
   import { stripRtf, type ClipboardHistoryItem } from "asyar-sdk/contracts";
+  import type { StoredClipboardItem } from "../../lib/ipc/commands";
   import { readFile } from "@tauri-apps/plugin-fs";
   import { revealItemInDir } from "@tauri-apps/plugin-opener";
   import { renderMarkdown, handleMarkdownCopyClick } from "../../utils/markdown";
@@ -53,14 +56,61 @@
   let currentFetchedUrl = $state('');
   
   let detailEl = $state<HTMLElement | null>(null);
+  let listWrapperEl = $state<HTMLElement | null>(null);
 
   let showRenderedHtml = $derived(clipboardViewState.showRenderedHtml);
 
-  // Derive filtered items from state (type filter + search applied there)
-  let filteredItems = $derived(clipboardViewState.filteredItems);
-  let selectedItem = $derived(clipboardViewState.selectedItem);
-  let selectedIndex = $derived(clipboardViewState.selectedIndex);
-  let favoritesCount = $derived(filteredItems.filter(i => i.favorite).length);
+  // Mirror the store's currently-visible window (searchResults ?? favorites
+  // + recent) into clipboardViewState.items so the existing filteredItems
+  // derivation and the keyboard handler in index.ts always see the same
+  // data as the rendered list.
+  $effect(() => {
+    const store = clipboardHistoryStore;
+    const next = store.searchResults
+      ?? [...store.favorites, ...store.recent];
+    clipboardViewState.items = next as unknown as ClipboardHistoryItem[];
+  });
+
+  // SINGLE source of truth: clipboardViewState.filteredItems (the local
+  // store-mirrored items plus type filter). The keyboard handler in
+  // index.ts also reads from this, so the rendered list and arrow-key
+  // navigation now operate on the exact same array.
+  let items = $derived(clipboardViewState.filteredItems);
+  let selectedId = $derived(clipboardViewState.selectedItemId);
+  let selectedIndex = $derived(items.findIndex(i => i.id === selectedId));
+  let favoritesCount = $derived(items.filter(i => i.favorite).length);
+
+  // When the visible list changes (search swap, type-filter change, store
+  // refresh), the previously selected id may no longer be in `items` — the
+  // highlight + detail pane go out of sync. Reset to the first visible row
+  // so selection always tracks the visible list.
+  $effect(() => {
+    const list = items;
+    if (list.length === 0) {
+      if (selectedId !== null) clipboardViewState.selectedItemId = null;
+      return;
+    }
+    if (!list.some(i => i.id === selectedId)) {
+      clipboardViewState.selectedItemId = list[0].id;
+    }
+  });
+
+  // Full item (content decrypted) fetched lazily when selection changes
+  let selectedFullItem = $state<StoredClipboardItem | null>(null);
+  $effect(() => {
+    const id = clipboardViewState.selectedItemId;
+    if (!id) { selectedFullItem = null; return; }
+    void fetchFullItemForId(id).then(full => {
+      if (clipboardViewState.selectedItemId === id) {
+        selectedFullItem = full;
+      }
+    }).catch(err => {
+      diagnosticsService.report({
+        source: 'frontend', kind: 'clipboard/get-item-failed', severity: 'error',
+        retryable: false, developerDetail: String(err),
+      });
+    });
+  });
 
   // Subscribe to the searchbar-accessory service so the user's dropdown
   // selection (declared via the manifest's `searchBarAccessory`) flows
@@ -78,12 +128,47 @@
     return off;
   });
 
+  // Attach scroll listener (capture, since scroll doesn't bubble) to detect
+  // near-bottom scrolling and trigger pagination.
+  $effect(() => {
+    const wrapper = listWrapperEl;
+    if (!wrapper) return;
+    wrapper.addEventListener('scroll', handleListScroll, { capture: true });
+    return () => wrapper.removeEventListener('scroll', handleListScroll, { capture: true });
+  });
+
+  // Load the initial window on first activation if the store is empty.
+  $effect(() => { void onViewActivated(); });
+
+  // Mirror the search query into the store's search so FTS is used.
+  $effect(() => { void onSearchChanged(clipboardViewState.searchQuery); });
+
+  // Re-run the current search when the FTS index becomes ready.
+  $effect(() => {
+    let unlisten: (() => void) | null = null;
+    (async () => {
+      try {
+        unlisten = await listen('clipboard:fts-ready', () => {
+          clipboardHistoryStore.indexState = 'ready';
+          const q = clipboardViewState.searchQuery.trim();
+          if (q) void onSearchChanged(q);
+        });
+      } catch (err) {
+        diagnosticsService.report({
+          source: 'frontend', kind: 'clipboard/fts-listener-failed', severity: 'error',
+          retryable: false, developerDetail: String(err),
+        });
+      }
+    })();
+    return () => { unlisten?.(); };
+  });
+
   // Mermaid Rendering Effect
   $effect(() => {
     // Re-run when selection or view mode changes
-    const _item = selectedItem;
+    const _item = selectedFullItem;
     const _rendered = showRenderedHtml;
-    
+
     if (detailEl) {
       tick().then(() => renderMermaidDiagrams(detailEl!));
     }
@@ -91,7 +176,7 @@
 
   // Load image via readFile when an image item is selected
   $effect(() => {
-    const item = selectedItem;
+    const item = selectedFullItem;
     if (item?.type === 'image' && item.content && item.content !== currentImagePath) {
       loadImage(item.content);
     } else if (!item || item.type !== 'image') {
@@ -107,7 +192,7 @@
 
   // Fetch URL content when a URL item is selected
   $effect(() => {
-    const item = selectedItem;
+    const item = selectedFullItem;
     if (!item || !isUrl(item.content) || !showRenderedHtml) {
       if (currentFetchedUrl) {
         if (urlBlobUrl) { URL.revokeObjectURL(urlBlobUrl); urlBlobUrl = ''; }
@@ -160,29 +245,35 @@
     }
   }
 
-  function selectItem(index: number) {
-    clipboardViewState.setSelectedItem(index);
+  function selectItem(id: string) {
+    clipboardViewState.selectedItemId = id;
   }
 
-  function getItemTitle(item: ClipboardHistoryItem) {
-    if (!item || !item.content) return "Empty";
-    if (item.type === "image") return "Image";
-    if (item.type === "files") {
-      try {
-        const paths: string[] = JSON.parse(item.content);
-        const names = paths.map(p => p.split('/').pop() || p.split('\\').pop() || p);
-        return names.join(', ');
-      } catch {
-        return "Files";
+  function handleListScroll(e: Event) {
+    const el = e.currentTarget as HTMLElement;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 200) {
+      void onScrolledToEnd();
+    }
+  }
+
+  async function pasteItemById(id: string) {
+    try {
+      const full = await fetchFullItemForId(id);
+      if (full) {
+        await clipboardViewState.handleItemAction(full as unknown as ClipboardHistoryItem, 'paste');
       }
+    } catch (err) {
+      diagnosticsService.report({
+        source: 'frontend', kind: 'clipboard/paste-failed', severity: 'error',
+        retryable: false, developerDetail: String(err),
+      });
     }
-    if (item.type === "html") {
-      const text = item.content.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
-      return text.substring(0, 200) || "HTML";
-    }
-    if (item.type === "rtf") return stripRtf(item.content).substring(0, 200) || "RTF";
-    // Only process first 200 chars — CSS truncates the rest anyway
-    return item.content.substring(0, 200).replace(/\n/g, " ").trim();
+  }
+
+  function getItemTitle(item: { type: string; preview?: string }) {
+    const preview = item.preview ?? '';
+    if (!preview) return item.type === "image" ? "Image" : item.type === "files" ? "Files" : "Empty";
+    return preview.substring(0, 200).replace(/\n/g, " ").trim() || "Empty";
   }
 
   function sanitizeHtml(html: string): string {
@@ -253,7 +344,7 @@
     }
   }
 
-  function getWordCount(item: ClipboardHistoryItem): number {
+  function getWordCount(item: { type: string; content?: string }): number {
     if (!item.content) return 0;
     let text = item.content;
     if (item.type === 'html') {
@@ -266,19 +357,20 @@
     return text.trim().split(/\s+/).filter(w => w.length > 0).length;
   }
 
-  function getMetadataText(item: ClipboardHistoryItem): string {
-    if (item.type === 'image' && item.metadata) {
+  function getMetadataText(item: { type: string; content?: string; metadata?: Record<string, unknown> }): string {
+    const meta = item.metadata;
+    if (item.type === 'image' && meta) {
       const parts: string[] = [];
-      if (item.metadata.width && item.metadata.height) {
-        parts.push(`${item.metadata.width}\u00d7${item.metadata.height}`);
+      if (meta.width && meta.height) {
+        parts.push(`${meta.width}\u00d7${meta.height}`);
       }
-      if (item.metadata.sizeBytes) {
-        parts.push(formatBytes(item.metadata.sizeBytes));
+      if (meta.sizeBytes) {
+        parts.push(formatBytes(meta.sizeBytes as number));
       }
       return parts.join(' \u00b7 ') || '';
     }
-    if (item.type === 'files' && item.metadata?.fileCount) {
-      return `${item.metadata.fileCount} file${item.metadata.fileCount !== 1 ? 's' : ''}`;
+    if (item.type === 'files' && meta?.fileCount) {
+      return `${meta.fileCount} file${(meta.fileCount as number) !== 1 ? 's' : ''}`;
     }
     if (item.content && ['text', 'html', 'rtf'].includes(item.type)) {
       const words = getWordCount(item);
@@ -299,8 +391,12 @@
 </script>
 
 <div class="view-container">
+  {#if clipboardHistoryStore.indexState === 'indexing' && clipboardViewState.searchQuery.trim()}
+    <div class="indexing-hint">Indexing… search results will appear when ready</div>
+  {/if}
+  <div class="split-list-wrapper" bind:this={listWrapperEl}>
   <SplitListDetail
-    items={filteredItems}
+    items={items}
     {selectedIndex}
     leftWidth={260}
     minLeftWidth={200}
@@ -312,8 +408,8 @@
       {#if index === 0 && favoritesCount > 0}
         <div class="list-section">Pinned</div>
       {/if}
-      {@const isFirstNonFavorite = index === favoritesCount && index < filteredItems.length}
-      {@const prevItem = index > favoritesCount ? filteredItems[index - 1] : null}
+      {@const isFirstNonFavorite = index === favoritesCount && index < items.length}
+      {@const prevItem = index > favoritesCount ? items[index - 1] : null}
       {@const sectionLabel = !item.favorite ? timeSection(item.createdAt) : null}
       {@const showDayHeader = !item.favorite && (isFirstNonFavorite || (prevItem && timeSection(prevItem.createdAt) !== sectionLabel))}
       {#if showDayHeader && sectionLabel}
@@ -322,8 +418,8 @@
       <LauncherListRow
         data-index={index}
         selected={selectedIndex === index}
-        onclick={() => selectItem(index)}
-        ondblclick={() => clipboardViewState.handleItemAction(item, 'paste')}
+        onclick={() => selectItem(item.id)}
+        ondblclick={() => pasteItemById(item.id)}
         title={getItemTitle(item)}
         subtitle={clipboardViewState.searchQuery && 'score' in item
           ? `Match: ${Math.round((1 - (typeof item.score === 'number' ? item.score : 0)) * 100)}%`
@@ -348,8 +444,8 @@
     {/snippet}
 
     {#snippet detail()}
-      {#if selectedItem}
-        {#if showRenderedHtml && isUrl(selectedItem.content) && urlBlobUrl}
+      {#if selectedId}
+        {#if showRenderedHtml && isUrl(selectedFullItem?.content) && urlBlobUrl}
           <iframe
             src={urlBlobUrl}
             class="url-iframe"
@@ -359,9 +455,11 @@
         {:else}
         <div class="clip-detail-content custom-scrollbar" bind:this={detailEl}>
 
-          {#if !selectedItem.content}
+          {#if !selectedFullItem}
+            <span style="color: var(--text-tertiary)">Loading…</span>
+          {:else if !selectedFullItem.content}
             <span style="color: var(--text-tertiary)">No preview available</span>
-          {:else if selectedItem.type === 'image'}
+          {:else if selectedFullItem.type === 'image'}
             <div class="image-container w-full h-full flex flex-col items-center justify-center p-4">
               {#if imageLoading}
                 <div class="text-caption opacity-50">Loading image...</div>
@@ -375,40 +473,40 @@
               {:else}
                 <div class="text-caption opacity-50">Failed to load image</div>
               {/if}
-              {#if selectedItem.metadata && (selectedItem.metadata.width || selectedItem.metadata.sizeBytes)}
+              {#if selectedFullItem.metadata && (selectedFullItem.metadata.width || selectedFullItem.metadata.sizeBytes)}
                 <div class="mt-3 text-caption opacity-70 flex items-center gap-3">
-                  {#if selectedItem.metadata.width && selectedItem.metadata.height}
-                    <span>{selectedItem.metadata.width} × {selectedItem.metadata.height}</span>
+                  {#if selectedFullItem.metadata.width && selectedFullItem.metadata.height}
+                    <span>{selectedFullItem.metadata.width} × {selectedFullItem.metadata.height}</span>
                   {/if}
-                  {#if selectedItem.metadata.sizeBytes}
-                    <span>{formatBytes(selectedItem.metadata.sizeBytes)}</span>
+                  {#if selectedFullItem.metadata.sizeBytes}
+                    <span>{formatBytes(selectedFullItem.metadata.sizeBytes as number)}</span>
                   {/if}
                 </div>
               {/if}
             </div>
-          {:else if selectedItem.type === 'html'}
+          {:else if selectedFullItem.type === 'html'}
             {#if showRenderedHtml}
               <div class="html-preview">
-                {@html sanitizeHtml(selectedItem.content)}
+                {@html sanitizeHtml(selectedFullItem.content)}
               </div>
             {:else}
-              <pre class="source-preview">{getSourcePreview(selectedItem.content)}</pre>
-              {#if isContentTruncated(selectedItem.content)}
-                <div class="truncation-notice">Showing first {MAX_PREVIEW_CHARS.toLocaleString()} of {selectedItem.content.length.toLocaleString()} characters</div>
+              <pre class="source-preview">{getSourcePreview(selectedFullItem.content)}</pre>
+              {#if isContentTruncated(selectedFullItem.content)}
+                <div class="truncation-notice">Showing first {MAX_PREVIEW_CHARS.toLocaleString()} of {selectedFullItem.content.length.toLocaleString()} characters</div>
               {/if}
             {/if}
-          {:else if selectedItem.type === 'rtf'}
+          {:else if selectedFullItem.type === 'rtf'}
             {#if showRenderedHtml}
-              <pre class="source-preview">{stripRtf(selectedItem.content)}</pre>
+              <pre class="source-preview">{stripRtf(selectedFullItem.content)}</pre>
             {:else}
-              <pre class="source-preview">{getSourcePreview(selectedItem.content)}</pre>
+              <pre class="source-preview">{getSourcePreview(selectedFullItem.content)}</pre>
             {/if}
-            {#if isContentTruncated(selectedItem.content)}
-              <div class="truncation-notice">Showing first {MAX_PREVIEW_CHARS.toLocaleString()} of {selectedItem.content.length.toLocaleString()} characters</div>
+            {#if isContentTruncated(selectedFullItem.content)}
+              <div class="truncation-notice">Showing first {MAX_PREVIEW_CHARS.toLocaleString()} of {selectedFullItem.content.length.toLocaleString()} characters</div>
             {/if}
-          {:else if selectedItem.type === 'files'}
+          {:else if selectedFullItem.type === 'files'}
             <div class="flex flex-col gap-1.5 p-4">
-              {#each getFiles(selectedItem.content) as filePath}
+              {#each getFiles(selectedFullItem.content) as filePath}
                 <div class="flex items-center gap-2 py-1.5 px-2 rounded" style="background: var(--bg-secondary);">
                   <svg class="w-4 h-4 flex-shrink-0 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
                   <span class="text-sm truncate flex-1" style="color: var(--text-primary); font-family: var(--font-mono);">{getFileName(filePath)}</span>
@@ -422,12 +520,12 @@
                 </div>
               {/each}
             </div>
-          {:else if showRenderedHtml && isUrl(selectedItem.content)}
+          {:else if showRenderedHtml && isUrl(selectedFullItem.content)}
             {#if urlLoading}
               <div class="url-loading">
                 <div class="url-loading-header">
-                  <div class="url-domain">{getUrlDomain(selectedItem.content)}</div>
-                  <div class="url-full">{selectedItem.content.trim()}</div>
+                  <div class="url-domain">{getUrlDomain(selectedFullItem.content)}</div>
+                  <div class="url-full">{selectedFullItem.content.trim()}</div>
                 </div>
                 <div class="url-progress-bar"><div class="url-progress-fill"></div></div>
                 <div class="url-skeleton">
@@ -444,8 +542,8 @@
                 <div class="url-icon">
                   <svg class="w-10 h-10 opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/></svg>
                 </div>
-                <div class="url-domain">{getUrlDomain(selectedItem.content)}</div>
-                <div class="url-full">{selectedItem.content.trim()}</div>
+                <div class="url-domain">{getUrlDomain(selectedFullItem.content)}</div>
+                <div class="url-full">{selectedFullItem.content.trim()}</div>
                 {#if urlFetchFailed}
                   <div class="url-fetch-notice">Preview unavailable</div>
                 {/if}
@@ -456,15 +554,15 @@
               <!-- svelte-ignore a11y_click_events_have_key_events -->
               <!-- svelte-ignore a11y_no_static_element_interactions -->
               <div class="md-content" onclick={handleMarkdownCopyClick}>
-                {@html renderMarkdown(selectedItem.content)}
+                {@html renderMarkdown(selectedFullItem.content)}
               </div>
-              {#if isContentTruncated(selectedItem.content)}
-                <div class="truncation-notice">Showing first {MAX_PREVIEW_CHARS.toLocaleString()} of {selectedItem.content.length.toLocaleString()} characters</div>
+              {#if isContentTruncated(selectedFullItem.content)}
+                <div class="truncation-notice">Showing first {MAX_PREVIEW_CHARS.toLocaleString()} of {selectedFullItem.content.length.toLocaleString()} characters</div>
               {/if}
             {:else}
-              <pre class="source-preview">{getSourcePreview(selectedItem.content)}</pre>
-              {#if isContentTruncated(selectedItem.content)}
-                <div class="truncation-notice">Showing first {MAX_PREVIEW_CHARS.toLocaleString()} of {selectedItem.content.length.toLocaleString()} characters</div>
+              <pre class="source-preview">{getSourcePreview(selectedFullItem.content)}</pre>
+              {#if isContentTruncated(selectedFullItem.content)}
+                <div class="truncation-notice">Showing first {MAX_PREVIEW_CHARS.toLocaleString()} of {selectedFullItem.content.length.toLocaleString()} characters</div>
               {/if}
             {/if}
           {/if}
@@ -474,35 +572,37 @@
         <ActionFooter>
           {#snippet left()}
             <div class="flex items-center space-x-3">
-              <Badge text={selectedItem.type} variant="default" mono />
-              <span class="flex items-center gap-1 text-caption">
-                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
-                {formatDetailDate(selectedItem.createdAt)}
-              </span>
-              {#if getMetadataText(selectedItem)}
-                <span class="text-caption opacity-70">
-                  {getMetadataText(selectedItem)}
+              {#if selectedFullItem}
+                <Badge text={selectedFullItem.type} variant="default" mono />
+                <span class="flex items-center gap-1 text-caption">
+                  <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                  {formatDetailDate(selectedFullItem.createdAt)}
                 </span>
-              {/if}
-              {#if selectedItem.sourceApp}
-                <span class="source-app-info">
-                  {#if selectedItem.sourceApp.iconUrl}
-                    <img
-                      src={selectedItem.sourceApp.iconUrl}
-                      class="source-app-icon"
-                      alt=""
-                      aria-hidden="true"
-                    />
-                  {:else}
-                    <svg class="source-app-icon-fallback" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
-                    </svg>
-                  {/if}
-                  <span class="source-app-name">{selectedItem.sourceApp.name}</span>
-                  {#if selectedItem.sourceApp.windowTitle}
-                    <span class="source-app-title">{selectedItem.sourceApp.windowTitle}</span>
-                  {/if}
-                </span>
+                {#if getMetadataText(selectedFullItem)}
+                  <span class="text-caption opacity-70">
+                    {getMetadataText(selectedFullItem)}
+                  </span>
+                {/if}
+                {#if selectedFullItem.sourceApp}
+                  <span class="source-app-info">
+                    {#if (selectedFullItem.sourceApp as any).iconUrl}
+                      <img
+                        src={(selectedFullItem.sourceApp as any).iconUrl}
+                        class="source-app-icon"
+                        alt=""
+                        aria-hidden="true"
+                      />
+                    {:else}
+                      <svg class="source-app-icon-fallback" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                      </svg>
+                    {/if}
+                    <span class="source-app-name">{(selectedFullItem.sourceApp as any).name}</span>
+                    {#if (selectedFullItem.sourceApp as any).windowTitle}
+                      <span class="source-app-title">{(selectedFullItem.sourceApp as any).windowTitle}</span>
+                    {/if}
+                  </span>
+                {/if}
               {/if}
             </div>
           {/snippet}
@@ -518,9 +618,32 @@
       {/if}
     {/snippet}
   </SplitListDetail>
+  </div>
 </div>
 
 <style>
+  .view-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+  }
+
+  .indexing-hint {
+    padding: 4px 12px;
+    font-size: var(--font-size-xs);
+    color: var(--text-tertiary);
+    background: var(--bg-secondary);
+    text-align: center;
+    flex-shrink: 0;
+  }
+
+  .split-list-wrapper {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+
   .clip-detail-content {
     flex: 1;
     overflow: auto;

--- a/src/built-in-features/clipboard-history/state.svelte.test.ts
+++ b/src/built-in-features/clipboard-history/state.svelte.test.ts
@@ -5,6 +5,25 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn()
 }))
 
+vi.mock('../../services/clipboard/stores/clipboardHistoryStore.svelte', () => ({
+  clipboardHistoryStore: {
+    favorites: [],
+    recent: [],
+    searchResults: null,
+    nextOlderCursor: undefined,
+    loadInitial: vi.fn().mockResolvedValue(undefined),
+    loadOlder: vi.fn().mockResolvedValue(undefined),
+    search: vi.fn().mockResolvedValue(undefined),
+    clearSearch: vi.fn(),
+    fetchFullItem: vi.fn().mockResolvedValue(null),
+    deleteHistoryItem: vi.fn().mockResolvedValue({ imageContentPath: undefined }),
+  }
+}))
+
+vi.mock('../../services/diagnostics/diagnosticsService.svelte', () => ({
+  diagnosticsService: { report: vi.fn() }
+}))
+
 vi.mock('../../services/log/logService', () => ({
   logService: {
     debug: vi.fn(),
@@ -257,11 +276,10 @@ describe('deleteItem', () => {
     state.initializeServices(context as any);
   });
 
-  it('calls clipboardService.deleteItem and refreshes history on success', async () => {
+  it('calls clipboardService.deleteItem and removes item from store on success', async () => {
     const result = await state.deleteItem('item-1');
     expect(result).toBe(true);
     expect(mockClipboardService.deleteItem).toHaveBeenCalledWith('item-1');
-    expect(mockClipboardService.getRecentItems).toHaveBeenCalled(); // refreshHistory was called
   });
 
   it('returns false when service is not initialized', async () => {
@@ -396,149 +414,44 @@ describe('getPlainText', () => {
   });
 });
 
-describe('filteredItems and search-aware navigation', () => {
+// The local SearchEngine path inside ClipboardViewStateClass is retired:
+// search is now Rust-FTS-backed in clipboardHistoryStore and the view
+// mirrors store.searchResults into clipboardViewState.items. The
+// retired tests asserted that `state.setSearch(query)` would narrow
+// `state.filteredItems` against `state.items`; that narrowing now
+// happens server-side and is tested in the store's own test file.
+// Type-filter behaviour is covered below.
+
+describe('type filter (applied on top of store-mirrored items)', () => {
   let state: ClipboardViewStateClass;
 
   beforeEach(() => {
     state = new ClipboardViewStateClass();
-    const items = [
-      { id: '1', content: 'apple pie recipe', type: 'text' as any, createdAt: 1, favorite: false },
-      { id: '2', content: 'banana smoothie', type: 'text' as any, createdAt: 2, favorite: false },
-      { id: '3', content: 'cherry tart', type: 'text' as any, createdAt: 3, favorite: false },
-    ];
-    state.setItems(items);
-  });
-
-  it('filteredItems returns all items when no search query', () => {
-    expect(state.filteredItems).toHaveLength(3);
-    expect(state.filteredItems.map(i => i.id)).toEqual(['1', '2', '3']);
-  });
-
-  it('filteredItems returns only matching items when search is active', () => {
-    state.setSearch('apple');
-    // Only item 1 matches "apple"
-    expect(state.filteredItems.length).toBeGreaterThan(0);
-    expect(state.filteredItems.every(i => i.content?.includes('apple'))).toBe(true);
-  });
-
-  it('selectedItem reflects filteredItems[selectedIndex] when search is active', () => {
-    state.setSearch('banana');
-    // The selected item must be the one visible in search results
-    expect(state.selectedItem?.id).toBe('2');
-    expect(state.selectedIndex).toBe(0);
-  });
-
-  it('setSelectedItem(0) selects the first filtered item, not the first original item', () => {
-    state.setSearch('cherry');
-    state.setSelectedItem(0);
-    // filteredItems[0] should be item 3 (cherry), not item 1 (apple)
-    expect(state.selectedItem?.id).toBe('3');
-  });
-
-  it('moveSelection navigates within filteredItems, not this.items, during search', () => {
-    state.setSearch('banana');
-    // Only item 2 matches; wrap-around should stay on item 2
-    state.moveSelection('down');
-    expect(state.selectedItem?.id).toBe('2');
-    state.moveSelection('up');
-    expect(state.selectedItem?.id).toBe('2');
-  });
-
-  it('selectedItem falls back to first filtered item when selected item is filtered out', () => {
-    // Select item 1 (apple)
-    state.setSelectedItem(0);
-    expect(state.selectedItem?.id).toBe('1');
-
-    // Now search for something that excludes item 1
-    state.setSearch('cherry');
-
-    // Selected item should update to the first cherry result, not stay on item 1
-    expect(state.selectedItem?.id).toBe('3');
-  });
-
-  it('returns html items whose visible text matches the search query', () => {
     state.setItems([
-      { id: '10', content: '<html><head><meta charset="UTF-8"></head><body><p>quarterly report summary</p></body></html>', preview: 'quarterly report summary', type: 'html' as any, createdAt: Date.now(), favorite: false },
-      { id: '11', content: 'unrelated text item', preview: 'unrelated text item', type: 'text' as any, createdAt: Date.now(), favorite: false },
+      { id: '1', content: 'text item',    preview: 'text item',    type: 'text'   as any, createdAt: 1, favorite: false },
+      { id: '2', content: '<p>html</p>',  preview: 'html item',    type: 'html'   as any, createdAt: 2, favorite: false },
+      { id: '3', content: '/p.png',       preview: '/p.png',       type: 'image'  as any, createdAt: 3, favorite: false },
+      { id: '4', content: '["/a.txt"]',   preview: '1 file: a.txt',type: 'files'  as any, createdAt: 4, favorite: false },
     ]);
-    state.setSearch('quarterly');
-    expect(state.filteredItems.some(i => i.id === '10')).toBe(true);
   });
 
-  it('returns file items whose filename matches the search query', () => {
-    state.setItems([
-      { id: '12', content: '["/home/user/documents/budget.xlsx"]', preview: '1 files: budget.xlsx', type: 'files' as any, createdAt: Date.now(), favorite: false },
-      { id: '13', content: 'unrelated text item', preview: 'unrelated text item', type: 'text' as any, createdAt: Date.now(), favorite: false },
-    ]);
-    state.setSearch('budget');
-    expect(state.filteredItems.some(i => i.id === '12')).toBe(true);
-  });
-});
-
-describe('Smart search with SearchEngine', () => {
-  let state: ClipboardViewStateClass;
-
-  beforeEach(() => {
-    state = new ClipboardViewStateClass();
+  it('filter "all" returns everything', () => {
+    state.setTypeFilter('all');
+    expect(state.filteredItems.map(i => i.id).sort()).toEqual(['1', '2', '3', '4']);
   });
 
-  it('matches subsequences: "qrtly" finds "quarterly"', () => {
-    state.setItems([
-      { id: '1', content: 'quarterly report summary', preview: 'quarterly report summary', type: 'text' as any, createdAt: 1, favorite: false },
-      { id: '2', content: 'unrelated content', preview: 'unrelated content', type: 'text' as any, createdAt: 2, favorite: false },
-    ]);
-    state.setSearch('qrtly');
-    expect(state.filteredItems.some(i => i.id === '1')).toBe(true);
-    expect(state.filteredItems.some(i => i.id === '2')).toBe(false);
+  it('filter "text" returns text + html + rtf rows', () => {
+    state.setTypeFilter('text');
+    expect(state.filteredItems.map(i => i.id).sort()).toEqual(['1', '2']);
   });
 
-  it('tolerates single-character typos: "recort" finds "record"', () => {
-    state.setItems([
-      { id: '1', content: 'record of transactions', preview: 'record of transactions', type: 'text' as any, createdAt: 1, favorite: false },
-      { id: '2', content: 'nothing related', preview: 'nothing related', type: 'text' as any, createdAt: 2, favorite: false },
-    ]);
-    state.setSearch('recort');
-    expect(state.filteredItems.some(i => i.id === '1')).toBe(true);
-  });
-
-  it('multi-term fuzzy: "qrtly rep" finds "quarterly report summary"', () => {
-    state.setItems([
-      { id: '1', content: 'quarterly report summary for Q3', preview: 'quarterly report summary for Q3', type: 'text' as any, createdAt: 1, favorite: false },
-      { id: '2', content: 'unrelated text', preview: 'unrelated text', type: 'text' as any, createdAt: 2, favorite: false },
-    ]);
-    state.setSearch('qrtly rep');
-    expect(state.filteredItems.some(i => i.id === '1')).toBe(true);
-    expect(state.filteredItems.some(i => i.id === '2')).toBe(false);
-  });
-
-  it('searches preprocessed plain text, not raw HTML', () => {
-    state.setItems([
-      { id: '1', content: '<html><body><p>quarterly report</p></body></html>', preview: 'quarterly report', type: 'html' as any, createdAt: 1, favorite: false },
-    ]);
-    state.setSearch('quarterly');
-    expect(state.filteredItems).toHaveLength(1);
-  });
-
-  it('ranks exact matches above fuzzy matches', () => {
-    state.setItems([
-      { id: 'fuzzy', content: 'approximate appple match', preview: 'approximate appple match', type: 'text' as any, createdAt: 1, favorite: false },
-      { id: 'exact', content: 'apple pie recipe', preview: 'apple pie recipe', type: 'text' as any, createdAt: 2, favorite: false },
-    ]);
-    state.setSearch('apple');
-    expect(state.filteredItems[0].id).toBe('exact');
-  });
-
-  it('applies type filter on top of search results', () => {
-    state.setItems([
-      { id: '1', content: 'apple text', type: 'text' as any, createdAt: 1, favorite: false },
-      { id: '2', content: 'apple html', preview: 'apple html', type: 'html' as any, createdAt: 2, favorite: false },
-      { id: '3', content: '/path/to/apple.png', type: 'image' as any, createdAt: 3, favorite: false },
-    ]);
+  it('filter "images" returns only image rows', () => {
     state.setTypeFilter('images');
-    state.setSearch('apple');
-    const ids = state.filteredItems.map(i => i.id);
-    expect(ids).not.toContain('1');
-    expect(ids).not.toContain('2');
-    expect(ids).toContain('3');
+    expect(state.filteredItems.map(i => i.id)).toEqual(['3']);
+  });
+
+  it('filter "files" returns only file rows', () => {
+    state.setTypeFilter('files');
+    expect(state.filteredItems.map(i => i.id)).toEqual(['4']);
   });
 });

--- a/src/built-in-features/clipboard-history/state.svelte.ts
+++ b/src/built-in-features/clipboard-history/state.svelte.ts
@@ -10,6 +10,8 @@ import {
   stripRtf,
 } from "asyar-sdk/contracts";
 import { shiftIndex } from "../../lib/listSelection.svelte";
+import { clipboardHistoryStore } from "../../services/clipboard/stores/clipboardHistoryStore.svelte";
+import { diagnosticsService } from "../../services/diagnostics/diagnosticsService.svelte";
 
 
 export class ClipboardViewStateClass {
@@ -18,19 +20,21 @@ export class ClipboardViewStateClass {
   items = $state<ClipboardHistoryItem[]>([]);
   selectedItemId = $state<string | null>(null);
 
+  // Search is now Rust-FTS-backed in the store; `this.items` is mirrored
+  // from the store (favorites + recent when not searching, searchResults
+  // when FTS has answered). We only apply the type filter on top — no
+  // local SearchEngine pass. The old local search filtered `this.items`
+  // by query *the instant the user typed*, before FTS had returned, so
+  // for queries whose matches lived outside the loaded window the view
+  // went empty for ~half a second until FTS came back. Skipping the
+  // local pass keeps the previous content visible during the wait.
   filteredItems = $derived.by(() => {
-    const query = this.searchQuery?.trim() ?? '';
-    
-    // Build search engine items
-    this.searchEngine.setItems(this.items);
-    const searched = query ? this.searchEngine.search(query) : this.items;
-
-    // Apply type filter on top of search results
-    if (this.typeFilter === 'all') return searched;
-    if (this.typeFilter === 'text') return searched.filter(i => i.type === 'text' || i.type === 'html' || i.type === 'rtf');
-    if (this.typeFilter === 'images') return searched.filter(i => i.type === 'image');
-    if (this.typeFilter === 'files') return searched.filter(i => i.type === 'files');
-    return searched;
+    const base = this.items;
+    if (this.typeFilter === 'all') return base;
+    if (this.typeFilter === 'text') return base.filter(i => i.type === 'text' || i.type === 'html' || i.type === 'rtf');
+    if (this.typeFilter === 'images') return base.filter(i => i.type === 'image');
+    if (this.typeFilter === 'files') return base.filter(i => i.type === 'files');
+    return base;
   });
 
   selectedIndex = $derived.by(() => {
@@ -204,7 +208,11 @@ export class ClipboardViewStateClass {
     try {
       const result = await this.clipboardService.deleteItem(itemId);
       if (result) {
-        await this.refreshHistory();
+        await clipboardHistoryStore.deleteHistoryItem(itemId);
+        this.items = this.items.filter(i => i.id !== itemId);
+        if (this.selectedItemId === itemId) {
+          this.selectedItemId = this.items.length > 0 ? this.items[0].id : null;
+        }
       }
       return result;
     } catch (error) {
@@ -226,14 +234,36 @@ export class ClipboardViewStateClass {
     const item = this.selectedItem;
     if (!item || !this.clipboardService) return;
 
-    const plainText = this.getPlainText(item);
-
-    const textItem = {
-      ...($state.snapshot(item) as ClipboardHistoryItem),
-      type: ClipboardItemType.Text as any,
-      content: plainText,
-    };
-    await this.clipboardService.pasteItem(textItem);
+    try {
+      if (item.content) {
+        // Path A: content present — keep $state.snapshot inline so the
+        // compiler emits the proxy-stripping clone.
+        const plainText = this.getPlainText(item);
+        await this.clipboardService.pasteItem({
+          ...($state.snapshot(item) as ClipboardHistoryItem),
+          type: ClipboardItemType.Text as any,
+          content: plainText,
+        });
+      } else {
+        // Path B: list-row payload — fetch the full row first.
+        const full = await clipboardHistoryStore.fetchFullItem(item.id);
+        if (full) {
+          const source = full as unknown as ClipboardHistoryItem;
+          const plainText = this.getPlainText(source);
+          await this.clipboardService.pasteItem({
+            ...source,
+            type: ClipboardItemType.Text as any,
+            content: plainText,
+          });
+        }
+      }
+    } catch (error) {
+      this.logService?.error(`Failed to paste as plain text: ${error}`);
+      diagnosticsService.report({
+        source: 'frontend', kind: 'clipboard/paste-failed', severity: 'error',
+        retryable: false, developerDetail: String(error),
+      });
+    }
   }
 
   async handleItemAction(
@@ -245,9 +275,23 @@ export class ClipboardViewStateClass {
     try {
       switch (action) {
         case "paste":
-          await this.clipboardService.pasteItem(
-            $state.snapshot(item) as ClipboardHistoryItem
-          );
+          // Path A: item already carries content — paste inline. The
+          // $state.snapshot(item) call MUST stay inline as a direct argument
+          // to pasteItem so the Svelte compiler emits the proxy-stripping
+          // clone (assigning the snapshot to a `let`/`const` first loses the
+          // transform in this build).
+          if (item.content) {
+            await this.clipboardService.pasteItem(
+              $state.snapshot(item) as ClipboardHistoryItem
+            );
+          } else {
+            // Path B: list-row payload — fetch the full row first to decrypt
+            // content, then paste.
+            const full = await clipboardHistoryStore.fetchFullItem(item.id);
+            if (full) {
+              await this.clipboardService.pasteItem(full as unknown as ClipboardHistoryItem);
+            }
+          }
           break;
 
         case "select":
@@ -256,6 +300,10 @@ export class ClipboardViewStateClass {
       }
     } catch (error) {
       this.logService?.error(`Failed to handle item action: ${error}`);
+      diagnosticsService.report({
+        source: 'frontend', kind: 'clipboard/paste-failed', severity: 'error',
+        retryable: false, developerDetail: String(error),
+      });
     }
   }
 
@@ -274,13 +322,7 @@ export class ClipboardViewStateClass {
   async refreshHistory() {
     this.isLoading = true;
     try {
-      if (this.clipboardService) {
-        const items = await this.clipboardService.getRecentItems(100);
-        const sorted = this.sortItemsByFavorite(items);
-        this.items = sorted;
-      } else {
-        this.logService?.warn("Clipboard service not available in refreshHistory");
-      }
+      await clipboardHistoryStore.loadInitial(100);
     } catch (error) {
       this.logService?.error(`Failed to refresh clipboard history: ${error}`);
       this.loadError = true;
@@ -292,3 +334,71 @@ export class ClipboardViewStateClass {
 }
 
 export const clipboardViewState = new ClipboardViewStateClass();
+
+/** Call when the view is opened or focused. Loads the initial window if empty. */
+export async function onViewActivated(): Promise<void> {
+  try {
+    if (clipboardHistoryStore.favorites.length === 0 && clipboardHistoryStore.recent.length === 0) {
+      await clipboardHistoryStore.loadInitial(100);
+    }
+  } catch (err) {
+    diagnosticsService.report({
+      source: 'frontend', kind: 'clipboard/load-failed', severity: 'error',
+      retryable: false, developerDetail: String(err),
+    });
+  }
+}
+
+/** Call when the search query changes. Empty string clears the search. */
+export async function onSearchChanged(query: string): Promise<void> {
+  try {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      clipboardHistoryStore.clearSearch();
+      return;
+    }
+    await clipboardHistoryStore.search(trimmed, 200);
+  } catch (err) {
+    diagnosticsService.report({
+      source: 'frontend', kind: 'clipboard/search-failed', severity: 'error',
+      retryable: false, developerDetail: String(err),
+    });
+  }
+}
+
+/** Call when the list has been scrolled near the bottom. Paginates the recent
+ *  window. No-op during search mode. */
+export async function onScrolledToEnd(): Promise<void> {
+  try {
+    if (clipboardHistoryStore.searchResults !== null) return;
+    if (!clipboardHistoryStore.nextOlderCursor) return;
+    await clipboardHistoryStore.loadOlder(200);
+  } catch (err) {
+    diagnosticsService.report({
+      source: 'frontend', kind: 'clipboard/load-older-failed', severity: 'error',
+      retryable: false, developerDetail: String(err),
+    });
+  }
+}
+
+/** Fetch the full row (content decrypted) for paste / detail. */
+export async function fetchFullItemForId(id: string) {
+  try {
+    return await clipboardHistoryStore.fetchFullItem(id);
+  } catch (err) {
+    diagnosticsService.report({
+      source: 'frontend', kind: 'clipboard/get-item-failed', severity: 'error',
+      retryable: false, developerDetail: String(err),
+    });
+    return null;
+  }
+}
+
+/** The list to render — search results when in search mode, otherwise
+ *  favorites + recent in their order. */
+export function visibleItems() {
+  return clipboardHistoryStore.searchResults ?? [
+    ...clipboardHistoryStore.favorites,
+    ...clipboardHistoryStore.recent,
+  ];
+}

--- a/src/lib/ipc/commands.ts
+++ b/src/lib/ipc/commands.ts
@@ -671,30 +671,106 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     favorite: boolean;
     metadata?: Record<string, unknown>;
     sourceApp?: Record<string, unknown>;
+    redactedKinds?: string[];
   }
 
-  export async function clipboardGetAll(): Promise<StoredClipboardItem[]> {
-    return invoke<StoredClipboardItem[]>('clipboard_get_all');
+  export interface StoredClipboardListItem {
+    id: string;
+    type: string;
+    preview?: string;
+    createdAt: number;
+    favorite: boolean;
+    metadata?: Record<string, unknown>;
+    sourceApp?: Record<string, unknown>;
+    redactedKinds?: string[];
   }
 
-  export async function clipboardGetRecent(limit: number): Promise<StoredClipboardItem[]> {
-    return invoke<StoredClipboardItem[]>('clipboard_get_recent', { limit });
+  export interface ClipboardCursor {
+    createdAt: number;
+    id: string;
+  }
+
+  export interface ClipboardInitialPage {
+    favorites: StoredClipboardListItem[];
+    recent: StoredClipboardListItem[];
+    nextCursor?: ClipboardCursor;
+  }
+
+  export interface ClipboardOlderPage {
+    items: StoredClipboardListItem[];
+    nextCursor?: ClipboardCursor;
+  }
+
+  export interface ClipboardExportPage {
+    items: StoredClipboardItem[];
+    nextCursor?: ClipboardCursor;
+  }
+
+  export interface ClipboardSearchResult {
+    items: StoredClipboardListItem[];
+    indexState: 'ready' | 'indexing';
+  }
+
+  export interface ClipboardCount {
+    total: number;
+    favorites: number;
+  }
+
+  export interface ClipboardCaptureResult {
+    insertedId: string;
+    evictedIds: string[];
+  }
+
+  export interface ClipboardDeleteResult {
+    imageContentPath?: string;
+  }
+
+  export interface ClipboardClearResult {
+    removedIds: string[];
+    removedImagePaths: string[];
+  }
+
+  export async function clipboardListInitial(limit: number): Promise<ClipboardInitialPage> {
+    return invoke<ClipboardInitialPage>('clipboard_list_initial', { limit });
+  }
+
+  export async function clipboardListOlder(cursor: ClipboardCursor, limit: number): Promise<ClipboardOlderPage> {
+    return invoke<ClipboardOlderPage>('clipboard_list_older', { cursor, limit });
+  }
+
+  export async function clipboardSearch(query: string, limit: number): Promise<ClipboardSearchResult> {
+    return invoke<ClipboardSearchResult>('clipboard_search', { query, limit });
+  }
+
+  export async function clipboardGetItem(id: string): Promise<StoredClipboardItem | null> {
+    return invoke<StoredClipboardItem | null>('clipboard_get_item', { id });
+  }
+
+  export async function clipboardExportForSync(
+    cursor: ClipboardCursor | undefined,
+    limit: number,
+  ): Promise<ClipboardExportPage> {
+    return invoke<ClipboardExportPage>('clipboard_export_for_sync', { cursor, limit });
+  }
+
+  export async function clipboardCount(): Promise<ClipboardCount> {
+    return invoke<ClipboardCount>('clipboard_count');
+  }
+
+  export async function clipboardRecordCapture(item: StoredClipboardItem): Promise<ClipboardCaptureResult> {
+    return invoke<ClipboardCaptureResult>('clipboard_record_capture', { item });
   }
 
   export async function clipboardToggleFavorite(id: string): Promise<boolean> {
     return invoke<boolean>('clipboard_toggle_favorite', { id });
   }
 
-  export async function clipboardDeleteItem(id: string): Promise<void> {
-    return invoke('clipboard_delete_item', { id });
+  export async function clipboardDeleteItem(id: string): Promise<ClipboardDeleteResult> {
+    return invoke<ClipboardDeleteResult>('clipboard_delete_item', { id });
   }
 
-  export async function clipboardClearNonFavorites(): Promise<void> {
-    return invoke('clipboard_clear_non_favorites');
-  }
-
-  export async function clipboardRecordCapture(item: StoredClipboardItem): Promise<StoredClipboardItem[]> {
-    return invoke<StoredClipboardItem[]>('clipboard_record_capture', { item });
+  export async function clipboardClearNonFavorites(): Promise<ClipboardClearResult> {
+    return invoke<ClipboardClearResult>('clipboard_clear_non_favorites');
   }
 
   // ── Storage: Snippets ────────────────────────────────────────────────────────

--- a/src/services/clipboard/clipboardHistoryService.test.ts
+++ b/src/services/clipboard/clipboardHistoryService.test.ts
@@ -47,14 +47,16 @@ vi.mock('@tauri-apps/plugin-os', () => ({
 
 vi.mock('./stores/clipboardHistoryStore.svelte', () => ({
   clipboardHistoryStore: {
-    init: vi.fn(),
+    loadInitial: vi.fn().mockResolvedValue(undefined),
     addHistoryItem: vi.fn(),
-    getHistoryItems: vi.fn().mockResolvedValue([]),
-    getRecentItems: vi.fn().mockResolvedValue([]),
     toggleFavorite: vi.fn(),
-    deleteHistoryItem: vi.fn(),
-    clearHistory: vi.fn(),
-    items: [],
+    deleteHistoryItem: vi.fn().mockResolvedValue({ imageContentPath: undefined }),
+    clearHistory: vi.fn().mockResolvedValue({ removedIds: [], removedImagePaths: [] }),
+    favorites: [],
+    recent: [],
+    searchResults: null,
+    indexState: 'ready',
+    nextOlderCursor: undefined,
   }
 }))
 
@@ -72,10 +74,18 @@ vi.mock('../privacy/secretRedactionService.svelte', () => ({
   },
 }))
 
+vi.mock('../diagnostics/diagnosticsService.svelte', () => ({
+  diagnosticsService: {
+    report: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
 import { ClipboardHistoryService } from './clipboardHistoryService'
 import { ClipboardItemType, type ClipboardHistoryItem } from 'asyar-sdk/contracts'
 import { clipboardPrivacyService } from '../privacy/clipboardPrivacyService.svelte'
 import { secretRedactionService } from '../privacy/secretRedactionService.svelte'
+import { clipboardHistoryStore } from './stores/clipboardHistoryStore.svelte'
+import { remove } from '@tauri-apps/plugin-fs'
 
 function getInstance(): ClipboardHistoryService {
   return new ClipboardHistoryService()
@@ -720,39 +730,41 @@ describe('handleClipboardChange', () => {
 });
 
 // ── getRecentItems ────────────────────────────────────────────────────────────
-// NOTE: The two tests below replaced assertions that called store.getHistoryItems()
-// and sliced the result client-side. Those assertions fossilized the bug
-// (full-table scan + TS .slice). Per feedback_recurring_bug_check_tests.md,
-// inverted/deleted — the service must now delegate to store.getRecentItems(limit).
 
 describe('getRecentItems', () => {
-  // service_getRecentItems_does_NOT_call_store_getHistoryItems
-  // This test confirms the buggy "call getHistoryItems then slice" path is gone.
-  it('does NOT call store.getHistoryItems for view loading', async () => {
-    const { clipboardHistoryStore } = await import('./stores/clipboardHistoryStore.svelte')
-    // Wire getRecentItems on the mock so the call can succeed
-    ;(clipboardHistoryStore as any).getRecentItems = vi.fn().mockResolvedValueOnce([])
-    await getInstance().getRecentItems(10)
-    expect(clipboardHistoryStore.getHistoryItems).not.toHaveBeenCalled()
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('delegates to loadInitial and returns favorites + recent', async () => {
+    const loadSpy = vi.spyOn(clipboardHistoryStore, 'loadInitial').mockResolvedValue(undefined);
+    clipboardHistoryStore.favorites = [
+      { id: 'f1', type: ClipboardItemType.Text, preview: 'fav', createdAt: 100, favorite: true },
+    ] as any;
+    clipboardHistoryStore.recent = [
+      { id: 'r1', type: ClipboardItemType.Text, preview: 'rec', createdAt: 50, favorite: false },
+    ] as any;
+
+    const items = await getInstance().getRecentItems(30);
+
+    expect(loadSpy).toHaveBeenCalledWith(30);
+    expect(items.map((i) => i.id)).toEqual(['f1', 'r1']);
   })
 
-  it('service_getRecentItems_calls_store_getRecentItems_with_same_limit', async () => {
-    const { clipboardHistoryStore } = await import('./stores/clipboardHistoryStore.svelte')
-    ;(clipboardHistoryStore as any).getRecentItems = vi.fn().mockResolvedValueOnce([])
-    await getInstance().getRecentItems(75)
-    expect((clipboardHistoryStore as any).getRecentItems).toHaveBeenCalledWith(75)
+  it('passes limit through to loadInitial', async () => {
+    const loadSpy = vi.spyOn(clipboardHistoryStore, 'loadInitial').mockResolvedValue(undefined);
+    clipboardHistoryStore.favorites = [] as any;
+    clipboardHistoryStore.recent = [] as any;
+
+    await getInstance().getRecentItems(75);
+
+    expect(loadSpy).toHaveBeenCalledWith(75);
   })
 
-  it('service_getRecentItems_returns_store_output_without_slicing', async () => {
-    const { clipboardHistoryStore } = await import('./stores/clipboardHistoryStore.svelte')
-    const storeItems = Array.from({ length: 5 }, (_, i) =>
-      makeItem(ClipboardItemType.Text, `item ${i}`)
-    )
-    ;(clipboardHistoryStore as any).getRecentItems = vi.fn().mockResolvedValueOnce(storeItems)
-    // Even though limit=100 is larger than the 5-item result, no slicing should occur
-    const result = await getInstance().getRecentItems(100)
-    expect(result).toHaveLength(5)
-    expect(result).toEqual(storeItems)
+  it('returns empty array and reports to diagnostics when loadInitial throws', async () => {
+    vi.spyOn(clipboardHistoryStore, 'loadInitial').mockRejectedValueOnce(new Error('db error'));
+
+    const result = await getInstance().getRecentItems(30);
+
+    expect(result).toEqual([]);
   })
 })
 
@@ -827,67 +839,41 @@ describe('image cache persistence', () => {
     );
   });
 
-  it('deleteItem removes cached image file for image items', async () => {
-    const { remove } = await import('@tauri-apps/plugin-fs');
-    const svc = getInstance();
-    const { clipboardHistoryStore } = await import('./stores/clipboardHistoryStore.svelte');
+  it('deleteItem unlinks image cache using the IPC response, not a full scan', async () => {
+    const deleteSpy = vi.spyOn(clipboardHistoryStore, 'deleteHistoryItem')
+      .mockResolvedValue({ imageContentPath: '/cache/foo.png' });
+    vi.mocked(remove).mockClear();
 
-    // Mock getHistoryItems to return an image item
-    const imageItem = {
-      id: 'img-1',
-      type: ClipboardItemType.Image,
-      content: '/mock/app/data/clipboard_cache/img-1.png',
-      createdAt: Date.now(),
-      favorite: false,
-    };
-    vi.mocked(clipboardHistoryStore.getHistoryItems).mockResolvedValueOnce([imageItem as any]);
+    const ok = await getInstance().deleteItem('foo');
 
-    await svc.deleteItem('img-1');
-
-    // Should attempt to remove the cached file
-    expect(remove).toHaveBeenCalledWith('/mock/app/data/clipboard_cache/img-1.png');
-    // Should also remove from store
-    expect(clipboardHistoryStore.deleteHistoryItem).toHaveBeenCalledWith('img-1');
+    expect(ok).toBe(true);
+    expect(deleteSpy).toHaveBeenCalledWith('foo');
+    expect(remove).toHaveBeenCalledWith('/cache/foo.png');
   });
 
-  it('deleteItem does NOT remove file for text items', async () => {
-    const { remove } = await import('@tauri-apps/plugin-fs');
-    const svc = getInstance();
-    const { clipboardHistoryStore } = await import('./stores/clipboardHistoryStore.svelte');
+  it('deleteItem does not unlink anything when the IPC response has no image path', async () => {
+    vi.spyOn(clipboardHistoryStore, 'deleteHistoryItem')
+      .mockResolvedValue({ imageContentPath: undefined });
+    vi.mocked(remove).mockClear();
 
-    const textItem = {
-      id: 'txt-1',
-      type: ClipboardItemType.Text,
-      content: 'hello',
-      createdAt: Date.now(),
-      favorite: false,
-    };
-    vi.mocked(clipboardHistoryStore.getHistoryItems).mockResolvedValueOnce([textItem as any]);
-
-    await svc.deleteItem('txt-1');
+    await getInstance().deleteItem('text-row');
 
     expect(remove).not.toHaveBeenCalled();
-    expect(clipboardHistoryStore.deleteHistoryItem).toHaveBeenCalledWith('txt-1');
   });
 
-  it('clearNonFavorites removes cached image files for non-favorite images', async () => {
-    const { remove } = await import('@tauri-apps/plugin-fs');
-    const svc = getInstance();
-    const { clipboardHistoryStore } = await import('./stores/clipboardHistoryStore.svelte');
+  it('clearNonFavorites unlinks every image path returned by the IPC response', async () => {
+    vi.spyOn(clipboardHistoryStore, 'clearHistory')
+      .mockResolvedValue({
+        removedIds: ['a', 'b'],
+        removedImagePaths: ['/cache/a.png', '/cache/b.png'],
+      });
+    vi.mocked(remove).mockClear();
 
-    const items = [
-      { id: 'img-fav', type: ClipboardItemType.Image, content: '/cache/img-fav.png', createdAt: Date.now(), favorite: true },
-      { id: 'img-nonfav', type: ClipboardItemType.Image, content: '/cache/img-nonfav.png', createdAt: Date.now(), favorite: false },
-      { id: 'txt-1', type: ClipboardItemType.Text, content: 'hello', createdAt: Date.now(), favorite: false },
-    ];
-    vi.mocked(clipboardHistoryStore.getHistoryItems).mockResolvedValueOnce(items as any);
+    const ok = await getInstance().clearNonFavorites();
 
-    await svc.clearNonFavorites();
-
-    // Should only remove cache for non-favorite image items
-    expect(remove).toHaveBeenCalledTimes(1);
-    expect(remove).toHaveBeenCalledWith('/cache/img-nonfav.png');
-    expect(clipboardHistoryStore.clearHistory).toHaveBeenCalled();
+    expect(ok).toBe(true);
+    expect(remove).toHaveBeenCalledWith('/cache/a.png');
+    expect(remove).toHaveBeenCalledWith('/cache/b.png');
   });
 
   it('handles copy failure gracefully', async () => {
@@ -907,10 +893,8 @@ describe('image cache persistence', () => {
 });
 
 describe('Android fallback', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks()
-    const { clipboardHistoryStore } = await import('./stores/clipboardHistoryStore.svelte')
-    ;(clipboardHistoryStore as any).getRecentItems = vi.fn().mockResolvedValue([])
   })
 
   it('uses polling on Android instead of event-driven monitoring', async () => {
@@ -1030,19 +1014,3 @@ describe('readCurrentText', () => {
   })
 })
 
-describe('legacy cleanup', () => {
-  it('removes legacy blob URL image items on initialize', async () => {
-    const { clipboardHistoryStore } = await import('./stores/clipboardHistoryStore.svelte');
-
-    const blobItem = makeItem(ClipboardItemType.Image, 'blob:http://localhost:123/456', { id: 'blob-id' });
-    const normalItem = makeItem(ClipboardItemType.Image, '/path/to/img.png', { id: 'normal-id' });
-
-    ;(clipboardHistoryStore as any).getRecentItems = vi.fn().mockResolvedValue([blobItem, normalItem] as any);
-    
-    const svc = getInstance();
-    await svc.initialize();
-    
-    expect(clipboardHistoryStore.deleteHistoryItem).toHaveBeenCalledWith(blobItem.id);
-    expect(clipboardHistoryStore.deleteHistoryItem).not.toHaveBeenCalledWith(normalItem.id);
-  });
-});

--- a/src/services/clipboard/clipboardHistoryService.ts
+++ b/src/services/clipboard/clipboardHistoryService.ts
@@ -10,7 +10,9 @@ import { appDataDir } from "@tauri-apps/api/path";
 import { platform } from "@tauri-apps/plugin-os";
 import { invoke } from '@tauri-apps/api/core';
 import * as commands from "../../lib/ipc/commands";
+import type { ClipboardDeleteResult, ClipboardClearResult } from "../../lib/ipc/commands";
 import { v4 as uuidv4 } from "uuid";
+import { diagnosticsService } from "../diagnostics/diagnosticsService.svelte";
 import { clipboardHistoryStore } from "./stores/clipboardHistoryStore.svelte";
 import { clipboardPrivacyService } from "../privacy/clipboardPrivacyService.svelte";
 import { secretRedactionService } from "../privacy/secretRedactionService.svelte";
@@ -70,7 +72,7 @@ export class ClipboardHistoryService implements IClipboardHistoryService {
    */
   public async initialize(): Promise<void> {
     logService.debug("Initializing ClipboardHistoryService");
-    await clipboardHistoryStore.init();
+    await clipboardHistoryStore.loadInitial(100);
 
     try {
       const currentPlatform = await platform();
@@ -79,21 +81,7 @@ export class ClipboardHistoryService implements IClipboardHistoryService {
         logService.info('Running on Android — clipboard monitoring limited to text only');
       }
     } catch {
-      // platform() may fail in test environments, default to non-Android
       this.isAndroid = false;
-    }
-
-    // Clean up legacy blob URL items left over from the pre-base64 image storage
-    const items = await this.getRecentItems();
-    const blobItems = items.filter(item => 
-      item.type === ClipboardItemType.Image && 
-      item.content?.startsWith('blob:')
-    );
-    if (blobItems.length > 0) {
-      logService.info(`Cleaning up ${blobItems.length} legacy blob URL image items`);
-      for (const item of blobItems) {
-        await this.deleteItem(item.id);
-      }
     }
 
     await this.startMonitoring();
@@ -579,9 +567,17 @@ export class ClipboardHistoryService implements IClipboardHistoryService {
    */
   public async getRecentItems(limit = 30): Promise<ClipboardHistoryItem[]> {
     try {
-      return await clipboardHistoryStore.getRecentItems(limit);
-    } catch (error) {
-      logService.error(`Error retrieving clipboard items: ${error}`);
+      await clipboardHistoryStore.loadInitial(limit);
+      const items = [...clipboardHistoryStore.favorites, ...clipboardHistoryStore.recent];
+      return items as unknown as ClipboardHistoryItem[];
+    } catch (err) {
+      void diagnosticsService.report({
+        source: 'frontend',
+        kind: 'clipboard/load-failed',
+        severity: 'error',
+        retryable: false,
+        developerDetail: String(err),
+      });
       return [];
     }
   }
@@ -604,18 +600,19 @@ export class ClipboardHistoryService implements IClipboardHistoryService {
    */
   public async deleteItem(itemId: string): Promise<boolean> {
     try {
-      // Look up the item to check if it's an image that needs cache cleanup
-      const items = await clipboardHistoryStore.getHistoryItems();
-      const item = items.find(i => i.id === itemId);
-
-      if (item?.type === ClipboardItemType.Image && item.content) {
-        await this.deleteImageFromCache(item.content);
+      const res: ClipboardDeleteResult = await clipboardHistoryStore.deleteHistoryItem(itemId);
+      if (res.imageContentPath) {
+        await this.deleteImageFromCache(res.imageContentPath);
       }
-
-      await clipboardHistoryStore.deleteHistoryItem(itemId);
       return true;
-    } catch (error) {
-      logService.error(`Error deleting history item: ${error}`);
+    } catch (err) {
+      void diagnosticsService.report({
+        source: 'frontend',
+        kind: 'clipboard/delete-failed',
+        severity: 'error',
+        retryable: false,
+        developerDetail: String(err),
+      });
       return false;
     }
   }
@@ -625,18 +622,19 @@ export class ClipboardHistoryService implements IClipboardHistoryService {
    */
   public async clearNonFavorites(): Promise<boolean> {
     try {
-      // Delete cached images for non-favorite items before clearing
-      const items = await clipboardHistoryStore.getHistoryItems();
-      for (const item of items) {
-        if (!item.favorite && item.type === ClipboardItemType.Image && item.content) {
-          await this.deleteImageFromCache(item.content);
-        }
+      const res: ClipboardClearResult = await clipboardHistoryStore.clearHistory();
+      for (const path of res.removedImagePaths) {
+        await this.deleteImageFromCache(path);
       }
-
-      await clipboardHistoryStore.clearHistory();
       return true;
-    } catch (error) {
-      logService.error(`Error clearing non-favorite items: ${error}`);
+    } catch (err) {
+      void diagnosticsService.report({
+        source: 'frontend',
+        kind: 'clipboard/clear-failed',
+        severity: 'error',
+        retryable: false,
+        developerDetail: String(err),
+      });
       return false;
     }
   }

--- a/src/services/clipboard/stores/clipboardHistoryStore.svelte.test.ts
+++ b/src/services/clipboard/stores/clipboardHistoryStore.svelte.test.ts
@@ -1,174 +1,169 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-
-vi.mock('../../log/logService', () => ({
-  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
-}))
-
-// In-memory storage backing the mock invoke calls
-const mockDb = vi.hoisted(() => ({
-  items: [] as any[],
-}))
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../../lib/ipc/commands', () => ({
-  clipboardRecordCapture: vi.fn(async (item: any) => {
-    // Find duplicate by content (text) or by id (image)
-    let duplicate: any = null
-    if (item.type === 'image') {
-      duplicate = mockDb.items.find((i: any) => i.type === item.type && i.id === item.id) ?? null
-    } else if (item.content) {
-      duplicate = mockDb.items.find((i: any) => i.type === item.type && i.content === item.content) ?? null
-    }
-    if (duplicate) {
-      if (duplicate.favorite) item = { ...item, favorite: true }
-      mockDb.items = mockDb.items.filter((i: any) => i.id !== duplicate.id)
-    }
-    mockDb.items.unshift(item)
-    return [...mockDb.items]
-  }),
-  clipboardGetAll: vi.fn(async () => [...mockDb.items]),
-  clipboardGetRecent: vi.fn(async (limit: number) => [...mockDb.items].slice(0, limit)),
-  clipboardToggleFavorite: vi.fn(async (id: string) => {
-    const item = mockDb.items.find((i: any) => i.id === id)
-    if (item) item.favorite = !item.favorite
-    return item?.favorite ?? false
-  }),
-  clipboardDeleteItem: vi.fn(async (id: string) => {
-    mockDb.items = mockDb.items.filter((i: any) => i.id !== id)
-  }),
-  clipboardClearNonFavorites: vi.fn(async () => {
-    mockDb.items = mockDb.items.filter((i: any) => i.favorite)
-  }),
-}))
+  clipboardListInitial: vi.fn(),
+  clipboardListOlder: vi.fn(),
+  clipboardSearch: vi.fn(),
+  clipboardGetItem: vi.fn(),
+  clipboardRecordCapture: vi.fn(),
+  clipboardToggleFavorite: vi.fn(),
+  clipboardDeleteItem: vi.fn(),
+  clipboardClearNonFavorites: vi.fn(),
+}));
 
-import { ClipboardHistoryStoreClass } from './clipboardHistoryStore.svelte'
+vi.mock('../../diagnostics/diagnosticsService.svelte', () => ({
+  diagnosticsService: { report: vi.fn() },
+}));
 
-describe('clipboardHistoryStore — Rust-backed', () => {
-  let store: ClipboardHistoryStoreClass
+vi.mock('../../log/logService', () => ({
+  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
 
-  beforeEach(async () => {
-    mockDb.items = []
-    store = new ClipboardHistoryStoreClass()
-    await store.init()
-  })
+import { clipboardHistoryStore } from './clipboardHistoryStore.svelte';
+import * as ipc from '../../../lib/ipc/commands';
 
-  it('preserves favorite:true when the same content is added again', async () => {
-    const now = Date.now()
-    const original = { id: '1', type: 'text' as any, content: 'hello', createdAt: now - 1000, favorite: true }
-    await store.addHistoryItem(original)
+const mockListInitial = ipc.clipboardListInitial as unknown as ReturnType<typeof vi.fn>;
+const mockListOlder = ipc.clipboardListOlder as unknown as ReturnType<typeof vi.fn>;
+const mockSearch = ipc.clipboardSearch as unknown as ReturnType<typeof vi.fn>;
+const mockGetItem = ipc.clipboardGetItem as unknown as ReturnType<typeof vi.fn>;
+const mockCapture = ipc.clipboardRecordCapture as unknown as ReturnType<typeof vi.fn>;
+const mockToggleFavorite = ipc.clipboardToggleFavorite as unknown as ReturnType<typeof vi.fn>;
+const mockDelete = ipc.clipboardDeleteItem as unknown as ReturnType<typeof vi.fn>;
+const mockClear = ipc.clipboardClearNonFavorites as unknown as ReturnType<typeof vi.fn>;
 
-    const duplicate = { id: '2', type: 'text' as any, content: 'hello', createdAt: now, favorite: false }
-    await store.addHistoryItem(duplicate)
+beforeEach(() => {
+  vi.clearAllMocks();
+  clipboardHistoryStore.reset();
+});
 
-    const items = await store.getHistoryItems()
-    expect(items).toHaveLength(1)
-    expect(items[0].favorite).toBe(true)
-  })
+describe('clipboardHistoryStore', () => {
+  it('loadInitial populates favorites + recent and stores nextCursor', async () => {
+    mockListInitial.mockResolvedValue({
+      favorites: [{ id: 'f1', type: 'text', createdAt: 100, favorite: true }],
+      recent: [{ id: 'r1', type: 'text', createdAt: 50, favorite: false }],
+      nextCursor: { createdAt: 50, id: 'r1' },
+    });
+    await clipboardHistoryStore.loadInitial(100);
+    expect(clipboardHistoryStore.favorites).toHaveLength(1);
+    expect(clipboardHistoryStore.recent).toHaveLength(1);
+    expect(clipboardHistoryStore.nextOlderCursor).toEqual({ createdAt: 50, id: 'r1' });
+  });
 
-  it('does not promote favorite when original was not favorited', async () => {
-    const now = Date.now()
-    const original = { id: '1', type: 'text' as any, content: 'hello', createdAt: now - 1000, favorite: false }
-    await store.addHistoryItem(original)
+  it('loadOlder appends and updates the cursor', async () => {
+    mockListInitial.mockResolvedValue({
+      favorites: [],
+      recent: [{ id: 'r1', type: 'text', createdAt: 100, favorite: false }],
+      nextCursor: { createdAt: 100, id: 'r1' },
+    });
+    mockListOlder.mockResolvedValue({
+      items: [{ id: 'r2', type: 'text', createdAt: 50, favorite: false }],
+      nextCursor: undefined,
+    });
+    await clipboardHistoryStore.loadInitial(1);
+    await clipboardHistoryStore.loadOlder(10);
+    expect(clipboardHistoryStore.recent.map((i) => i.id)).toEqual(['r1', 'r2']);
+    expect(clipboardHistoryStore.nextOlderCursor).toBeUndefined();
+  });
 
-    const duplicate = { id: '2', type: 'text' as any, content: 'hello', createdAt: now, favorite: false }
-    await store.addHistoryItem(duplicate)
+  it('search populates searchResults and reads indexState', async () => {
+    mockSearch.mockResolvedValue({
+      items: [{ id: 'r1', type: 'text', createdAt: 100, favorite: false }],
+      indexState: 'ready',
+    });
+    await clipboardHistoryStore.search('apple', 200);
+    expect(clipboardHistoryStore.searchResults).not.toBeNull();
+    expect(clipboardHistoryStore.searchResults!).toHaveLength(1);
+    expect(clipboardHistoryStore.indexState).toBe('ready');
+  });
 
-    const items = await store.getHistoryItems()
-    expect(items).toHaveLength(1)
-    expect(items[0].favorite).toBe(false)
-  })
+  it('clearSearch resets searchResults to null', async () => {
+    mockSearch.mockResolvedValue({ items: [], indexState: 'ready' });
+    await clipboardHistoryStore.search('x', 10);
+    clipboardHistoryStore.clearSearch();
+    expect(clipboardHistoryStore.searchResults).toBeNull();
+  });
 
-  it('toggles favorite status', async () => {
-    await store.addHistoryItem({ id: '1', type: 'text' as any, content: 'hello', createdAt: Date.now(), favorite: false })
+  it('fetchFullItem calls clipboardGetItem and does NOT touch list endpoints', async () => {
+    mockGetItem.mockResolvedValue({ id: 'full', type: 'text', content: 'body', preview: 'body', createdAt: 1, favorite: false });
+    const got = await clipboardHistoryStore.fetchFullItem('full');
+    expect(got?.content).toBe('body');
+    expect(mockListInitial).not.toHaveBeenCalled();
+    expect(mockListOlder).not.toHaveBeenCalled();
+  });
 
-    await store.toggleFavorite('1')
-    expect(store.items[0].favorite).toBe(true)
+  it('deleteHistoryItem removes the row locally and reports image path', async () => {
+    mockListInitial.mockResolvedValue({ favorites: [], recent: [
+      { id: 'a', type: 'text', createdAt: 1, favorite: false },
+      { id: 'b', type: 'text', createdAt: 2, favorite: false },
+    ], nextCursor: undefined });
+    mockDelete.mockResolvedValue({ imageContentPath: undefined });
+    await clipboardHistoryStore.loadInitial(10);
+    const res = await clipboardHistoryStore.deleteHistoryItem('a');
+    expect(res.imageContentPath).toBeUndefined();
+    expect(clipboardHistoryStore.recent.map((i) => i.id)).toEqual(['b']);
+  });
 
-    await store.toggleFavorite('1')
-    expect(store.items[0].favorite).toBe(false)
-  })
+  it('clearHistory removes non-favorites locally and reports image paths', async () => {
+    mockListInitial.mockResolvedValue({
+      favorites: [{ id: 'f', type: 'text', createdAt: 100, favorite: true }],
+      recent: [{ id: 'n', type: 'text', createdAt: 50, favorite: false }],
+      nextCursor: undefined,
+    });
+    mockClear.mockResolvedValue({ removedIds: ['n'], removedImagePaths: ['/cache/n.png'] });
+    await clipboardHistoryStore.loadInitial(10);
+    const res = await clipboardHistoryStore.clearHistory();
+    expect(res.removedImagePaths).toEqual(['/cache/n.png']);
+    expect(clipboardHistoryStore.recent).toHaveLength(0);
+    expect(clipboardHistoryStore.favorites).toHaveLength(1);
+  });
 
-  it('deletes an item', async () => {
-    await store.addHistoryItem({ id: '1', type: 'text' as any, content: 'a', createdAt: Date.now(), favorite: false })
-    await store.addHistoryItem({ id: '2', type: 'text' as any, content: 'b', createdAt: Date.now() + 1, favorite: false })
+  it('addHistoryItem inserts at top of recent, drops evicted ids, fires upsert event', async () => {
+    mockListInitial.mockResolvedValue({
+      favorites: [],
+      recent: [{ id: 'old', type: 'text', createdAt: 50, favorite: false }],
+      nextCursor: undefined,
+    });
+    mockCapture.mockResolvedValue({ insertedId: 'new', evictedIds: [] });
+    await clipboardHistoryStore.loadInitial(10);
 
-    await store.deleteHistoryItem('1')
-    expect(store.items).toHaveLength(1)
-    expect(store.items[0].id).toBe('2')
-  })
+    const events: { type: string; id: string }[] = [];
+    const unsub = clipboardHistoryStore.subscribe((e) => events.push({ type: e.type, id: e.itemId }));
 
-  it('clears non-favorites only', async () => {
-    await store.addHistoryItem({ id: '1', type: 'text' as any, content: 'a', createdAt: Date.now(), favorite: false })
-    await store.addHistoryItem({ id: '2', type: 'text' as any, content: 'b', createdAt: Date.now() + 1, favorite: true })
+    await clipboardHistoryStore.addHistoryItem({
+      id: 'new', type: 'text', content: 'body', preview: 'body',
+      createdAt: 100, favorite: false,
+    } as any);
 
-    await store.clearHistory()
-    expect(store.items).toHaveLength(1)
-    expect(store.items[0].id).toBe('2')
-  })
+    expect(clipboardHistoryStore.recent[0].id).toBe('new');
+    expect(events).toEqual([{ type: 'upsert', id: 'new' }]);
+    unsub();
+  });
 
-  it('getHistoryItems returns a plain array that can be structuredCloned', async () => {
-    const now = Date.now()
-    await store.addHistoryItem({ id: '1', type: 'text' as any, content: 'hello', createdAt: now, favorite: false })
+  it('toggleFavorite moves between recent and favorites', async () => {
+    mockListInitial.mockResolvedValue({
+      favorites: [],
+      recent: [{ id: 'r1', type: 'text', createdAt: 100, favorite: false }],
+      nextCursor: undefined,
+    });
+    mockToggleFavorite.mockResolvedValue(true);
+    await clipboardHistoryStore.loadInitial(10);
+    await clipboardHistoryStore.toggleFavorite('r1');
+    expect(clipboardHistoryStore.favorites.map((i) => i.id)).toEqual(['r1']);
+    expect(clipboardHistoryStore.recent).toHaveLength(0);
+  });
 
-    const items = await store.getHistoryItems()
-
-    // Must not throw — Svelte 5 $state Proxies fail structuredClone
-    expect(() => structuredClone(items)).not.toThrow()
-    expect(items).toHaveLength(1)
-    expect(items[0].content).toBe('hello')
-  })
-
-  // ── getRecentItems ──────────────────────────────────────────────────────
-
-  it('getRecentItems_invokes_clipboard_get_recent_with_limit', async () => {
-    const { clipboardGetRecent } = await import('../../../lib/ipc/commands')
-    vi.mocked(clipboardGetRecent).mockResolvedValueOnce([])
-    await store.getRecentItems(50)
-    expect(clipboardGetRecent).toHaveBeenCalledWith(50)
-  })
-
-  it('getRecentItems_returns_what_rust_returned_unchanged', async () => {
-    const { clipboardGetRecent } = await import('../../../lib/ipc/commands')
-    const rustResult = [
-      { id: 'f1', type: 'text', content: 'fav 1', createdAt: 100, favorite: true },
-      { id: 'f2', type: 'text', content: 'fav 2', createdAt: 200, favorite: true },
-      { id: 'f3', type: 'text', content: 'fav 3', createdAt: 300, favorite: true },
-      { id: 'n1', type: 'text', content: 'non 1', createdAt: 400, favorite: false },
-      { id: 'n2', type: 'text', content: 'non 2', createdAt: 500, favorite: false },
-      { id: 'n3', type: 'text', content: 'non 3', createdAt: 600, favorite: false },
-      { id: 'n4', type: 'text', content: 'non 4', createdAt: 700, favorite: false },
-    ]
-    vi.mocked(clipboardGetRecent).mockResolvedValueOnce(rustResult as any)
-    const result = await store.getRecentItems(10)
-    // Must return all 7 in the same order — no slicing, no re-sorting
-    expect(result).toHaveLength(7)
-    expect(result.map((i) => i.id)).toEqual(['f1', 'f2', 'f3', 'n1', 'n2', 'n3', 'n4'])
-  })
-
-  it('getRecentItems_returns_empty_array_on_ipc_error', async () => {
-    const { clipboardGetRecent } = await import('../../../lib/ipc/commands')
-    vi.mocked(clipboardGetRecent).mockRejectedValueOnce(new Error('IPC failure'))
-    const result = await store.getRecentItems(50)
-    expect(result).toEqual([])
-    const { logService } = await import('../../log/logService')
-    expect(logService.error).toHaveBeenCalled()
-  })
-
-  it('addHistoryItem always persists via clipboard_record_capture', async () => {
-    // Source-app iconUrl enrichment only happens in Rust during
-    // record_capture, so any in-memory-only fallback would silently
-    // drop it from every new capture.
-    const item = { id: 'persist-1', type: 'text' as any, content: 'flickr', createdAt: Date.now(), favorite: false }
-
-    await store.addHistoryItem(item)
-
-    // mockDb is the backing store for the clipboardRecordCapture mock —
-    // an item only lands here if Rust persistence ran. An in-memory-only
-    // fallback path would update store.items but leave mockDb empty.
-    expect(mockDb.items).toContainEqual(
-      expect.objectContaining({ id: 'persist-1', content: 'flickr' }),
-    )
-    expect(store.items).toContainEqual(
-      expect.objectContaining({ id: 'persist-1', content: 'flickr' }),
-    )
-  })
-})
+  it('toggleFavorite on a search-only row inserts it into favorites', async () => {
+    // No loadInitial — favorites and recent both start empty.
+    mockSearch.mockResolvedValue({
+      items: [{ id: 'searchOnly', type: 'text', createdAt: 50, favorite: false }],
+      indexState: 'ready',
+    });
+    mockToggleFavorite.mockResolvedValue(true);
+    await clipboardHistoryStore.search('x', 10);
+    await clipboardHistoryStore.toggleFavorite('searchOnly');
+    expect(clipboardHistoryStore.favorites.map((i) => i.id)).toEqual(['searchOnly']);
+    expect(clipboardHistoryStore.recent).toHaveLength(0);
+    // The search result list itself is also updated.
+    expect(clipboardHistoryStore.searchResults?.[0].favorite).toBe(true);
+  });
+});

--- a/src/services/clipboard/stores/clipboardHistoryStore.svelte.ts
+++ b/src/services/clipboard/stores/clipboardHistoryStore.svelte.ts
@@ -1,165 +1,231 @@
 import { logService } from "../../log/logService";
+import { diagnosticsService } from "../../diagnostics/diagnosticsService.svelte";
 import type { ClipboardHistoryItem } from "asyar-sdk/contracts";
 import {
-  clipboardGetAll,
-  clipboardGetRecent,
+  clipboardListInitial,
+  clipboardListOlder,
+  clipboardSearch,
+  clipboardGetItem,
+  clipboardRecordCapture,
   clipboardToggleFavorite,
   clipboardDeleteItem,
   clipboardClearNonFavorites,
-  clipboardRecordCapture,
   type StoredClipboardItem,
+  type StoredClipboardListItem,
+  type ClipboardCursor,
+  type ClipboardDeleteResult,
+  type ClipboardClearResult,
 } from "../../../lib/ipc/commands";
 
-/**
- * Convert SDK type to Rust-compatible stored type.
- * The types are structurally identical (both camelCase JSON),
- * but metadata needs to be a plain object for Rust serde_json::Value.
- */
-function toStored(item: ClipboardHistoryItem): StoredClipboardItem {
-  return item as unknown as StoredClipboardItem;
-}
-
-function fromStored(items: StoredClipboardItem[]): ClipboardHistoryItem[] {
-  return items as unknown as ClipboardHistoryItem[];
-}
-
-/**
- * Local change event emitted by the store whenever an item is added,
- * favorited, deleted, or cleared. Consumed by the cloud sync provider
- * (see `clipboardSyncProvider.subscribeToChanges`) to mark items dirty
- * for the next push tick.
- */
 export type ClipboardStoreChangeEvent =
   | { type: 'upsert'; itemId: string }
   | { type: 'delete'; itemId: string };
 
+type ListItem = StoredClipboardListItem;
+
+function reportFailure(kind: string, err: unknown): void {
+  void diagnosticsService.report({
+    source: 'frontend',
+    kind,
+    severity: 'error',
+    retryable: false,
+    developerDetail: String(err),
+  });
+}
+
 export class ClipboardHistoryStoreClass {
-  items = $state<ClipboardHistoryItem[]>([]);
-  private initialized = false;
-  // Hand-rolled subscriber list — kept narrow so consumers can react to
-  // local mutations without spinning up a Svelte $effect runtime. Used by
-  // the cloud sync delta provider; not part of the broader UI contract.
+  favorites = $state<ListItem[]>([]);
+  recent = $state<ListItem[]>([]);
+  searchResults = $state<ListItem[] | null>(null);
+  indexState = $state<'ready' | 'indexing'>('indexing');
+  nextOlderCursor = $state<ClipboardCursor | undefined>(undefined);
+
   #subscribers = new Set<(event: ClipboardStoreChangeEvent) => void>();
 
-  /** Subscribe to local change events. Returns an unsubscribe function. */
   subscribe(callback: (event: ClipboardStoreChangeEvent) => void): () => void {
     this.#subscribers.add(callback);
-    return () => {
-      this.#subscribers.delete(callback);
-    };
+    return () => { this.#subscribers.delete(callback); };
   }
 
   #notify(event: ClipboardStoreChangeEvent): void {
     this.#subscribers.forEach((cb) => {
-      try {
-        cb(event);
-      } catch (err) {
+      try { cb(event); }
+      catch (err) {
         logService.warn(`clipboardHistoryStore subscriber threw: ${err}`);
       }
     });
   }
 
-  /**
-   * Initialize the clipboard history store by loading all items from Rust SQLite.
-   */
-  async init(): Promise<void> {
-    if (this.initialized) return;
-    this.initialized = true;
+  reset(): void {
+    this.favorites = [];
+    this.recent = [];
+    this.searchResults = null;
+    this.indexState = 'indexing';
+    this.nextOlderCursor = undefined;
+  }
 
+  async loadInitial(limit = 100): Promise<void> {
     try {
-      const stored = await clipboardGetAll();
-      this.items = fromStored(stored);
-    } catch (error) {
-      logService.error(`Failed to init clipboard history store: ${error}`);
+      const page = await clipboardListInitial(limit);
+      this.favorites = page.favorites;
+      this.recent = page.recent;
+      this.nextOlderCursor = page.nextCursor;
+    } catch (err) {
+      reportFailure('clipboard/load-failed', err);
     }
   }
 
-  /**
-   * Add an item to the clipboard history.
-   * Delegates all dedup / insert / cleanup logic — and source-app iconUrl
-   * enrichment — to the Rust `clipboard_record_capture` command. The
-   * returned list is the new source of truth.
-   */
+  // Guards against concurrent loadOlder calls. Without this, fast scrolling
+  // fires the scroll handler dozens of times per second, each spawning its
+  // own IPC + array-spread. Result: same page appended N times, recent
+  // array grows unboundedly, webview eventually OOMs and the app crashes.
+  #loadingOlder = false;
+
+  async loadOlder(limit = 200): Promise<void> {
+    if (this.#loadingOlder || !this.nextOlderCursor) return;
+    this.#loadingOlder = true;
+    try {
+      const cursor = this.nextOlderCursor;
+      const page = await clipboardListOlder(cursor, limit);
+      this.recent = [...this.recent, ...page.items];
+      this.nextOlderCursor = page.nextCursor;
+    } catch (err) {
+      reportFailure('clipboard/load-older-failed', err);
+    } finally {
+      this.#loadingOlder = false;
+    }
+  }
+
+  // Monotonic sequence number used to drop stale search responses.
+  // Without it, typing "apple" launches 5 IPCs (one per keystroke); they
+  // queue on Tauri's worker pool and race to write `searchResults`. The
+  // user perceives this as "search takes a long time" because each
+  // intermediate write triggers a re-render of the result list. With
+  // this guard, only the latest issued query's response is applied —
+  // earlier in-flight responses are dropped before they touch the UI.
+  #searchSeq = 0;
+
+  async search(query: string, limit = 200): Promise<void> {
+    const mySeq = ++this.#searchSeq;
+    try {
+      const res = await clipboardSearch(query, limit);
+      // Drop response if a newer search has been issued in the meantime.
+      if (mySeq !== this.#searchSeq) return;
+      this.searchResults = res.items;
+      this.indexState = res.indexState;
+    } catch (err) {
+      reportFailure('clipboard/search-failed', err);
+    }
+  }
+
+  clearSearch(): void {
+    // Bump the sequence so any in-flight search response is dropped on
+    // arrival — without this, the user clearing their query could be
+    // immediately overwritten by a late-arriving prior search.
+    this.#searchSeq++;
+    this.searchResults = null;
+  }
+
+  async fetchFullItem(id: string): Promise<StoredClipboardItem | null> {
+    try {
+      return await clipboardGetItem(id);
+    } catch (err) {
+      reportFailure('clipboard/get-item-failed', err);
+      return null;
+    }
+  }
+
   async addHistoryItem(item: ClipboardHistoryItem): Promise<void> {
     try {
-      const stored = await clipboardRecordCapture(toStored(item));
-      this.items = fromStored(stored);
-      this.#notify({ type: 'upsert', itemId: item.id });
-    } catch (error) {
-      logService.error(`Failed to record clipboard capture: ${error}`);
+      const stored = item as unknown as StoredClipboardItem;
+      const res = await clipboardRecordCapture(stored);
+      if (res.evictedIds.length > 0) {
+        const evicted = new Set(res.evictedIds);
+        this.recent = this.recent.filter((i) => !evicted.has(i.id));
+        this.favorites = this.favorites.filter((i) => !evicted.has(i.id));
+      }
+      const newRow: ListItem = {
+        id: stored.id,
+        type: stored.type,
+        preview: stored.preview,
+        createdAt: stored.createdAt,
+        favorite: stored.favorite,
+        metadata: stored.metadata,
+        sourceApp: stored.sourceApp,
+        redactedKinds: stored.redactedKinds,
+      };
+      if (newRow.favorite) {
+        this.favorites = [newRow, ...this.favorites.filter((i) => i.id !== newRow.id)];
+      } else {
+        this.recent = [newRow, ...this.recent.filter((i) => i.id !== newRow.id)];
+      }
+      this.#notify({ type: 'upsert', itemId: stored.id });
+    } catch (err) {
+      reportFailure('clipboard/capture-failed', err);
     }
   }
 
-  /**
-   * Get all clipboard history items.
-   */
-  async getHistoryItems(): Promise<ClipboardHistoryItem[]> {
-    try {
-      const stored = await clipboardGetAll();
-      this.items = fromStored(stored);
-      return $state.snapshot(this.items) as ClipboardHistoryItem[];
-    } catch (error) {
-      logService.error(`Failed to get clipboard history items: ${error}`);
-      return $state.snapshot(this.items) as ClipboardHistoryItem[];
-    }
-  }
-
-  /**
-   * Get all favorites plus the newest `limit` non-favorites, as returned by Rust.
-   * The ordering (favorites-first, then newest non-favorites) is determined
-   * server-side; this method returns the list unchanged.
-   */
-  async getRecentItems(limit: number): Promise<ClipboardHistoryItem[]> {
-    try {
-      const stored = await clipboardGetRecent(limit);
-      this.items = fromStored(stored);
-      return $state.snapshot(this.items) as ClipboardHistoryItem[];
-    } catch (error) {
-      logService.error(`Failed to get recent clipboard items: ${error}`);
-      return [];
-    }
-  }
-
-  /**
-   * Toggle favorite status of an item.
-   */
   async toggleFavorite(id: string): Promise<void> {
     try {
       const newFavorite = await clipboardToggleFavorite(id);
-      // Update local state without a full reload
-      this.items = this.items.map(item =>
-        item.id === id ? { ...item, favorite: newFavorite } : item
-      );
+
+      // Find the row anywhere in the loaded windows so we can move it.
+      const source =
+        this.recent.find((i) => i.id === id) ??
+        this.favorites.find((i) => i.id === id) ??
+        this.searchResults?.find((i) => i.id === id);
+
+      if (source) {
+        const updated = { ...source, favorite: newFavorite };
+        if (newFavorite) {
+          this.recent = this.recent.filter((i) => i.id !== id);
+          this.favorites = [updated, ...this.favorites.filter((i) => i.id !== id)];
+        } else {
+          this.favorites = this.favorites.filter((i) => i.id !== id);
+          this.recent = [updated, ...this.recent.filter((i) => i.id !== id)];
+        }
+      }
+
+      if (this.searchResults) {
+        this.searchResults = this.searchResults.map((i) =>
+          i.id === id ? { ...i, favorite: newFavorite } : i
+        );
+      }
       this.#notify({ type: 'upsert', itemId: id });
-    } catch (error) {
-      logService.error(`Failed to toggle favorite status: ${error}`);
+    } catch (err) {
+      reportFailure('clipboard/favorite-failed', err);
     }
   }
 
-  /**
-   * Delete an item from history.
-   */
-  async deleteHistoryItem(id: string): Promise<void> {
+  async deleteHistoryItem(id: string): Promise<ClipboardDeleteResult> {
     try {
-      await clipboardDeleteItem(id);
-      this.items = this.items.filter(item => item.id !== id);
+      const res = await clipboardDeleteItem(id);
+      this.favorites = this.favorites.filter((i) => i.id !== id);
+      this.recent = this.recent.filter((i) => i.id !== id);
+      if (this.searchResults) {
+        this.searchResults = this.searchResults.filter((i) => i.id !== id);
+      }
       this.#notify({ type: 'delete', itemId: id });
-    } catch (error) {
-      logService.error(`Failed to delete clipboard history item: ${error}`);
+      return res;
+    } catch (err) {
+      reportFailure('clipboard/delete-failed', err);
+      return { imageContentPath: undefined };
     }
   }
 
-  /**
-   * Clear all non-favorite items from history.
-   */
-  async clearHistory(): Promise<void> {
-    const removedIds = this.items.filter(item => !item.favorite).map(item => item.id);
+  async clearHistory(): Promise<ClipboardClearResult> {
     try {
-      await clipboardClearNonFavorites();
-      this.items = this.items.filter(item => item.favorite);
-      removedIds.forEach((id) => this.#notify({ type: 'delete', itemId: id }));
-    } catch (error) {
-      logService.error(`Failed to clear clipboard history: ${error}`);
+      const res = await clipboardClearNonFavorites();
+      const removed = new Set(res.removedIds);
+      this.recent = this.recent.filter((i) => !removed.has(i.id));
+      if (this.searchResults) {
+        this.searchResults = this.searchResults.filter((i) => !removed.has(i.id));
+      }
+      res.removedIds.forEach((rid) => this.#notify({ type: 'delete', itemId: rid }));
+      return res;
+    } catch (err) {
+      reportFailure('clipboard/clear-failed', err);
+      return { removedIds: [], removedImagePaths: [] };
     }
   }
 }

--- a/src/services/profile/providers/clipboardSyncProvider.test.ts
+++ b/src/services/profile/providers/clipboardSyncProvider.test.ts
@@ -1,52 +1,116 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../lib/ipc/commands', () => ({
+  clipboardExportForSync: vi.fn(),
+  clipboardCount: vi.fn(),
+}));
+
+vi.mock('../../clipboard/stores/clipboardHistoryStore.svelte', () => ({
+  clipboardHistoryStore: {
+    addHistoryItem: vi.fn(),
+    deleteHistoryItem: vi.fn(),
+    clearHistory: vi.fn(),
+    subscribe: vi.fn(() => () => {}),
+  },
+}));
+
 import { ClipboardSyncProvider } from './clipboardSyncProvider';
+import {
+  clipboardExportForSync,
+  clipboardCount,
+  type StoredClipboardItem,
+} from '../../../lib/ipc/commands';
 import type { SyncProviderData } from '../types';
 
-const mockItems = [
-  { id: 'c1', type: 'text', content: 'Hello World', createdAt: 1000, favorite: false },
-  { id: 'c2', type: 'image', createdAt: 2000, favorite: false },
-];
+const mockExport = clipboardExportForSync as unknown as ReturnType<typeof vi.fn>;
+const mockCount = clipboardCount as unknown as ReturnType<typeof vi.fn>;
 
-vi.mock('../../clipboard/stores/clipboardHistoryStore.svelte', () => {
-  type ChangeCb = (event: { type: 'upsert' | 'delete'; itemId: string }) => void;
-  const subscribers = new Set<ChangeCb>();
-  return {
-    clipboardHistoryStore: {
-      getHistoryItems: vi.fn().mockResolvedValue([
-        { id: 'c1', type: 'text', content: 'Hello World', createdAt: 1000, favorite: false },
-        { id: 'c2', type: 'image', createdAt: 2000, favorite: false },
-      ]),
-      addHistoryItem: vi.fn().mockResolvedValue(undefined),
-      clearHistory: vi.fn().mockResolvedValue(undefined),
-      deleteHistoryItem: vi.fn().mockResolvedValue(undefined),
-      subscribe: vi.fn((cb: ChangeCb) => {
-        subscribers.add(cb);
-        return () => subscribers.delete(cb);
-      }),
-      __emit: (ev: { type: 'upsert' | 'delete'; itemId: string }) => {
-        subscribers.forEach((cb) => cb(ev));
-      },
-    },
-  };
-});
+beforeEach(() => { vi.clearAllMocks(); });
 
-describe('ClipboardSyncProvider', () => {
-  let provider: ClipboardSyncProvider;
+// ── Paged export ─────────────────────────────────────────────────────────────
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    provider = new ClipboardSyncProvider();
+describe('ClipboardSyncProvider — paged export', () => {
+  it('exportItems iterates every row across multiple pages without holding all rows at once', async () => {
+    const allRows: StoredClipboardItem[] = Array.from({ length: 5 }, (_, i) => ({
+      id: `id-${i}`, type: 'text', content: `body ${i}`, preview: `body ${i}`,
+      createdAt: 1000 + i, favorite: false,
+    }));
+    let call = 0;
+    mockExport.mockImplementation(async (cursor: unknown, limit: number) => {
+      const pageStart = call * limit;
+      call++;
+      const slice = allRows.slice(pageStart, pageStart + limit);
+      const nextCursor = (pageStart + limit) < allRows.length
+        ? { createdAt: slice[slice.length - 1].createdAt, id: slice[slice.length - 1].id }
+        : undefined;
+      return { items: slice, nextCursor };
+    });
+
+    const provider = new ClipboardSyncProvider();
+    const items = await provider.exportItems();
+    expect(items.map((i: any) => i.id).sort()).toEqual(allRows.map((r) => r.id).sort());
+    expect(mockExport).toHaveBeenCalled();
+    expect(mockExport.mock.calls[0][1]).toBeGreaterThan(0); // limit > 0
   });
 
+  it('exportItems issues multiple pages when the dataset is larger than the page size', async () => {
+    const allRows: StoredClipboardItem[] = Array.from({ length: 5 }, (_, i) => ({
+      id: `id-${i}`, type: 'text', content: `c${i}`, preview: `c${i}`,
+      createdAt: 1000 + i, favorite: false,
+    }));
+    let call = 0;
+    mockExport.mockImplementation(async () => {
+      const pageSize = 2;
+      const start = call * pageSize;
+      call++;
+      const slice = allRows.slice(start, start + pageSize);
+      const nextCursor = (start + pageSize) < allRows.length
+        ? { createdAt: slice[slice.length - 1].createdAt, id: slice[slice.length - 1].id }
+        : undefined;
+      return { items: slice, nextCursor };
+    });
+
+    const provider = new ClipboardSyncProvider();
+    const items = await provider.exportItems();
+    expect(items.map((i: any) => i.id).sort()).toEqual(allRows.map((r) => r.id).sort());
+    expect(call).toBe(3); // 2 + 2 + 1
+  });
+
+  it('getLocalSummary uses clipboardCount (no full list)', async () => {
+    mockCount.mockResolvedValue({ total: 12345, favorites: 99 });
+    const provider = new ClipboardSyncProvider();
+    const summary = await provider.getLocalSummary();
+    expect(summary.itemCount).toBe(12345);
+    expect(mockExport).not.toHaveBeenCalled();
+  });
+});
+
+// ── Metadata ──────────────────────────────────────────────────────────────────
+
+describe('ClipboardSyncProvider — metadata', () => {
   it('has correct metadata', () => {
+    const provider = new ClipboardSyncProvider();
     expect(provider.id).toBe('clipboard');
     expect(provider.syncTier).toBe('core');
     expect(provider.defaultEnabled).toBe(true);
     expect(provider.defaultConflictStrategy).toBe('merge');
     expect(provider.sensitiveFields).toEqual([]);
   });
+});
 
-  it('exportFull includes binary asset for image items', async () => {
+// ── exportFull ────────────────────────────────────────────────────────────────
+
+describe('ClipboardSyncProvider — exportFull', () => {
+  it('includes binary asset for image items', async () => {
+    mockExport.mockResolvedValueOnce({
+      items: [
+        { id: 'c1', type: 'text', content: 'Hello World', createdAt: 1000, favorite: false },
+        { id: 'c2', type: 'image', createdAt: 2000, favorite: false },
+      ],
+      nextCursor: undefined,
+    });
+
+    const provider = new ClipboardSyncProvider();
     const result = await provider.exportFull();
     expect(result.providerId).toBe('clipboard');
     expect(result.version).toBe(1);
@@ -59,7 +123,35 @@ describe('ClipboardSyncProvider', () => {
     expect(result.binaryAssets![0].archivePath).toBe('assets/clipboard/c2.png');
   });
 
-  it('exportForSync excludes image items', async () => {
+  it('preserves raw HTML content unchanged', async () => {
+    mockExport.mockResolvedValueOnce({
+      items: [
+        { id: 'h2', type: 'html', content: '<p>Hello <b>world</b></p>', createdAt: 1000, favorite: false },
+      ],
+      nextCursor: undefined,
+    });
+
+    const provider = new ClipboardSyncProvider();
+    const result = await provider.exportFull();
+    const data = result.data as any[];
+    expect(data[0].content).toBe('<p>Hello <b>world</b></p>');
+    expect(data[0].type).toBe('html');
+  });
+});
+
+// ── exportForSync ─────────────────────────────────────────────────────────────
+
+describe('ClipboardSyncProvider — exportForSync', () => {
+  it('excludes image items', async () => {
+    mockExport.mockResolvedValueOnce({
+      items: [
+        { id: 'c1', type: 'text', content: 'Hello World', createdAt: 1000, favorite: false },
+        { id: 'c2', type: 'image', createdAt: 2000, favorite: false },
+      ],
+      nextCursor: undefined,
+    });
+
+    const provider = new ClipboardSyncProvider();
     const result = await provider.exportForSync();
     const data = result.data as any[];
     expect(data.length).toBe(1);
@@ -67,7 +159,69 @@ describe('ClipboardSyncProvider', () => {
     expect(result.binaryAssets).toBeUndefined();
   });
 
-  it('preview calculates correct stats', async () => {
+  it('strips HTML tags from html items and downgrades type to text', async () => {
+    mockExport.mockResolvedValueOnce({
+      items: [
+        { id: 'h1', type: 'html', content: '<p>Hello <b>world</b></p>', preview: 'Hello world', createdAt: 1000, favorite: false },
+      ],
+      nextCursor: undefined,
+    });
+
+    const provider = new ClipboardSyncProvider();
+    const result = await provider.exportForSync();
+    const data = result.data as any[];
+    expect(data).toHaveLength(1);
+    expect(data[0].id).toBe('h1');
+    expect(data[0].content).toBe('Hello world');
+    expect(data[0].type).toBe('text');
+  });
+
+  it('strips RTF markup from rtf items and downgrades type to text', async () => {
+    mockExport.mockResolvedValueOnce({
+      items: [
+        { id: 'r1', type: 'rtf', content: '{\\rtf1 visible text}', preview: 'visible text', createdAt: 1000, favorite: false },
+      ],
+      nextCursor: undefined,
+    });
+
+    const provider = new ClipboardSyncProvider();
+    const result = await provider.exportForSync();
+    const data = result.data as any[];
+    expect(data).toHaveLength(1);
+    expect(data[0].id).toBe('r1');
+    expect(data[0].content).toBe('visible text');
+    expect(data[0].type).toBe('text');
+  });
+
+  it('leaves text items unchanged', async () => {
+    mockExport.mockResolvedValueOnce({
+      items: [
+        { id: 't1', type: 'text', content: 'plain text', createdAt: 1000, favorite: false },
+      ],
+      nextCursor: undefined,
+    });
+
+    const provider = new ClipboardSyncProvider();
+    const result = await provider.exportForSync();
+    const data = result.data as any[];
+    expect(data[0].content).toBe('plain text');
+    expect(data[0].type).toBe('text');
+  });
+});
+
+// ── preview ───────────────────────────────────────────────────────────────────
+
+describe('ClipboardSyncProvider — preview', () => {
+  it('calculates correct stats', async () => {
+    mockCount.mockResolvedValue({ total: 2, favorites: 0 });
+    mockExport.mockResolvedValueOnce({
+      items: [
+        { id: 'c1', type: 'text', content: 'Hello World', createdAt: 1000, favorite: false },
+        { id: 'c2', type: 'image', createdAt: 2000, favorite: false },
+      ],
+      nextCursor: undefined,
+    });
+
     const incoming: SyncProviderData = {
       providerId: 'clipboard',
       version: 1,
@@ -78,15 +232,20 @@ describe('ClipboardSyncProvider', () => {
       ],
     };
 
+    const provider = new ClipboardSyncProvider();
     const preview = await provider.preview(incoming);
     expect(preview.localCount).toBe(2);
     expect(preview.incomingCount).toBe(2);
-    expect(preview.conflicts).toBe(1); // c1 exists in both
-    expect(preview.newItems).toBe(1);  // c3 is new
+    expect(preview.conflicts).toBe(1);  // c1 exists in both
+    expect(preview.newItems).toBe(1);   // c3 is new
     expect(preview.removedItems).toBe(1); // c2 only in local
   });
+});
 
-  it('applyImport replace — calls clearHistory and addHistoryItem for each', async () => {
+// ── applyImport ───────────────────────────────────────────────────────────────
+
+describe('ClipboardSyncProvider — applyImport', () => {
+  it('replace — calls clearHistory and addHistoryItem for each', async () => {
     const { clipboardHistoryStore } = await import('../../clipboard/stores/clipboardHistoryStore.svelte');
     const incoming: SyncProviderData = {
       providerId: 'clipboard',
@@ -97,6 +256,7 @@ describe('ClipboardSyncProvider', () => {
       ],
     };
 
+    const provider = new ClipboardSyncProvider();
     const result = await provider.applyImport(incoming, 'replace');
     expect(clipboardHistoryStore.clearHistory).toHaveBeenCalled();
     expect(clipboardHistoryStore.addHistoryItem).toHaveBeenCalledTimes(1);
@@ -104,25 +264,34 @@ describe('ClipboardSyncProvider', () => {
     expect(result.itemsAdded).toBe(1);
   });
 
-  it('applyImport merge — adds only new items (by id)', async () => {
+  it('merge — adds only new items (by id)', async () => {
+    mockExport.mockResolvedValueOnce({
+      items: [
+        { id: 'c1', type: 'text', content: 'Hello World', createdAt: 1000, favorite: false },
+        { id: 'c2', type: 'image', createdAt: 2000, favorite: false },
+      ],
+      nextCursor: undefined,
+    });
+
     const { clipboardHistoryStore } = await import('../../clipboard/stores/clipboardHistoryStore.svelte');
     const incoming: SyncProviderData = {
       providerId: 'clipboard',
       version: 1,
       exportedAt: Date.now(),
       data: [
-        { id: 'c1', type: 'text', content: 'Hello World', createdAt: 1000, favorite: false }, // existing
-        { id: 'c3', type: 'text', content: 'New Item', createdAt: 3000, favorite: false },    // new
+        { id: 'c1', type: 'text', content: 'Hello World', createdAt: 1000, favorite: false },
+        { id: 'c3', type: 'text', content: 'New Item', createdAt: 3000, favorite: false },
       ],
     };
 
+    const provider = new ClipboardSyncProvider();
     const result = await provider.applyImport(incoming, 'merge');
     expect(clipboardHistoryStore.clearHistory).not.toHaveBeenCalled();
     expect(clipboardHistoryStore.addHistoryItem).toHaveBeenCalledTimes(1);
     expect(result.itemsAdded).toBe(1);
   });
 
-  it('applyImport skip — does nothing', async () => {
+  it('skip — does nothing', async () => {
     const { clipboardHistoryStore } = await import('../../clipboard/stores/clipboardHistoryStore.svelte');
     const incoming: SyncProviderData = {
       providerId: 'clipboard',
@@ -131,96 +300,28 @@ describe('ClipboardSyncProvider', () => {
       data: [{ id: 'c99', type: 'text', content: 'X', createdAt: 1, favorite: false }],
     };
 
+    const provider = new ClipboardSyncProvider();
     const result = await provider.applyImport(incoming, 'skip');
     expect(clipboardHistoryStore.clearHistory).not.toHaveBeenCalled();
     expect(clipboardHistoryStore.addHistoryItem).not.toHaveBeenCalled();
     expect(result.itemsAdded).toBe(0);
     expect(result.itemsUpdated).toBe(0);
   });
-
-  it('getLocalSummary returns correct count', async () => {
-    const summary = await provider.getLocalSummary();
-    expect(summary.itemCount).toBe(2);
-    expect(summary.label).toBe('2 clipboard item(s)');
-  });
 });
 
-describe('exportForSync() content stripping', () => {
-  let provider: ClipboardSyncProvider;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    provider = new ClipboardSyncProvider();
-  });
-
-  it('strips HTML tags from html items and downgrades type to text', async () => {
-    const { clipboardHistoryStore } = await import('../../clipboard/stores/clipboardHistoryStore.svelte');
-    vi.mocked(clipboardHistoryStore.getHistoryItems).mockResolvedValueOnce([
-      { id: 'h1', type: 'html' as any, content: '<p>Hello <b>world</b></p>', preview: 'Hello world', createdAt: 1000, favorite: false },
-    ]);
-
-    const result = await provider.exportForSync();
-    const data = result.data as any[];
-
-    expect(data).toHaveLength(1);
-    expect(data[0].id).toBe('h1');
-    expect(data[0].content).toBe('Hello world');
-    expect(data[0].type).toBe('text');
-  });
-
-  it('strips RTF markup from rtf items and downgrades type to text', async () => {
-    const { clipboardHistoryStore } = await import('../../clipboard/stores/clipboardHistoryStore.svelte');
-    vi.mocked(clipboardHistoryStore.getHistoryItems).mockResolvedValueOnce([
-      { id: 'r1', type: 'rtf' as any, content: '{\\rtf1 visible text}', preview: 'visible text', createdAt: 1000, favorite: false },
-    ]);
-
-    const result = await provider.exportForSync();
-    const data = result.data as any[];
-
-    expect(data).toHaveLength(1);
-    expect(data[0].id).toBe('r1');
-    expect(data[0].content).toBe('visible text');
-    expect(data[0].type).toBe('text');
-  });
-
-  it('leaves text items unchanged', async () => {
-    const { clipboardHistoryStore } = await import('../../clipboard/stores/clipboardHistoryStore.svelte');
-    vi.mocked(clipboardHistoryStore.getHistoryItems).mockResolvedValueOnce([
-      { id: 't1', type: 'text' as any, content: 'plain text', createdAt: 1000, favorite: false },
-    ]);
-
-    const result = await provider.exportForSync();
-    const data = result.data as any[];
-
-    expect(data[0].content).toBe('plain text');
-    expect(data[0].type).toBe('text');
-  });
-
-  it('exportFull preserves raw HTML content unchanged', async () => {
-    const { clipboardHistoryStore } = await import('../../clipboard/stores/clipboardHistoryStore.svelte');
-    vi.mocked(clipboardHistoryStore.getHistoryItems).mockResolvedValueOnce([
-      { id: 'h2', type: 'html' as any, content: '<p>Hello <b>world</b></p>', createdAt: 1000, favorite: false },
-    ]);
-
-    const result = await provider.exportFull();
-    const data = result.data as any[];
-
-    expect(data[0].content).toBe('<p>Hello <b>world</b></p>');
-    expect(data[0].type).toBe('html');
-  });
-});
+// ── Delta sync surface ────────────────────────────────────────────────────────
 
 describe('ClipboardSyncProvider — delta sync surface', () => {
-  let provider: ClipboardSyncProvider;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    provider = new ClipboardSyncProvider();
-  });
-
   it('exportItems returns one SyncItem per non-image clipboard entry', async () => {
-    // c2 is an image and is filtered out — image bytes go through the
-    // separate binary asset path, not the text-delta sync channel.
+    mockExport.mockResolvedValueOnce({
+      items: [
+        { id: 'c1', type: 'text', content: 'Hello World', createdAt: 1000, favorite: false },
+        { id: 'c2', type: 'image', createdAt: 2000, favorite: false },
+      ],
+      nextCursor: undefined,
+    });
+
+    const provider = new ClipboardSyncProvider();
     const items = await provider.exportItems();
     expect(items.length).toBe(1);
     expect(items[0].id).toBe('c1');
@@ -230,24 +331,33 @@ describe('ClipboardSyncProvider — delta sync surface', () => {
   it('applyItemUpsert routes to addHistoryItem with the content', async () => {
     const { clipboardHistoryStore } = await import('../../clipboard/stores/clipboardHistoryStore.svelte');
     const content = { id: 'c10', type: 'text', content: 'Hello', createdAt: 5000, favorite: false };
+    const provider = new ClipboardSyncProvider();
     await provider.applyItemUpsert({ id: 'c10', categoryId: 'clipboard', content });
     expect(clipboardHistoryStore.addHistoryItem).toHaveBeenCalledWith(content);
   });
 
   it('applyItemDelete routes to deleteHistoryItem with the id', async () => {
     const { clipboardHistoryStore } = await import('../../clipboard/stores/clipboardHistoryStore.svelte');
+    const provider = new ClipboardSyncProvider();
     await provider.applyItemDelete('c1');
     expect(clipboardHistoryStore.deleteHistoryItem).toHaveBeenCalledWith('c1');
   });
 
   it('subscribeToChanges fires when the store emits an upsert', async () => {
+    // Re-wire the subscribe mock to support __emit for this test
+    const { clipboardHistoryStore } = await import('../../clipboard/stores/clipboardHistoryStore.svelte');
+    type ChangeCb = (event: { type: 'upsert' | 'delete'; itemId: string }) => void;
+    const subscribers = new Set<ChangeCb>();
+    vi.mocked(clipboardHistoryStore.subscribe).mockImplementation((cb: ChangeCb) => {
+      subscribers.add(cb);
+      return () => subscribers.delete(cb);
+    });
+
+    const provider = new ClipboardSyncProvider();
     const events: Array<{ type: string; itemId: string; categoryId: string }> = [];
     const unsub = provider.subscribeToChanges((ev) => events.push(ev));
 
-    const { clipboardHistoryStore } = await import('../../clipboard/stores/clipboardHistoryStore.svelte');
-    (clipboardHistoryStore as unknown as {
-      __emit: (e: { type: 'upsert' | 'delete'; itemId: string }) => void;
-    }).__emit({ type: 'upsert', itemId: 'c5' });
+    subscribers.forEach((cb) => cb({ type: 'upsert', itemId: 'c5' }));
 
     expect(events.length).toBe(1);
     expect(events[0]).toEqual({ type: 'upsert', itemId: 'c5', categoryId: 'clipboard' });
@@ -255,13 +365,19 @@ describe('ClipboardSyncProvider — delta sync surface', () => {
   });
 
   it('subscribeToChanges propagates delete events', async () => {
+    const { clipboardHistoryStore } = await import('../../clipboard/stores/clipboardHistoryStore.svelte');
+    type ChangeCb = (event: { type: 'upsert' | 'delete'; itemId: string }) => void;
+    const subscribers = new Set<ChangeCb>();
+    vi.mocked(clipboardHistoryStore.subscribe).mockImplementation((cb: ChangeCb) => {
+      subscribers.add(cb);
+      return () => subscribers.delete(cb);
+    });
+
+    const provider = new ClipboardSyncProvider();
     const events: Array<{ type: string; itemId: string; categoryId: string }> = [];
     const unsub = provider.subscribeToChanges((ev) => events.push(ev));
 
-    const { clipboardHistoryStore } = await import('../../clipboard/stores/clipboardHistoryStore.svelte');
-    (clipboardHistoryStore as unknown as {
-      __emit: (e: { type: 'upsert' | 'delete'; itemId: string }) => void;
-    }).__emit({ type: 'delete', itemId: 'c1' });
+    subscribers.forEach((cb) => cb({ type: 'delete', itemId: 'c1' }));
 
     expect(events).toEqual([{ type: 'delete', itemId: 'c1', categoryId: 'clipboard' }]);
     unsub();

--- a/src/services/profile/providers/clipboardSyncProvider.ts
+++ b/src/services/profile/providers/clipboardSyncProvider.ts
@@ -1,3 +1,9 @@
+import {
+  clipboardExportForSync,
+  clipboardCount,
+  type StoredClipboardItem,
+  type ClipboardCursor,
+} from '../../../lib/ipc/commands';
 import { clipboardHistoryStore } from '../../clipboard/stores/clipboardHistoryStore.svelte';
 import { stripHtml, stripRtf, type ClipboardHistoryItem } from 'asyar-sdk/contracts';
 import type {
@@ -13,6 +19,19 @@ import type {
   Unsubscribe,
 } from '../types';
 
+const SYNC_PAGE_SIZE = 500;
+
+async function collectAllItems(): Promise<StoredClipboardItem[]> {
+  const all: StoredClipboardItem[] = [];
+  let cursor: ClipboardCursor | undefined;
+  do {
+    const page = await clipboardExportForSync(cursor, SYNC_PAGE_SIZE);
+    all.push(...page.items);
+    cursor = page.nextCursor;
+  } while (cursor);
+  return all;
+}
+
 export class ClipboardSyncProvider implements ISyncProvider {
   readonly id = 'clipboard';
   readonly displayName = 'Clipboard History';
@@ -23,62 +42,59 @@ export class ClipboardSyncProvider implements ISyncProvider {
   readonly sensitiveFields: string[] = [];
 
   async exportFull(): Promise<SyncProviderData> {
-    const items = await clipboardHistoryStore.getHistoryItems();
-    const binaryAssets: BinaryAsset[] = [];
-
-    for (const item of items) {
-      if (item.type === 'image') {
-        binaryAssets.push({
-          id: item.id,
-          filename: `${item.id}.png`,
-          mimeType: 'image/png',
-          archivePath: `assets/clipboard/${item.id}.png`,
-        });
-      }
-    }
-
+    const items = await collectAllItems();
+    const binaryAssets: BinaryAsset[] = items
+      .filter((i) => i.type === 'image')
+      .map((i) => ({
+        id: i.id,
+        filename: `${i.id}.png`,
+        mimeType: 'image/png',
+        archivePath: `assets/clipboard/${i.id}.png`,
+      }));
     return {
       providerId: this.id,
       version: 1,
       exportedAt: Date.now(),
-      data: items,
+      data: items as unknown as ClipboardHistoryItem[],
       binaryAssets: binaryAssets.length > 0 ? binaryAssets : undefined,
     };
   }
 
   async exportForSync(): Promise<SyncProviderData> {
-    const items = await clipboardHistoryStore.getHistoryItems();
+    const items = await collectAllItems();
     const exported = items
-      .filter(item => item.type !== 'image')
-      .map(item => {
-        if (item.type === 'html' && item.content) {
-          return { ...item, type: 'text' as ClipboardHistoryItem['type'], content: stripHtml(item.content) };
+      .filter((i) => i.type !== 'image')
+      .map((i) => {
+        if (i.type === 'html' && i.content) {
+          return { ...i, type: 'text' as const, content: stripHtml(i.content) };
         }
-        if (item.type === 'rtf' && item.content) {
-          return { ...item, type: 'text' as ClipboardHistoryItem['type'], content: stripRtf(item.content) };
+        if (i.type === 'rtf' && i.content) {
+          return { ...i, type: 'text' as const, content: stripRtf(i.content) };
         }
-        return item;
+        return i;
       });
     return {
       providerId: this.id,
       version: 1,
       exportedAt: Date.now(),
-      data: exported,
+      data: exported as unknown as ClipboardHistoryItem[],
     };
   }
 
   async preview(incoming: SyncProviderData): Promise<ImportPreview> {
-    const local = await clipboardHistoryStore.getHistoryItems();
+    const summary = await clipboardCount();
+    const localCount = summary.total;
     const incomingItems = incoming.data as ClipboardHistoryItem[];
-    const localIds = new Set(local.map(i => i.id));
-    const incomingIds = new Set(incomingItems.map(i => i.id));
+    const incomingIds = new Set(incomingItems.map((i) => i.id));
+    const local = await collectAllItems();
+    const localIds = new Set(local.map((i) => i.id));
 
     return {
-      localCount: local.length,
+      localCount,
       incomingCount: incomingItems.length,
-      conflicts: incomingItems.filter(i => localIds.has(i.id)).length,
-      newItems: incomingItems.filter(i => !localIds.has(i.id)).length,
-      removedItems: local.filter(i => !incomingIds.has(i.id)).length,
+      conflicts: incomingItems.filter((i) => localIds.has(i.id)).length,
+      newItems: incomingItems.filter((i) => !localIds.has(i.id)).length,
+      removedItems: local.filter((i) => !incomingIds.has(i.id)).length,
     };
   }
 
@@ -97,36 +113,28 @@ export class ClipboardSyncProvider implements ISyncProvider {
       return { success: true, itemsAdded: incomingItems.length, itemsUpdated: 0, itemsRemoved: 0, warnings: [] };
     }
 
-    // merge: dedup by id, add new items only
-    const local = await clipboardHistoryStore.getHistoryItems();
-    const localIds = new Set(local.map(i => i.id));
+    const local = await collectAllItems();
+    const localIds = new Set(local.map((i) => i.id));
     let added = 0;
-
     for (const item of incomingItems) {
       if (!localIds.has(item.id)) {
         await clipboardHistoryStore.addHistoryItem(item);
         added++;
       }
     }
-
     return { success: true, itemsAdded: added, itemsUpdated: 0, itemsRemoved: 0, warnings: [] };
   }
 
   async getLocalSummary(): Promise<DataSummary> {
-    const items = await clipboardHistoryStore.getHistoryItems();
-    return { itemCount: items.length, label: `${items.length} clipboard item(s)` };
+    const c = await clipboardCount();
+    return { itemCount: c.total, label: `${c.total} clipboard item(s)` };
   }
 
-  // ── Delta sync surface ──────────────────────────────────────────────────
-  // Collection: one SyncItem per stored clipboard entry, keyed by item.id.
-
   async exportItems(): Promise<SyncItem[]> {
-    const items = await clipboardHistoryStore.getHistoryItems();
-    // Skip images — they require binary asset transport, which is out of
-    // scope for the text-only delta sync channel.
+    const items = await collectAllItems();
     return items
-      .filter((item) => item.type !== 'image')
-      .map((item) => ({ id: item.id, categoryId: this.id, content: item }));
+      .filter((i) => i.type !== 'image')
+      .map((i) => ({ id: i.id, categoryId: this.id, content: i as unknown as ClipboardHistoryItem }));
   }
 
   async applyItemUpsert(item: SyncItem): Promise<void> {


### PR DESCRIPTION
Replaces the 1,000-item full-list model. The launcher now loads only
the visible window via cursor pagination, searches via an in-memory
FTS5 index rebuilt at startup, and decrypts content lazily on paste.
HMAC-SHA256 content_hash gives O(1) dedup. AES-GCM encryption at
rest preserved.

Perf at 50k rows: list_initial 0.23 ms, list_older 0.37 ms,
search 9.22 ms, FTS rebuild 893 ms.