### PR TITLE
chore(deps): bump rand to 0.10

### DIFF
--- a/asyar-launcher/src-tauri/Cargo.lock
+++ b/asyar-launcher/src-tauri/Cargo.lock
@@ -38,7 +38,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -171,7 +171,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -233,7 +233,7 @@ dependencies = [
  "png 0.17.16",
  "procfs",
  "proptest",
- "rand 0.9.3",
+ "rand 0.10.1",
  "rdev",
  "regex",
  "reqwest 0.12.28",
@@ -882,6 +882,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,6 +1237,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -2316,6 +2336,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -4618,7 +4639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4966,6 +4987,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5021,6 +5053,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -5894,7 +5932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5905,7 +5943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/asyar-launcher/src-tauri/Cargo.toml
+++ b/asyar-launcher/src-tauri/Cargo.toml
@@ -47,7 +47,7 @@ hmac = "0.12"
 aes-gcm = "0.10"
 argon2 = "0.5"
 bip39 = { version = "2.0", default-features = false, features = ["std"] }
-rand = "0.9"
+rand = "0.10"
 zeroize = "1"
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 reqwest = { version = "0.12", features = ["json", "stream"] } # For downloading

--- a/asyar-launcher/src-tauri/src/crypto/keystore.rs
+++ b/asyar-launcher/src-tauri/src/crypto/keystore.rs
@@ -12,7 +12,7 @@
 
 use crate::error::AppError;
 use base64::Engine;
-use rand::RngCore;
+use rand::RngExt;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -96,7 +96,7 @@ impl KeyStore for InMemoryKeyStore {
             return Ok(Zeroizing::new(k));
         }
         let mut k = [0u8; 32];
-        rand::rng().fill_bytes(&mut k);
+        rand::rng().fill(&mut k[..]);
         *guard = Some(k);
         Ok(Zeroizing::new(k))
     }
@@ -156,7 +156,7 @@ impl KeyStore for OsKeyStore {
             Ok(b64) => decode_key(&b64),
             Err(keyring::Error::NoEntry) => {
                 let mut k = [0u8; 32];
-                rand::rng().fill_bytes(&mut k);
+                rand::rng().fill(&mut k[..]);
                 let encoded = encode_key(&k);
                 entry.set_password(&encoded).map_err(|e| {
                     AppError::Encryption(format!("keychain write failed: {e}"))
@@ -264,7 +264,7 @@ impl KeyStore for FileKeyStore {
         }
 
         let mut k = [0u8; 32];
-        rand::rng().fill_bytes(&mut k);
+        rand::rng().fill(&mut k[..]);
         let encoded = encode_key(&k);
 
         write_with_restrictive_permissions(&self.path, &encoded)?;

--- a/asyar-launcher/src-tauri/src/oauth/pkce.rs
+++ b/asyar-launcher/src-tauri/src/oauth/pkce.rs
@@ -1,6 +1,6 @@
 use base64::Engine;
 use crate::error::AppError;
-use rand::Rng;
+use rand::RngExt;
 use sha2::{Digest, Sha256};
 
 /// Generate a random PKCE code verifier (43–128 URL-safe base64 chars, no padding).

--- a/asyar-launcher/src-tauri/src/sync/e2ee/service.rs
+++ b/asyar-launcher/src-tauri/src/sync/e2ee/service.rs
@@ -15,7 +15,7 @@ use crate::storage::DataStore;
 use crate::sync::e2ee::mode::Mode;
 use crate::sync::types::E2eeStatePayload;
 use base64::{engine::general_purpose::STANDARD as B64, Engine};
-use rand::RngCore;
+use rand::RngExt;
 use zeroize::Zeroizing;
 
 fn current_unix_ms() -> i64 {
@@ -103,9 +103,9 @@ impl<'a> E2eeService<'a> {
     /// cache locally, return the 24-word recovery phrase.
     pub async fn enrol(&self, token: &str, passphrase: &str) -> Result<EnrolmentResult, AppError> {
         let mut seed = Zeroizing::new([0u8; 32]);
-        rand::rng().fill_bytes(&mut *seed);
+        rand::rng().fill(&mut seed[..]);
         let mut salt = [0u8; 32];
-        rand::rng().fill_bytes(&mut salt);
+        rand::rng().fill(&mut salt[..]);
 
         let wrap_key = kdf::derive_wrap_key(
             passphrase,
@@ -231,7 +231,7 @@ impl<'a> E2eeService<'a> {
         }
 
         let mut salt = [0u8; 32];
-        rand::rng().fill_bytes(&mut salt);
+        rand::rng().fill(&mut salt[..]);
         let wrap_key = kdf::derive_wrap_key(
             new_passphrase,
             &salt,


### PR DESCRIPTION
Migrate to the new RngExt trait: replace `RngCore`/`Rng` imports with
`RngExt` and switch `fill_bytes(&mut buf)` calls to `fill(&mut buf[..])`
in keystore, e2ee, and pkce.