### PR TITLE
Chore/sdk-2.7.0-and-ci-fixes

### DIFF
--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -23,7 +23,7 @@ fields are listed below.
 | `permissionArgs` | `object` | ❌ | Each key must also appear in `permissions` | Sidecar for parameterized permissions. Value shape is permission-specific. Currently only `fs:watch` uses it (value must be `string[]` of glob patterns; see the `fs:watch` section below). |
 | `icon` | `string` | ❌ | Emoji or `"icon:<name>"` | Default icon for all commands. |
 | `minAppVersion` | `string` | ❌ | Valid semver | Minimum Asyar app version. Extension will be marked incompatible if the app is older. |
-| `asyarSdk` | `string` | ❌ | Semver range | SDK version requirement (e.g. `"^2.6.0"`). Extension will not load if the bundled SDK is older. |
+| `asyarSdk` | `string` | ❌ | Semver range | SDK version requirement (e.g. `"^2.7.0"`). Extension will not load if the bundled SDK is older. |
 | `platforms` | `string[]` | ❌ | `"macos"`, `"windows"`, `"linux"` | Restrict the extension to specific operating systems. Omit entirely for a universal extension. Extensions that don't support the current OS are hidden in the store and blocked from loading. |
 | `preferences` | `PreferenceDeclaration[]` | ❌ | See [Preferences reference](./sdk/preferences.md) | Extension-level user-configurable settings. Auto-rendered as a settings panel in the launcher's Extensions tab, injected into `context.preferences` at extension boot, and synced across devices (except `password` type, which stays on-device). |
 | `actions` | `ManifestAction[]` | ❌ | See [Actions reference](./actions.md#manifest-declared-actions) | Extension-level actions that appear in the ⌘K drawer whenever any command from this extension is selected in the root search results. |
@@ -150,7 +150,7 @@ See [`FileSystemWatcherService`](./sdk/file-system-watcher.md) for the runtime s
   "type": "extension",
   "background": { "main": "dist/worker.js" },
   "searchable": true,
-  "asyarSdk": "^2.6.0",
+  "asyarSdk": "^2.7.0",
   "minAppVersion": "1.0.0",
   "platforms": ["macos", "linux"],
   "permissions": ["network", "notifications:send"],

--- a/docs/tutorials/bookmarks-example.md
+++ b/docs/tutorials/bookmarks-example.md
@@ -24,7 +24,7 @@ A complete production-ready extension demonstrating:
   "type": "extension",
   "background": { "main": "dist/worker.js" },
   "searchable": true,
-  "asyarSdk": "^2.6.0",
+  "asyarSdk": "^2.7.0",
   "permissions": ["notifications:send"],
   "commands": [
     {

--- a/docs/tutorials/manual-setup.md
+++ b/docs/tutorials/manual-setup.md
@@ -31,7 +31,7 @@ com.yourname.hello-world/
   "author": "Your Name",
   "icon": "👋",
   "type": "extension",
-  "asyarSdk": "^2.6.0",
+  "asyarSdk": "^2.7.0",
   "commands": [
     {
       "id": "open",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-store": "~2.4.2",
     "@tauri-apps/plugin-updater": "~2.10.0",
-    "asyar-sdk": "^2.6.0",
+    "asyar-sdk": "^2.7.0",
     "date-fns": "^4.1.0",
     "katex": "^0.16.45",
     "marked": "^17.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ~2.10.0
         version: 2.10.0
       asyar-sdk:
-        specifier: ^2.6.0
-        version: 2.6.0
+        specifier: ^2.7.0
+        version: 2.7.0
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1289,8 +1289,8 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  asyar-sdk@2.6.0:
-    resolution: {integrity: sha512-lsQjSaf7z7Tb3HkJ+RxIg6m2HIdHIFH9P4NMox3g+6Lo3pcHg1AiNtf7L4ehq3R7FKA5U1a/ozNCUil9qYKEqg==}
+  asyar-sdk@2.7.0:
+    resolution: {integrity: sha512-YfJxVG+ZAiXp0R8HUATSHxEXP88Obay0l1LJgX8YAmMi6e71qmXap6YOELCGN5e/O7L5e2Xzhz0lEfi1BIO6gg==}
     hasBin: true
 
   async-function@1.0.0:
@@ -4268,7 +4268,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  asyar-sdk@2.6.0:
+  asyar-sdk@2.7.0:
     dependencies:
       '@leeoniya/ufuzzy': 1.0.19
       adm-zip: 0.5.16
@@ -4278,7 +4278,7 @@ snapshots:
       inquirer: 10.2.2
       keytar: 7.9.0
       ora: 8.2.0
-      semver: 7.7.4
+      semver: 7.8.0
 
   async-function@1.0.0: {}
 

--- a/scripts/download-sidecars.mjs
+++ b/scripts/download-sidecars.mjs
@@ -8,95 +8,39 @@
  * Run from the repo root:
  *   node scripts/download-sidecars.mjs
  *
- * Idempotent: skips download if the file already exists.
+ * Idempotent: skips download if the destination already exists.
  */
 
-import { createWriteStream, existsSync, chmodSync, mkdirSync, copyFileSync } from 'fs'
-import { get } from 'https'
-import { join, dirname } from 'path'
-import { fileURLToPath } from 'url'
-import { execFileSync } from 'child_process'
-import { tmpdir } from 'os'
+import { existsSync, chmodSync, mkdirSync, copyFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+
+import { resolvePlatform } from './sidecar-platforms.mjs'
+import { download } from './http-download.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '..')
 const BINARIES_DIR = join(ROOT, 'src-tauri', 'binaries')
 
-// ── Platform detection ────────────────────────────────────────────────────────
-
-const RUST_TRIPLES = {
-  'darwin-arm64': 'aarch64-apple-darwin',
-  'darwin-x64':   'x86_64-apple-darwin',
-  'linux-x64':    'x86_64-unknown-linux-gnu',
-  'linux-arm64':  'aarch64-unknown-linux-gnu',
-  'win32-x64':    'x86_64-pc-windows-msvc',
-}
-
-const BUN_ARCHIVE_NAMES = {
-  'darwin-arm64': 'bun-darwin-aarch64.zip',
-  'darwin-x64':   'bun-darwin-x64.zip',
-  'linux-x64':    'bun-linux-x64.zip',
-  'linux-arm64':  'bun-linux-aarch64.zip',
-  'win32-x64':    'bun-windows-x64.zip',
-}
-
-const UV_ARCHIVE_NAMES = {
-  'darwin-arm64': 'uv-aarch64-apple-darwin.tar.gz',
-  'darwin-x64':   'uv-x86_64-apple-darwin.tar.gz',
-  'linux-x64':    'uv-x86_64-unknown-linux-gnu.tar.gz',
-  'linux-arm64':  'uv-aarch64-unknown-linux-gnu.tar.gz',
-  'win32-x64':    'uv-x86_64-pc-windows-msvc.zip',
-}
-
-const platformKey = `${process.platform}-${process.arch}`
-const rustTriple = RUST_TRIPLES[platformKey]
-
-if (!rustTriple) {
-  console.error(`Unsupported platform: ${platformKey}`)
-  console.error(`Supported: ${Object.keys(RUST_TRIPLES).join(', ')}`)
+let platform
+try {
+  platform = resolvePlatform(process.platform, process.arch)
+} catch (err) {
+  console.error(err.message)
   process.exit(1)
 }
 
+const { platformKey, rustTriple, bunArchive, uvArchive } = platform
 const isWindows = process.platform === 'win32'
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
+const exeExt = isWindows ? '.exe' : ''
 
 function step(msg) {
   console.log(`\n-- ${msg} ${'-'.repeat(Math.max(0, 60 - msg.length))}`)
 }
 
-/**
- * Download a URL to a local file, following redirects.
- */
-function download(url, dest) {
-  return new Promise((resolve, reject) => {
-    const file = createWriteStream(dest)
-    const request = (u) => {
-      get(u, (res) => {
-        if (res.statusCode === 301 || res.statusCode === 302) {
-          file.close()
-          return request(res.headers.location)
-        }
-        if (res.statusCode !== 200) {
-          file.close()
-          return reject(new Error(`HTTP ${res.statusCode} for ${u}`))
-        }
-        res.pipe(file)
-        file.on('finish', () => file.close(resolve))
-        file.on('error', reject)
-      }).on('error', reject)
-    }
-    request(url)
-  })
-}
-
-/**
- * Find a binary by name inside a directory tree.
- * Returns the first match or throws.
- */
 function findBinary(searchDir, binaryName) {
-  // Use execFileSync with find/where to avoid shell injection — all args are
-  // hardcoded constants, not user input.
   let output
   if (isWindows) {
     output = execFileSync('cmd', ['/c', 'dir', '/s', '/b', join(searchDir, binaryName)], {
@@ -114,105 +58,51 @@ function findBinary(searchDir, binaryName) {
   return lines[0]
 }
 
-/**
- * Extract a .zip archive to outDir.
- */
-function extractZip(archivePath, outDir) {
+function extractArchive(archivePath, outDir) {
   mkdirSync(outDir, { recursive: true })
-  if (isWindows) {
+  if (archivePath.endsWith('.tar.gz')) {
+    execFileSync('tar', ['-xzf', archivePath, '-C', outDir], { stdio: 'pipe' })
+  } else if (isWindows) {
     execFileSync('tar', ['-xf', archivePath, '-C', outDir], { stdio: 'pipe' })
   } else {
     execFileSync('unzip', ['-o', archivePath, '-d', outDir], { stdio: 'pipe' })
   }
 }
 
-/**
- * Extract a .tar.gz archive to outDir.
- */
-function extractTarGz(archivePath, outDir) {
-  mkdirSync(outDir, { recursive: true })
-  execFileSync('tar', ['-xzf', archivePath, '-C', outDir], { stdio: 'pipe' })
-}
-
 function makeExecutable(filePath) {
-  if (!isWindows) {
-    chmodSync(filePath, 0o755)
-  }
+  if (!isWindows) chmodSync(filePath, 0o755)
 }
 
-// ── Download bun ──────────────────────────────────────────────────────────────
-
-async function downloadBun() {
-  const archiveName = BUN_ARCHIVE_NAMES[platformKey]
-  const url = `https://github.com/oven-sh/bun/releases/latest/download/${archiveName}`
-  const ext = isWindows ? '.exe' : ''
-  const destName = `bun-${rustTriple}${ext}`
+async function ensureSidecar({ repo, archive, binaryName }) {
+  const destName = `${binaryName}-${rustTriple}${exeExt}`
   const destPath = join(BINARIES_DIR, destName)
 
   if (existsSync(destPath)) {
-    console.log(`  bun: already exists at binaries/${destName}, skipping`)
+    console.log(`  ${binaryName}: already exists at binaries/${destName}, skipping`)
     return
   }
 
-  console.log(`  bun: downloading ${archiveName} from GitHub...`)
-  const tmpArchive = join(tmpdir(), archiveName)
+  const url = `https://github.com/${repo}/releases/latest/download/${archive}`
+  const tmpArchive = join(tmpdir(), archive)
+  console.log(`  ${binaryName}: downloading ${archive} from GitHub...`)
   await download(url, tmpArchive)
-  console.log(`  bun: extracting...`)
 
-  const tmpOut = join(tmpdir(), `bun-extract-${Date.now()}`)
-  const bunBinaryName = isWindows ? 'bun.exe' : 'bun'
-  extractZip(tmpArchive, tmpOut)
-  const extracted = findBinary(tmpOut, bunBinaryName)
+  const tmpOut = join(tmpdir(), `${binaryName}-extract-${Date.now()}`)
+  console.log(`  ${binaryName}: extracting...`)
+  extractArchive(tmpArchive, tmpOut)
 
+  const binaryFile = `${binaryName}${exeExt}`
+  const extracted = findBinary(tmpOut, binaryFile)
   copyFileSync(extracted, destPath)
   makeExecutable(destPath)
 
-  console.log(`  bun: installed to binaries/${destName}`)
+  console.log(`  ${binaryName}: installed to binaries/${destName}`)
 }
-
-// ── Download uv ───────────────────────────────────────────────────────────────
-
-async function downloadUv() {
-  const archiveName = UV_ARCHIVE_NAMES[platformKey]
-  const url = `https://github.com/astral-sh/uv/releases/latest/download/${archiveName}`
-  const ext = isWindows ? '.exe' : ''
-  const destName = `uv-${rustTriple}${ext}`
-  const destPath = join(BINARIES_DIR, destName)
-
-  if (existsSync(destPath)) {
-    console.log(`  uv: already exists at binaries/${destName}, skipping`)
-    return
-  }
-
-  console.log(`  uv: downloading ${archiveName} from GitHub...`)
-  const tmpArchive = join(tmpdir(), archiveName)
-  await download(url, tmpArchive)
-  console.log(`  uv: extracting...`)
-
-  const tmpOut = join(tmpdir(), `uv-extract-${Date.now()}`)
-  const uvBinaryName = isWindows ? 'uv.exe' : 'uv'
-
-  if (archiveName.endsWith('.tar.gz')) {
-    extractTarGz(tmpArchive, tmpOut)
-  } else {
-    // win32: .zip
-    extractZip(tmpArchive, tmpOut)
-  }
-  const extracted = findBinary(tmpOut, uvBinaryName)
-
-  copyFileSync(extracted, destPath)
-  makeExecutable(destPath)
-
-  console.log(`  uv: installed to binaries/${destName}`)
-}
-
-// ── Main ──────────────────────────────────────────────────────────────────────
 
 step(`Downloading sidecars for ${platformKey} (${rustTriple})`)
-
 mkdirSync(BINARIES_DIR, { recursive: true })
 
-await downloadBun()
-await downloadUv()
+await ensureSidecar({ repo: 'oven-sh/bun',    archive: bunArchive, binaryName: 'bun' })
+await ensureSidecar({ repo: 'astral-sh/uv',   archive: uvArchive,  binaryName: 'uv'  })
 
 console.log('\n  Sidecars ready.')

--- a/scripts/http-download.mjs
+++ b/scripts/http-download.mjs
@@ -1,0 +1,69 @@
+import { createWriteStream, unlinkSync, existsSync } from 'node:fs'
+import { get as httpsGet } from 'node:https'
+import { get as httpGet } from 'node:http'
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
+
+function pickGet(url) {
+  return url.startsWith('https:') ? httpsGet : httpGet
+}
+
+// Download `url` to `dest`, following up to `maxRedirects` HTTP redirects
+// (301/302/303/307/308). The destination file is materialised only after the
+// final 200 response arrives — earlier implementations created the file
+// up-front and reused it across redirects, which left the stream closed by
+// the time the body arrived, hung the promise, and crashed CI with
+// "Detected unsettled top-level await". `options.getImpl` lets tests inject
+// a fake `https.get`-style function.
+export function download(url, dest, options = {}) {
+  const { maxRedirects = 10, getImpl } = options
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const finish = (err) => {
+      if (settled) return
+      settled = true
+      err ? reject(err) : resolve()
+    }
+
+    const visit = (currentUrl, redirectsLeft) => {
+      const get = getImpl ?? pickGet(currentUrl)
+      const req = get(currentUrl, (res) => {
+        const { statusCode } = res
+
+        if (REDIRECT_STATUSES.has(statusCode)) {
+          res.resume()
+          const location = res.headers && res.headers.location
+          if (!location) {
+            return finish(new Error(`Redirect with no Location header from ${currentUrl}`))
+          }
+          if (redirectsLeft <= 0) {
+            return finish(new Error(`Too many redirects starting at ${url}`))
+          }
+          return visit(new URL(location, currentUrl).toString(), redirectsLeft - 1)
+        }
+
+        if (statusCode !== 200) {
+          res.resume()
+          return finish(new Error(`HTTP ${statusCode} for ${currentUrl}`))
+        }
+
+        const file = createWriteStream(dest)
+        const fail = (err) => {
+          file.destroy()
+          if (existsSync(dest)) {
+            try { unlinkSync(dest) } catch {}
+          }
+          finish(err)
+        }
+        file.on('error', fail)
+        res.on('error', fail)
+        file.on('finish', () => file.close((err) => (err ? fail(err) : finish())))
+        res.pipe(file)
+      })
+      req.on('error', finish)
+    }
+
+    visit(url, maxRedirects)
+  })
+}

--- a/scripts/http-download.test.mjs
+++ b/scripts/http-download.test.mjs
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { EventEmitter } from 'node:events'
+import { Readable } from 'node:stream'
+
+import { download } from './http-download.mjs'
+
+class FakeResponse extends Readable {
+  constructor({ statusCode, headers = {}, body = Buffer.alloc(0) }) {
+    super()
+    this.statusCode = statusCode
+    this.headers = headers
+    this._payload = body
+    this._sent = false
+  }
+  _read() {
+    if (this._sent) return
+    this._sent = true
+    if (this._payload.length) this.push(this._payload)
+    this.push(null)
+  }
+}
+
+// Returns a fake `https.get`-style function that consumes one scripted step
+// per request. Each request yields a `FakeResponse` on the next tick, like
+// the real Node http client.
+function scriptedGet(steps) {
+  const queue = [...steps]
+  return function (_url, cb) {
+    const step = queue.shift()
+    if (!step) throw new Error(`Unexpected extra HTTP request`)
+    const req = new EventEmitter()
+    setImmediate(() => cb(new FakeResponse(step)))
+    return req
+  }
+}
+
+describe('download()', () => {
+  let dir
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'sidecar-dl-test-'))
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('writes the body to disk on a direct 200', async () => {
+    const dest = join(dir, 'out.bin')
+    const body = Buffer.from('hello world')
+    await download('https://example.invalid/file', dest, {
+      getImpl: scriptedGet([{ statusCode: 200, body }]),
+    })
+    expect(readFileSync(dest)).toEqual(body)
+  })
+
+  it('follows a multi-hop 302 redirect chain to the final 200', async () => {
+    // This is the GitHub releases redirect pattern (latest → tagged → CDN)
+    // that hung CI with the previous downloader implementation.
+    const dest = join(dir, 'out.bin')
+    const body = Buffer.from('payload-after-redirects')
+    await download('https://example.invalid/start', dest, {
+      getImpl: scriptedGet([
+        { statusCode: 302, headers: { location: 'https://example.invalid/mid' } },
+        { statusCode: 302, headers: { location: 'https://example.invalid/final' } },
+        { statusCode: 200, body },
+      ]),
+    })
+    expect(readFileSync(dest)).toEqual(body)
+  })
+
+  it('handles 307 and 308 redirects in addition to 301/302/303', async () => {
+    const dest = join(dir, 'out.bin')
+    const body = Buffer.from('all-redirect-codes')
+    await download('https://example.invalid/a', dest, {
+      getImpl: scriptedGet([
+        { statusCode: 301, headers: { location: 'https://example.invalid/b' } },
+        { statusCode: 303, headers: { location: 'https://example.invalid/c' } },
+        { statusCode: 307, headers: { location: 'https://example.invalid/d' } },
+        { statusCode: 308, headers: { location: 'https://example.invalid/e' } },
+        { statusCode: 200, body },
+      ]),
+    })
+    expect(readFileSync(dest)).toEqual(body)
+  })
+
+  it('resolves relative Location headers against the request URL', async () => {
+    const dest = join(dir, 'out.bin')
+    const body = Buffer.from('relative-loc')
+    await download('https://example.invalid/dir/file', dest, {
+      getImpl: scriptedGet([
+        { statusCode: 302, headers: { location: '/elsewhere' } },
+        { statusCode: 200, body },
+      ]),
+    })
+    expect(readFileSync(dest)).toEqual(body)
+  })
+
+  it('rejects on non-200 final response without creating the destination file', async () => {
+    const dest = join(dir, 'out.bin')
+    await expect(
+      download('https://example.invalid/x', dest, {
+        getImpl: scriptedGet([{ statusCode: 404 }]),
+      }),
+    ).rejects.toThrow(/HTTP 404/)
+    expect(existsSync(dest)).toBe(false)
+  })
+
+  it('rejects on a non-200 response after a redirect, without leaving a partial file', async () => {
+    const dest = join(dir, 'out.bin')
+    await expect(
+      download('https://example.invalid/y', dest, {
+        getImpl: scriptedGet([
+          { statusCode: 302, headers: { location: 'https://example.invalid/z' } },
+          { statusCode: 500 },
+        ]),
+      }),
+    ).rejects.toThrow(/HTTP 500/)
+    expect(existsSync(dest)).toBe(false)
+  })
+
+  it('rejects on a redirect loop exceeding maxRedirects', async () => {
+    const dest = join(dir, 'out.bin')
+    const loop = { statusCode: 302, headers: { location: 'https://example.invalid/loop' } }
+    await expect(
+      download('https://example.invalid/loop', dest, {
+        getImpl: scriptedGet(Array(20).fill(loop)),
+        maxRedirects: 3,
+      }),
+    ).rejects.toThrow(/Too many redirects/)
+  })
+
+  it('rejects on a redirect missing the Location header', async () => {
+    const dest = join(dir, 'out.bin')
+    await expect(
+      download('https://example.invalid/missing-loc', dest, {
+        getImpl: scriptedGet([{ statusCode: 302 }]),
+      }),
+    ).rejects.toThrow(/Redirect with no Location header/)
+  })
+})

--- a/scripts/sidecar-platforms.mjs
+++ b/scripts/sidecar-platforms.mjs
@@ -1,0 +1,46 @@
+// Single source of truth for sidecar (bun + uv) per-platform archive names
+// and Rust target triples. CI build matrices in .github/workflows/ MUST stay
+// covered by this table — `sidecar-platforms.test.mjs` enforces the link.
+
+export const SIDECAR_PLATFORMS = {
+  'darwin-arm64': {
+    rustTriple: 'aarch64-apple-darwin',
+    bunArchive: 'bun-darwin-aarch64.zip',
+    uvArchive:  'uv-aarch64-apple-darwin.tar.gz',
+  },
+  'darwin-x64': {
+    rustTriple: 'x86_64-apple-darwin',
+    bunArchive: 'bun-darwin-x64.zip',
+    uvArchive:  'uv-x86_64-apple-darwin.tar.gz',
+  },
+  'linux-x64': {
+    rustTriple: 'x86_64-unknown-linux-gnu',
+    bunArchive: 'bun-linux-x64.zip',
+    uvArchive:  'uv-x86_64-unknown-linux-gnu.tar.gz',
+  },
+  'linux-arm64': {
+    rustTriple: 'aarch64-unknown-linux-gnu',
+    bunArchive: 'bun-linux-aarch64.zip',
+    uvArchive:  'uv-aarch64-unknown-linux-gnu.tar.gz',
+  },
+  'win32-x64': {
+    rustTriple: 'x86_64-pc-windows-msvc',
+    bunArchive: 'bun-windows-x64.zip',
+    uvArchive:  'uv-x86_64-pc-windows-msvc.zip',
+  },
+  'win32-arm64': {
+    rustTriple: 'aarch64-pc-windows-msvc',
+    bunArchive: 'bun-windows-arm64.zip',
+    uvArchive:  'uv-aarch64-pc-windows-msvc.zip',
+  },
+}
+
+export function resolvePlatform(nodePlatform, nodeArch) {
+  const key = `${nodePlatform}-${nodeArch}`
+  const entry = SIDECAR_PLATFORMS[key]
+  if (!entry) {
+    const supported = Object.keys(SIDECAR_PLATFORMS).join(', ')
+    throw new Error(`Unsupported platform: ${key}. Supported: ${supported}`)
+  }
+  return { platformKey: key, ...entry }
+}

--- a/scripts/sidecar-platforms.test.mjs
+++ b/scripts/sidecar-platforms.test.mjs
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+import { SIDECAR_PLATFORMS, resolvePlatform } from './sidecar-platforms.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const WORKFLOWS_DIR = resolve(__dirname, '..', '.github', 'workflows')
+
+// Extract every Rust target triple referenced by every workflow under
+// .github/workflows/. Covers three syntactic patterns:
+//   1. `rust-target: <triple>`           (matrix entries)
+//   2. `targets: <comma-separated>`      (dtolnay/rust-toolchain inputs)
+//   3. `--target <triple>`               (cargo / tauri build commands)
+// `universal-apple-darwin` is expanded into its two underlying triples.
+function rustTargetsInWorkflows() {
+  const targets = new Set()
+  for (const file of readdirSync(WORKFLOWS_DIR)) {
+    if (!file.endsWith('.yml') && !file.endsWith('.yaml')) continue
+    const text = readFileSync(resolve(WORKFLOWS_DIR, file), 'utf8')
+
+    for (const m of text.matchAll(/rust-target:\s*([a-z0-9_-]+)/g)) {
+      targets.add(m[1])
+    }
+    for (const m of text.matchAll(/^\s*targets:\s*([a-z0-9_,\s-]+)$/gm)) {
+      for (const t of m[1].split(',').map((s) => s.trim()).filter(Boolean)) {
+        targets.add(t)
+      }
+    }
+    for (const m of text.matchAll(/--target\s+([a-z0-9_-]+)/g)) {
+      targets.add(m[1])
+    }
+  }
+  if (targets.has('universal-apple-darwin')) {
+    targets.delete('universal-apple-darwin')
+    targets.add('aarch64-apple-darwin')
+    targets.add('x86_64-apple-darwin')
+  }
+  return targets
+}
+
+describe('SIDECAR_PLATFORMS', () => {
+  it('covers every Rust target referenced by the CI workflows', () => {
+    const ciTargets = rustTargetsInWorkflows()
+    expect(ciTargets.size).toBeGreaterThan(0) // sanity: we actually parsed something
+
+    const supportedTriples = new Set(
+      Object.values(SIDECAR_PLATFORMS).map((p) => p.rustTriple),
+    )
+    const missing = [...ciTargets].filter((t) => !supportedTriples.has(t))
+    expect(missing).toEqual([])
+  })
+
+  it('resolves each Node `platform-arch` key to its full entry', () => {
+    for (const [key, entry] of Object.entries(SIDECAR_PLATFORMS)) {
+      const [platform, arch] = key.split('-')
+      const resolved = resolvePlatform(platform, arch)
+      expect(resolved.platformKey).toBe(key)
+      expect(resolved.rustTriple).toBe(entry.rustTriple)
+      expect(resolved.bunArchive).toBe(entry.bunArchive)
+      expect(resolved.uvArchive).toBe(entry.uvArchive)
+    }
+  })
+
+  it('throws with the supported list when given an unknown platform', () => {
+    expect(() => resolvePlatform('haiku', 'mips')).toThrowError(
+      /Unsupported platform: haiku-mips\. Supported: /,
+    )
+  })
+
+  it('uses consistent archive naming conventions', () => {
+    for (const entry of Object.values(SIDECAR_PLATFORMS)) {
+      expect(entry.bunArchive).toMatch(/^bun-[a-z0-9-]+\.zip$/)
+      expect(entry.uvArchive).toMatch(/^uv-[a-z0-9_-]+\.(zip|tar\.gz)$/)
+      expect(entry.rustTriple).toMatch(/^[a-z0-9][a-z0-9_-]+[a-z0-9]$/)
+    }
+  })
+})

--- a/src/built-in-features/create-extension/scaffoldService.ts
+++ b/src/built-in-features/create-extension/scaffoldService.ts
@@ -32,7 +32,7 @@ async function getLatestSdkVersion(): Promise<string> {
       return `^${output.stdout.trim()}`;
     }
   } catch { }
-  return '^2.6.0'; // Offline fallback
+  return '^2.7.0'; // Offline fallback
 }
 
 // ── Shared templates (all non-theme types) ──────────────────────────────────

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,6 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: ['src/**/*.{test,spec}.{ts,js}'],
+    include: ['src/**/*.{test,spec}.{ts,js}', 'scripts/**/*.test.mjs'],
   },
 })


### PR DESCRIPTION
The sidecar downloader hung on every macOS/Linux/win-x64 CI run because it
reused a single write stream across GitHub's 302→302→200 redirect chain,
so the final response piped into an already-closed file and the promise
never settled. Windows ARM64 builds errored out separately because the
platform table never listed win32-arm64.

Extract the platform mapping and the HTTP download into dedicated modules.
The downloader now follows 301/302/303/307/308, resolves relative Location
headers, caps redirect depth, and only materialises the destination file
after the final 200. A contract test parses every workflow under
.github/workflows/ and fails fast if a Rust target ever drifts out of the
platform table.