### PR TITLE
fix(browser): harden bridge against companion reconnect storms

### DIFF
--- a/asyar-launcher/src-tauri/src/browser/bridge/mod.rs
+++ b/asyar-launcher/src-tauri/src/browser/bridge/mod.rs
@@ -2,6 +2,7 @@ pub mod cache;
 pub mod connections;
 pub mod pairing;
 pub mod protocol;
+pub mod rate_limit;
 pub mod server;
 pub mod token_store;
 pub mod ws_handler;
@@ -17,6 +18,7 @@ pub struct BridgeState<R: tauri::Runtime = tauri::Wry> {
     pub cache: Arc<cache::TabSnapshotCache>,
     pub events: Arc<BrowserEventsHub>,
     pub last_active: Arc<std::sync::RwLock<Option<crate::browser::types::BrowserKey>>>,
+    pub rate_limiter: Arc<rate_limit::ConnectionRateLimiter>,
     pub app_handle: tauri::AppHandle<R>,
 }
 
@@ -32,6 +34,7 @@ impl<R: tauri::Runtime> Clone for BridgeState<R> {
             cache: self.cache.clone(),
             events: self.events.clone(),
             last_active: self.last_active.clone(),
+            rate_limiter: self.rate_limiter.clone(),
             app_handle: self.app_handle.clone(),
         }
     }

--- a/asyar-launcher/src-tauri/src/browser/bridge/rate_limit.rs
+++ b/asyar-launcher/src-tauri/src/browser/bridge/rate_limit.rs
@@ -16,6 +16,13 @@ struct Bucket {
     last: Instant,
 }
 
+/// Hard ceiling on the number of live buckets, as a backstop against a flood of
+/// unique `variant`s (which come from client-controlled query input). Pruning
+/// keeps the map far below this in practice; the cap only bites under a genuine
+/// flood of simultaneously-throttled peers — astronomically unlikely on a
+/// loopback bridge, but it guarantees the map can never grow without bound.
+const DEFAULT_MAX_BUCKETS: usize = 1024;
+
 /// Per-peer token-bucket limiter guarding the browser bridge routes. Each
 /// `BrowserKey` (family + variant) gets its own bucket, so one looping or
 /// malicious companion cannot starve the others. A peer may burst up to
@@ -24,6 +31,7 @@ struct Bucket {
 pub struct ConnectionRateLimiter {
     capacity: f64,
     refill_per_sec: f64,
+    max_buckets: usize,
     buckets: Mutex<HashMap<BrowserKey, Bucket>>,
 }
 
@@ -32,8 +40,20 @@ impl ConnectionRateLimiter {
         Self {
             capacity,
             refill_per_sec,
+            max_buckets: DEFAULT_MAX_BUCKETS,
             buckets: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Override the bucket ceiling (mainly for tests).
+    pub fn with_max_buckets(mut self, max_buckets: usize) -> Self {
+        self.max_buckets = max_buckets;
+        self
+    }
+
+    /// Number of live buckets — used by tests to assert memory stays bounded.
+    pub fn bucket_count(&self) -> usize {
+        self.buckets.lock().unwrap().len()
     }
 
     /// Convenience entry point used in production: checks against the current
@@ -44,6 +64,29 @@ impl ConnectionRateLimiter {
 
     pub fn check_at(&self, key: &BrowserKey, now: Instant) -> RateDecision {
         let mut buckets = self.buckets.lock().unwrap();
+
+        // Drop stranger buckets that have refilled to full capacity: such a
+        // bucket is indistinguishable from a never-seen key, so removing it is a
+        // no-op for legitimate peers while bounding memory to currently-throttled
+        // ones. This is what neutralizes a flood of unique client `variant`s
+        // without the permanent lockout a plain hard cap would cause.
+        let capacity = self.capacity;
+        let refill = self.refill_per_sec;
+        buckets.retain(|k, b| {
+            k == key
+                || (b.tokens + now.saturating_duration_since(b.last).as_secs_f64() * refill)
+                    < capacity
+        });
+
+        // Backstop: if even after pruning we are at the ceiling and this is a new
+        // key, shed it before allocating a bucket (and before any auth/keychain
+        // work downstream) rather than grow unbounded.
+        if buckets.len() >= self.max_buckets && !buckets.contains_key(key) {
+            return RateDecision::Deny {
+                retry_after_secs: 60,
+            };
+        }
+
         let bucket = buckets.entry(key.clone()).or_insert(Bucket {
             tokens: self.capacity,
             last: now,
@@ -169,5 +212,64 @@ mod tests {
             limiter.check_at(&key("chrome"), later),
             RateDecision::Deny { .. }
         ));
+    }
+
+    #[test]
+    fn prunes_fully_refilled_buckets_of_other_keys() {
+        let limiter = ConnectionRateLimiter::new(5.0, 1.0);
+        let t0 = Instant::now();
+        // A flood of unique variants (the DoS vector: `variant` is client input).
+        for i in 0..100 {
+            let _ = limiter.check_at(&key(&format!("v{i}")), t0);
+        }
+        assert_eq!(
+            limiter.bucket_count(),
+            100,
+            "each unique key holds a bucket"
+        );
+        // After enough time for every stranger bucket to refill to full, a check
+        // for a NEW key drops them — a fully-refilled bucket carries no state, so
+        // pruning it changes nothing for a real peer but bounds memory.
+        let later = t0 + Duration::from_secs(10);
+        let _ = limiter.check_at(&key("fresh"), later);
+        assert_eq!(
+            limiter.bucket_count(),
+            1,
+            "fully-refilled stranger buckets must be pruned"
+        );
+    }
+
+    #[test]
+    fn enforces_max_buckets_ceiling_for_new_keys() {
+        let limiter = ConnectionRateLimiter::new(5.0, 1.0).with_max_buckets(3);
+        let t0 = Instant::now();
+        for i in 0..3 {
+            assert_eq!(
+                limiter.check_at(&key(&format!("v{i}")), t0),
+                RateDecision::Allow
+            );
+        }
+        // 4th distinct key at the same instant: nothing has refilled, so pruning
+        // keeps all 3 and the ceiling sheds the newcomer before it allocates.
+        assert!(matches!(
+            limiter.check_at(&key("v3"), t0),
+            RateDecision::Deny { .. }
+        ));
+        assert_eq!(limiter.bucket_count(), 3, "ceiling caps the map size");
+    }
+
+    #[test]
+    fn ceiling_never_blocks_an_already_tracked_key() {
+        let limiter = ConnectionRateLimiter::new(5.0, 1.0).with_max_buckets(2);
+        let t0 = Instant::now();
+        let _ = limiter.check_at(&key("a"), t0);
+        let _ = limiter.check_at(&key("b"), t0);
+        // A brand-new key is shed by the ceiling...
+        assert!(matches!(
+            limiter.check_at(&key("c"), t0),
+            RateDecision::Deny { .. }
+        ));
+        // ...but a peer we are already tracking is never locked out.
+        assert_eq!(limiter.check_at(&key("a"), t0), RateDecision::Allow);
     }
 }

--- a/asyar-launcher/src-tauri/src/browser/bridge/rate_limit.rs
+++ b/asyar-launcher/src-tauri/src/browser/bridge/rate_limit.rs
@@ -1,0 +1,173 @@
+use crate::browser::types::BrowserKey;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Instant;
+
+/// Outcome of a rate-limit check. `Deny` carries a `Retry-After` hint in whole
+/// seconds so the caller can advertise a backoff to a well-behaved client.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RateDecision {
+    Allow,
+    Deny { retry_after_secs: u64 },
+}
+
+struct Bucket {
+    tokens: f64,
+    last: Instant,
+}
+
+/// Per-peer token-bucket limiter guarding the browser bridge routes. Each
+/// `BrowserKey` (family + variant) gets its own bucket, so one looping or
+/// malicious companion cannot starve the others. A peer may burst up to
+/// `capacity` connection attempts, after which it is throttled to
+/// `refill_per_sec` attempts per second.
+pub struct ConnectionRateLimiter {
+    capacity: f64,
+    refill_per_sec: f64,
+    buckets: Mutex<HashMap<BrowserKey, Bucket>>,
+}
+
+impl ConnectionRateLimiter {
+    pub fn new(capacity: f64, refill_per_sec: f64) -> Self {
+        Self {
+            capacity,
+            refill_per_sec,
+            buckets: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Convenience entry point used in production: checks against the current
+    /// instant. Tests use [`check_at`](Self::check_at) with a controlled clock.
+    pub fn check(&self, key: &BrowserKey) -> RateDecision {
+        self.check_at(key, Instant::now())
+    }
+
+    pub fn check_at(&self, key: &BrowserKey, now: Instant) -> RateDecision {
+        let mut buckets = self.buckets.lock().unwrap();
+        let bucket = buckets.entry(key.clone()).or_insert(Bucket {
+            tokens: self.capacity,
+            last: now,
+        });
+
+        // Refill by elapsed time, clamped to capacity. `saturating_duration_since`
+        // guards against a `now` earlier than the last seen instant.
+        let elapsed = now.saturating_duration_since(bucket.last).as_secs_f64();
+        bucket.tokens = (bucket.tokens + elapsed * self.refill_per_sec).min(self.capacity);
+        bucket.last = now;
+
+        if bucket.tokens >= 1.0 {
+            bucket.tokens -= 1.0;
+            RateDecision::Allow
+        } else {
+            // Whole seconds until the bucket holds one full token again.
+            let deficit = 1.0 - bucket.tokens;
+            let retry_after_secs = (deficit / self.refill_per_sec).ceil() as u64;
+            RateDecision::Deny {
+                retry_after_secs: retry_after_secs.max(1),
+            }
+        }
+    }
+}
+
+impl Default for ConnectionRateLimiter {
+    /// Bridge default: burst of 5, then 1 attempt/sec sustained.
+    fn default() -> Self {
+        Self::new(5.0, 1.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::browser::types::BrowserFamily;
+    use std::time::Duration;
+
+    fn key(variant: &str) -> BrowserKey {
+        BrowserKey {
+            family: BrowserFamily::Chromium,
+            variant: variant.to_string(),
+        }
+    }
+
+    #[test]
+    fn allows_up_to_capacity_then_denies() {
+        let limiter = ConnectionRateLimiter::new(5.0, 1.0);
+        let t0 = Instant::now();
+        // First 5 attempts at the same instant all pass.
+        for i in 0..5 {
+            assert_eq!(
+                limiter.check_at(&key("chrome"), t0),
+                RateDecision::Allow,
+                "attempt {i} should be allowed"
+            );
+        }
+        // The 6th in the same window is throttled.
+        assert!(matches!(
+            limiter.check_at(&key("chrome"), t0),
+            RateDecision::Deny { .. }
+        ));
+    }
+
+    #[test]
+    fn refills_over_time() {
+        let limiter = ConnectionRateLimiter::new(5.0, 1.0);
+        let t0 = Instant::now();
+        for _ in 0..5 {
+            assert_eq!(limiter.check_at(&key("chrome"), t0), RateDecision::Allow);
+        }
+        assert!(matches!(
+            limiter.check_at(&key("chrome"), t0),
+            RateDecision::Deny { .. }
+        ));
+        // After 2 seconds, ~2 tokens have refilled -> two more allowed.
+        let t2 = t0 + Duration::from_secs(2);
+        assert_eq!(limiter.check_at(&key("chrome"), t2), RateDecision::Allow);
+        assert_eq!(limiter.check_at(&key("chrome"), t2), RateDecision::Allow);
+        assert!(matches!(
+            limiter.check_at(&key("chrome"), t2),
+            RateDecision::Deny { .. }
+        ));
+    }
+
+    #[test]
+    fn deny_reports_nonzero_retry_after() {
+        let limiter = ConnectionRateLimiter::new(2.0, 1.0);
+        let t0 = Instant::now();
+        let _ = limiter.check_at(&key("chrome"), t0);
+        let _ = limiter.check_at(&key("chrome"), t0);
+        match limiter.check_at(&key("chrome"), t0) {
+            RateDecision::Deny { retry_after_secs } => assert!(retry_after_secs >= 1),
+            RateDecision::Allow => panic!("expected a denial"),
+        }
+    }
+
+    #[test]
+    fn buckets_are_independent_per_key() {
+        let limiter = ConnectionRateLimiter::new(2.0, 1.0);
+        let t0 = Instant::now();
+        // Exhaust chrome's bucket.
+        let _ = limiter.check_at(&key("chrome"), t0);
+        let _ = limiter.check_at(&key("chrome"), t0);
+        assert!(matches!(
+            limiter.check_at(&key("chrome"), t0),
+            RateDecision::Deny { .. }
+        ));
+        // A different variant still has a full bucket.
+        assert_eq!(limiter.check_at(&key("edge"), t0), RateDecision::Allow);
+    }
+
+    #[test]
+    fn never_exceeds_capacity_after_long_idle() {
+        let limiter = ConnectionRateLimiter::new(3.0, 1.0);
+        let t0 = Instant::now();
+        // Idle for a long time should NOT let the bucket overflow past capacity.
+        let later = t0 + Duration::from_secs(3600);
+        for _ in 0..3 {
+            assert_eq!(limiter.check_at(&key("chrome"), later), RateDecision::Allow);
+        }
+        assert!(matches!(
+            limiter.check_at(&key("chrome"), later),
+            RateDecision::Deny { .. }
+        ));
+    }
+}

--- a/asyar-launcher/src-tauri/src/browser/bridge/server.rs
+++ b/asyar-launcher/src-tauri/src/browser/bridge/server.rs
@@ -44,6 +44,24 @@ impl ServerHandle {
     }
 }
 
+/// Per-peer connection throttle shared by the `/pair-request` and `/bridge`
+/// routes. Returns a `429 Too Many Requests` error (with a `Retry-After` hint in
+/// the body) when the browser key has exceeded its rate budget, or `None` when
+/// the request may proceed.
+fn throttle<R: tauri::Runtime>(
+    state: &BridgeState<R>,
+    key: &crate::browser::types::BrowserKey,
+) -> Option<(StatusCode, String)> {
+    use crate::browser::bridge::rate_limit::RateDecision;
+    match state.rate_limiter.check(key) {
+        RateDecision::Allow => None,
+        RateDecision::Deny { retry_after_secs } => Some((
+            StatusCode::TOO_MANY_REQUESTS,
+            format!("rate limited; retry after {retry_after_secs}s"),
+        )),
+    }
+}
+
 async fn discover_handler() -> Json<serde_json::Value> {
     Json(json!({
         "name": "asyar",
@@ -76,6 +94,9 @@ async fn pair_request_handler<R: tauri::Runtime>(
         family,
         variant: body.variant.clone(),
     };
+    if let Some(err) = throttle(&state, &key) {
+        return Err(err);
+    }
     let pairing_id = state.pairing.request(key).await;
 
     use tauri::Emitter;
@@ -126,12 +147,50 @@ pub fn token_from_subprotocols(header_value: &str) -> Option<String> {
         .find_map(|entry| entry.strip_prefix("bearer.").map(|t| t.to_string()))
 }
 
+/// WebSocket close codes that tell a browser companion WHY its `/bridge`
+/// connection was rejected. A browser's `WebSocket` API cannot read the HTTP
+/// status of a *failed* upgrade, so instead of rejecting with `401`/`429` (which
+/// the companion only ever sees as an opaque `1006`), we accept the upgrade and
+/// immediately close with one of these. That lets the companion react correctly:
+/// clear a stale token and re-pair, or back off without discarding a valid one.
+pub const WS_CLOSE_AUTH: u16 = 1008; // Policy Violation: bad/missing token or no pairing.
+pub const WS_CLOSE_THROTTLED: u16 = 1013; // Try Again Later: rate limited.
+
+/// Sends a single Close frame and drops the socket. Used for the rejection paths
+/// above — no connection is registered and no data is exchanged.
+async fn close_with<S>(mut socket: S, code: u16, reason: &'static str)
+where
+    S: futures_util::Sink<axum::extract::ws::Message> + Unpin,
+{
+    use axum::extract::ws::{CloseFrame, Message};
+    use futures_util::SinkExt;
+    let _ = socket
+        .send(Message::Close(Some(CloseFrame {
+            code,
+            reason: reason.into(),
+        })))
+        .await;
+}
+
 async fn bridge_ws_handler<R: tauri::Runtime>(
     ws: WebSocketUpgrade,
     State(state): State<BridgeState<R>>,
     axum::extract::Query(q): axum::extract::Query<BridgeQuery>,
     headers: HeaderMap,
 ) -> Result<Response, (StatusCode, String)> {
+    use crate::browser::bridge::rate_limit::RateDecision;
+
+    let family = match q.family.as_str() {
+        "chromium" => crate::browser::types::BrowserFamily::Chromium,
+        "firefox" => crate::browser::types::BrowserFamily::Firefox,
+        "safari" => crate::browser::types::BrowserFamily::Safari,
+        other => return Err((StatusCode::BAD_REQUEST, format!("bad family: {}", other))),
+    };
+    let key = crate::browser::types::BrowserKey {
+        family,
+        variant: q.variant.clone(),
+    };
+
     // 1. Authorization: Bearer <token>  (non-browser clients, tests)
     let header_token = headers
         .get("authorization")
@@ -144,40 +203,38 @@ async fn bridge_ws_handler<R: tauri::Runtime>(
         .and_then(|v| v.to_str().ok())
         .and_then(token_from_subprotocols);
     let used_subprotocol = subproto_token.is_some();
-    let token = header_token
-        .or(subproto_token)
-        .ok_or_else(|| (StatusCode::UNAUTHORIZED, "missing bearer token".to_string()))?;
-    let family = match q.family.as_str() {
-        "chromium" => crate::browser::types::BrowserFamily::Chromium,
-        "firefox" => crate::browser::types::BrowserFamily::Firefox,
-        "safari" => crate::browser::types::BrowserFamily::Safari,
-        other => return Err((StatusCode::BAD_REQUEST, format!("bad family: {}", other))),
-    };
-    let key = crate::browser::types::BrowserKey {
-        family,
-        variant: q.variant.clone(),
-    };
-    let stored = state
-        .tokens
-        .get(&key)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?
-        .ok_or_else(|| {
-            (
-                StatusCode::UNAUTHORIZED,
-                "no pairing for this browser".to_string(),
-            )
-        })?;
-    if stored != token {
-        return Err((StatusCode::UNAUTHORIZED, "token mismatch".to_string()));
-    }
-    let state_for_socket = state.clone();
-    // Browsers close the socket if the server does not select one of the offered
-    // subprotocols, so echo `asyar.v1` back when the subprotocol channel was used.
+
+    // Browsers close the socket if the server does not echo one of the offered
+    // subprotocols — including on the rejection paths below, otherwise our close
+    // frame (and its reason code) would never reach the companion.
     let ws = if used_subprotocol {
         ws.protocols(["asyar.v1"])
     } else {
         ws
     };
+
+    // Throttle BEFORE any auth work so a reconnect storm can't hammer the token
+    // store (and, through it, the OS keychain). Tell the companion to back off
+    // via a 1013 close rather than an HTTP 429 it cannot read.
+    if matches!(state.rate_limiter.check(&key), RateDecision::Deny { .. }) {
+        return Ok(ws.on_upgrade(|socket| close_with(socket, WS_CLOSE_THROTTLED, "rate limited")));
+    }
+
+    // Authenticate. ANY failure (missing token, no pairing, mismatch) closes with
+    // 1008 so the companion clears its stale token and re-pairs — instead of
+    // looping forever against an invisible 401.
+    let Some(token) = header_token.or(subproto_token) else {
+        return Ok(ws.on_upgrade(|socket| close_with(socket, WS_CLOSE_AUTH, "missing token")));
+    };
+    let stored = state
+        .tokens
+        .get(&key)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    if stored.as_deref() != Some(token.as_str()) {
+        return Ok(ws.on_upgrade(|socket| close_with(socket, WS_CLOSE_AUTH, "unauthorized")));
+    }
+
+    let state_for_socket = state.clone();
     Ok(ws.on_upgrade(move |socket| {
         crate::browser::bridge::ws_handler::handle_socket(socket, state_for_socket, key)
     }))
@@ -215,11 +272,17 @@ mod tests {
     use super::*;
     use crate::browser::bridge::{
         cache::TabSnapshotCache, connections::CompanionRegistry, pairing::PairingRegistry,
-        token_store::InMemoryTokenStore,
+        rate_limit::ConnectionRateLimiter, token_store::InMemoryTokenStore,
     };
     use std::sync::Arc;
 
     fn build_test_state() -> BridgeState<tauri::test::MockRuntime> {
+        build_test_state_with_limiter(ConnectionRateLimiter::default())
+    }
+
+    fn build_test_state_with_limiter(
+        limiter: ConnectionRateLimiter,
+    ) -> BridgeState<tauri::test::MockRuntime> {
         let app = tauri::test::mock_app();
         BridgeState {
             tokens: Arc::new(InMemoryTokenStore::new()),
@@ -228,6 +291,7 @@ mod tests {
             cache: Arc::new(TabSnapshotCache::new()),
             events: Arc::new(crate::browser::events::BrowserEventsHub::new()),
             last_active: Arc::new(std::sync::RwLock::new(None)),
+            rate_limiter: Arc::new(limiter),
             app_handle: app.handle().clone(),
         }
     }
@@ -307,6 +371,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pair_request_is_throttled_after_capacity() {
+        let state = build_test_state_with_limiter(ConnectionRateLimiter::new(3.0, 1.0));
+        let handle = start_server(state.clone()).await.unwrap();
+        let client = reqwest::Client::new();
+        let url = format!("http://127.0.0.1:{}/pair-request", handle.port());
+        let body = serde_json::json!({ "family": "chromium", "variant": "chrome" });
+        // First `capacity` rapid requests are accepted.
+        for i in 0..3 {
+            let resp = client.post(&url).json(&body).send().await.unwrap();
+            assert_eq!(resp.status(), reqwest::StatusCode::OK, "request {i}");
+        }
+        // The next one in the same window is throttled.
+        let resp = client.post(&url).json(&body).send().await.unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn bridge_ws_throttle_closes_with_1013() {
+        use crate::browser::types::{BrowserFamily, BrowserKey};
+        use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+        use tokio_tungstenite::tungstenite::http::HeaderValue;
+
+        let state = build_test_state_with_limiter(ConnectionRateLimiter::new(1.0, 1.0));
+        state
+            .tokens
+            .set(
+                &BrowserKey {
+                    family: BrowserFamily::Chromium,
+                    variant: "chrome".to_string(),
+                },
+                "secret-token",
+            )
+            .unwrap();
+        let handle = start_server(state.clone()).await.unwrap();
+        let url = format!(
+            "ws://127.0.0.1:{}/bridge?family=chromium&variant=chrome",
+            handle.port()
+        );
+        let make_req = || {
+            let mut req = url.clone().into_client_request().unwrap();
+            req.headers_mut().insert(
+                "authorization",
+                HeaderValue::from_static("Bearer secret-token"),
+            );
+            req
+        };
+        // First connection (within the burst) upgrades successfully.
+        let (_socket, _resp) = tokio_tungstenite::connect_async(make_req()).await.unwrap();
+        // The second within the same window is throttled — delivered as a 1013
+        // "Try Again Later" close so the companion backs off WITHOUT discarding
+        // its (valid) token.
+        let (socket, _resp) = tokio_tungstenite::connect_async(make_req()).await.unwrap();
+        assert_eq!(first_close_code(socket).await, Some(WS_CLOSE_THROTTLED));
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn pair_status_returns_approved_with_token_after_resolve() {
         use crate::browser::types::{BrowserFamily, BrowserKey, PairDecision};
         let state = build_test_state();
@@ -363,8 +485,26 @@ mod tests {
         handle.shutdown().await;
     }
 
+    /// Reads frames until the server's Close frame arrives, returning its code.
+    async fn first_close_code(
+        mut socket: tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+    ) -> Option<u16> {
+        use futures_util::StreamExt;
+        use tokio_tungstenite::tungstenite::Message;
+        while let Some(msg) = socket.next().await {
+            match msg {
+                Ok(Message::Close(Some(frame))) => return Some(frame.code.into()),
+                Ok(_) => continue,
+                Err(_) => return None,
+            }
+        }
+        None
+    }
+
     #[tokio::test]
-    async fn ws_rejects_without_token() {
+    async fn ws_closes_with_1008_when_token_missing() {
         use tokio_tungstenite::tungstenite::client::IntoClientRequest;
         let state = build_test_state();
         let handle = start_server(state.clone()).await.unwrap();
@@ -373,8 +513,47 @@ mod tests {
             handle.port()
         );
         let req = url.into_client_request().unwrap();
-        let result = tokio_tungstenite::connect_async(req).await;
-        assert!(result.is_err(), "expected 401-class failure");
+        // The upgrade now succeeds; the rejection reason is delivered as a WS
+        // close code (a browser cannot read an HTTP 401 on a failed upgrade).
+        let (socket, _resp) = tokio_tungstenite::connect_async(req).await.unwrap();
+        assert_eq!(first_close_code(socket).await, Some(WS_CLOSE_AUTH));
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn ws_closes_with_1008_on_token_mismatch() {
+        use crate::browser::types::{BrowserFamily, BrowserKey};
+        use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+        use tokio_tungstenite::tungstenite::http::HeaderValue;
+        let state = build_test_state();
+        // A pairing EXISTS, but the companion presents a stale/wrong token —
+        // exactly the drift that caused the infinite reconnect loop.
+        state
+            .tokens
+            .set(
+                &BrowserKey {
+                    family: BrowserFamily::Chromium,
+                    variant: "chrome".to_string(),
+                },
+                "the-real-token",
+            )
+            .unwrap();
+        let handle = start_server(state.clone()).await.unwrap();
+        let url = format!(
+            "ws://127.0.0.1:{}/bridge?family=chromium&variant=chrome",
+            handle.port()
+        );
+        let mut req = url.into_client_request().unwrap();
+        req.headers_mut().insert(
+            "authorization",
+            HeaderValue::from_static("Bearer a-stale-token"),
+        );
+        let (socket, _resp) = tokio_tungstenite::connect_async(req).await.unwrap();
+        assert_eq!(
+            first_close_code(socket).await,
+            Some(WS_CLOSE_AUTH),
+            "a mismatched token must yield a 1008 so the client clears it and re-pairs"
+        );
         handle.shutdown().await;
     }
 

--- a/asyar-launcher/src-tauri/src/browser/bridge/server.rs
+++ b/asyar-launcher/src-tauri/src/browser/bridge/server.rs
@@ -156,6 +156,11 @@ pub fn token_from_subprotocols(header_value: &str) -> Option<String> {
 pub const WS_CLOSE_AUTH: u16 = 1008; // Policy Violation: bad/missing token or no pairing.
 pub const WS_CLOSE_THROTTLED: u16 = 1013; // Try Again Later: rate limited.
 
+/// Upper bound on the client-supplied `variant`. Real browser variants are short
+/// (`chrome`, `chrome-beta`, `edge`, `brave`, …); anything longer is abusive
+/// input and is rejected before it can key a rate-limiter bucket.
+const MAX_VARIANT_LEN: usize = 64;
+
 /// Sends a single Close frame and drops the socket. Used for the rejection paths
 /// above — no connection is registered and no data is exchanged.
 async fn close_with<S>(mut socket: S, code: u16, reason: &'static str)
@@ -186,6 +191,11 @@ async fn bridge_ws_handler<R: tauri::Runtime>(
         "safari" => crate::browser::types::BrowserFamily::Safari,
         other => return Err((StatusCode::BAD_REQUEST, format!("bad family: {}", other))),
     };
+    // Reject abusive `variant` up front — before it can allocate a rate-limiter
+    // bucket or reach the keychain lookup.
+    if q.variant.len() > MAX_VARIANT_LEN {
+        return Err((StatusCode::BAD_REQUEST, "variant too long".to_string()));
+    }
     let key = crate::browser::types::BrowserKey {
         family,
         variant: q.variant.clone(),
@@ -385,6 +395,34 @@ mod tests {
         // The next one in the same window is throttled.
         let resp = client.post(&url).json(&body).send().await.unwrap();
         assert_eq!(resp.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn bridge_ws_rejects_overlong_variant_before_allocating() {
+        use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+        use tokio_tungstenite::tungstenite::Error as WsError;
+        let state = build_test_state();
+        let handle = start_server(state.clone()).await.unwrap();
+        // `variant` is client-controlled; an abusive over-long value must be
+        // rejected up front, before it can allocate a rate-limiter bucket or
+        // reach the keychain lookup.
+        let variant = "x".repeat(500);
+        let url = format!(
+            "ws://127.0.0.1:{}/bridge?family=chromium&variant={}",
+            handle.port(),
+            variant
+        );
+        let req = url.into_client_request().unwrap();
+        match tokio_tungstenite::connect_async(req).await {
+            Err(WsError::Http(resp)) => assert_eq!(resp.status().as_u16(), 400),
+            other => panic!("expected a 400 rejection, got {other:?}"),
+        }
+        assert_eq!(
+            state.rate_limiter.bucket_count(),
+            0,
+            "an over-long variant must not create a bucket"
+        );
         handle.shutdown().await;
     }
 

--- a/asyar-launcher/src-tauri/src/browser/bridge/token_store.rs
+++ b/asyar-launcher/src-tauri/src/browser/bridge/token_store.rs
@@ -1,7 +1,41 @@
 use crate::browser::types::{BrowserFamily, BrowserKey};
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 const KEYRING_SERVICE: &str = "asyar-browser-bridge";
+
+/// The durable secret backend behind [`KeyringTokenStore`]. Abstracted so the
+/// caching layer can be tested without touching the real OS keychain.
+pub trait SecretBackend: Send + Sync {
+    fn read(&self, account: &str) -> Result<Option<String>, String>;
+    fn write(&self, account: &str, secret: &str) -> Result<(), String>;
+    fn remove(&self, account: &str) -> Result<(), String>;
+}
+
+/// Production backend: persists secrets in the OS keychain via `keyring`.
+pub struct KeyringBackend;
+
+impl SecretBackend for KeyringBackend {
+    fn read(&self, account: &str) -> Result<Option<String>, String> {
+        let entry = keyring::Entry::new(KEYRING_SERVICE, account).map_err(|e| e.to_string())?;
+        match entry.get_password() {
+            Ok(t) => Ok(Some(t)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+    fn write(&self, account: &str, secret: &str) -> Result<(), String> {
+        let entry = keyring::Entry::new(KEYRING_SERVICE, account).map_err(|e| e.to_string())?;
+        entry.set_password(secret).map_err(|e| e.to_string())
+    }
+    fn remove(&self, account: &str) -> Result<(), String> {
+        let entry = keyring::Entry::new(KEYRING_SERVICE, account).map_err(|e| e.to_string())?;
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+}
 
 pub trait TokenStore: Send + Sync {
     fn set(&self, key: &BrowserKey, token: &str) -> Result<(), String>;
@@ -19,14 +53,27 @@ fn account_for(key: &BrowserKey) -> String {
     format!("{}:{}", family, key.variant)
 }
 
+/// Token store backed by a durable [`SecretBackend`] with an in-memory cache in
+/// front of it. The cache makes auth checks on the hot `/bridge` path free after
+/// the first lookup per browser — a reconnect loop no longer hammers the OS
+/// keychain. Negative lookups (no pairing) are cached too, so an unpaired or
+/// malicious client looping on the bridge also touches the backend only once.
 pub struct KeyringTokenStore {
-    index: Arc<RwLock<Vec<BrowserKey>>>,
+    backend: Arc<dyn SecretBackend>,
+    cache: RwLock<HashMap<BrowserKey, Option<String>>>,
+    index: RwLock<Vec<BrowserKey>>,
 }
 
 impl KeyringTokenStore {
     pub fn new() -> Self {
+        Self::with_backend(Arc::new(KeyringBackend))
+    }
+
+    pub fn with_backend(backend: Arc<dyn SecretBackend>) -> Self {
         Self {
-            index: Arc::new(RwLock::new(Vec::new())),
+            backend,
+            cache: RwLock::new(HashMap::new()),
+            index: RwLock::new(Vec::new()),
         }
     }
 
@@ -43,9 +90,11 @@ impl Default for KeyringTokenStore {
 
 impl TokenStore for KeyringTokenStore {
     fn set(&self, key: &BrowserKey, token: &str) -> Result<(), String> {
-        let entry =
-            keyring::Entry::new(KEYRING_SERVICE, &account_for(key)).map_err(|e| e.to_string())?;
-        entry.set_password(token).map_err(|e| e.to_string())?;
+        self.backend.write(&account_for(key), token)?;
+        self.cache
+            .write()
+            .unwrap()
+            .insert(key.clone(), Some(token.to_string()));
         let mut idx = self.index.write().unwrap();
         if !idx.contains(key) {
             idx.push(key.clone());
@@ -54,22 +103,22 @@ impl TokenStore for KeyringTokenStore {
     }
 
     fn get(&self, key: &BrowserKey) -> Result<Option<String>, String> {
-        let entry =
-            keyring::Entry::new(KEYRING_SERVICE, &account_for(key)).map_err(|e| e.to_string())?;
-        match entry.get_password() {
-            Ok(t) => Ok(Some(t)),
-            Err(keyring::Error::NoEntry) => Ok(None),
-            Err(e) => Err(e.to_string()),
+        if let Some(cached) = self.cache.read().unwrap().get(key) {
+            return Ok(cached.clone());
         }
+        let value = self.backend.read(&account_for(key))?;
+        self.cache
+            .write()
+            .unwrap()
+            .insert(key.clone(), value.clone());
+        Ok(value)
     }
 
     fn delete(&self, key: &BrowserKey) -> Result<(), String> {
-        let entry =
-            keyring::Entry::new(KEYRING_SERVICE, &account_for(key)).map_err(|e| e.to_string())?;
-        match entry.delete_credential() {
-            Ok(()) | Err(keyring::Error::NoEntry) => {}
-            Err(e) => return Err(e.to_string()),
-        }
+        self.backend.remove(&account_for(key))?;
+        // Mark as known-absent rather than evicting, so a follow-up `get` is
+        // still served from cache instead of re-probing the backend.
+        self.cache.write().unwrap().insert(key.clone(), None);
         let mut idx = self.index.write().unwrap();
         idx.retain(|k| k != key);
         Ok(())
@@ -122,12 +171,119 @@ pub fn generate_token() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
 
     fn key() -> BrowserKey {
         BrowserKey {
             family: BrowserFamily::Chromium,
             variant: "chrome".to_string(),
         }
+    }
+
+    /// Fake backend that records how many times each operation was called, so
+    /// tests can prove the cache shields the keychain on the hot path.
+    #[derive(Default)]
+    struct CountingBackend {
+        store: Mutex<HashMap<String, String>>,
+        reads: AtomicUsize,
+        writes: AtomicUsize,
+        removes: AtomicUsize,
+    }
+    impl CountingBackend {
+        fn reads(&self) -> usize {
+            self.reads.load(Ordering::SeqCst)
+        }
+    }
+    impl SecretBackend for CountingBackend {
+        fn read(&self, account: &str) -> Result<Option<String>, String> {
+            self.reads.fetch_add(1, Ordering::SeqCst);
+            Ok(self.store.lock().unwrap().get(account).cloned())
+        }
+        fn write(&self, account: &str, secret: &str) -> Result<(), String> {
+            self.writes.fetch_add(1, Ordering::SeqCst);
+            self.store
+                .lock()
+                .unwrap()
+                .insert(account.to_string(), secret.to_string());
+            Ok(())
+        }
+        fn remove(&self, account: &str) -> Result<(), String> {
+            self.removes.fetch_add(1, Ordering::SeqCst);
+            self.store.lock().unwrap().remove(account);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn repeated_get_hits_backend_only_once() {
+        let backend = Arc::new(CountingBackend::default());
+        backend.write(&account_for(&key()), "tok").unwrap();
+        let store = KeyringTokenStore::with_backend(backend.clone());
+
+        // Backend read count before the first get (write doesn't read).
+        let base = backend.reads();
+        for _ in 0..10 {
+            assert_eq!(store.get(&key()).unwrap(), Some("tok".to_string()));
+        }
+        assert_eq!(
+            backend.reads() - base,
+            1,
+            "10 gets must touch the backend exactly once"
+        );
+    }
+
+    #[test]
+    fn repeated_get_of_unpaired_key_hits_backend_only_once() {
+        let backend = Arc::new(CountingBackend::default());
+        let store = KeyringTokenStore::with_backend(backend.clone());
+        for _ in 0..10 {
+            assert_eq!(store.get(&key()).unwrap(), None);
+        }
+        assert_eq!(
+            backend.reads(),
+            1,
+            "a looping unpaired client must not re-probe the backend"
+        );
+    }
+
+    #[test]
+    fn set_populates_cache_so_get_needs_no_read() {
+        let backend = Arc::new(CountingBackend::default());
+        let store = KeyringTokenStore::with_backend(backend.clone());
+        store.set(&key(), "tok").unwrap();
+        let before = backend.reads();
+        assert_eq!(store.get(&key()).unwrap(), Some("tok".to_string()));
+        assert_eq!(
+            backend.reads(),
+            before,
+            "get after set must not read backend"
+        );
+    }
+
+    #[test]
+    fn delete_caches_absence_so_get_needs_no_read() {
+        let backend = Arc::new(CountingBackend::default());
+        let store = KeyringTokenStore::with_backend(backend.clone());
+        store.set(&key(), "tok").unwrap();
+        store.delete(&key()).unwrap();
+        let before = backend.reads();
+        assert_eq!(store.get(&key()).unwrap(), None);
+        assert_eq!(
+            backend.reads(),
+            before,
+            "get after delete must be served from cache"
+        );
+    }
+
+    #[test]
+    fn set_then_delete_updates_paired_list() {
+        let backend = Arc::new(CountingBackend::default());
+        let store = KeyringTokenStore::with_backend(backend);
+        store.set(&key(), "tok").unwrap();
+        assert_eq!(store.list_paired().unwrap(), vec![key()]);
+        store.delete(&key()).unwrap();
+        assert!(store.list_paired().unwrap().is_empty());
     }
 
     #[test]

--- a/asyar-launcher/src-tauri/src/browser/bridge/ws_handler.rs
+++ b/asyar-launcher/src-tauri/src/browser/bridge/ws_handler.rs
@@ -130,7 +130,7 @@ mod tests {
     use super::*;
     use crate::browser::bridge::{
         cache::TabSnapshotCache, connections::CompanionRegistry, pairing::PairingRegistry,
-        token_store::InMemoryTokenStore, BridgeState,
+        rate_limit::ConnectionRateLimiter, token_store::InMemoryTokenStore, BridgeState,
     };
     use crate::browser::events::{BrowserEvent, BrowserEventKind, BrowserEventsHub};
     use crate::browser::types::{BrowserFamily, BrowserKey};
@@ -147,6 +147,7 @@ mod tests {
             cache: Arc::new(TabSnapshotCache::new()),
             events: Arc::new(BrowserEventsHub::new()),
             last_active: Arc::new(std::sync::RwLock::new(None)),
+            rate_limiter: Arc::new(ConnectionRateLimiter::default()),
             app_handle: app.handle().clone(),
         }
     }

--- a/asyar-launcher/src-tauri/src/browser/service.rs
+++ b/asyar-launcher/src-tauri/src/browser/service.rs
@@ -420,7 +420,7 @@ mod tests {
     use super::*;
     use crate::browser::bridge::{
         cache::TabSnapshotCache, connections::CompanionRegistry, pairing::PairingRegistry,
-        token_store::InMemoryTokenStore, BridgeState,
+        rate_limit::ConnectionRateLimiter, token_store::InMemoryTokenStore, BridgeState,
     };
     use crate::browser::types::BrowserKey;
     use std::path::Path;
@@ -435,6 +435,7 @@ mod tests {
             cache: Arc::new(TabSnapshotCache::new()),
             events: Arc::new(crate::browser::events::BrowserEventsHub::new()),
             last_active: Arc::new(std::sync::RwLock::new(None)),
+            rate_limiter: Arc::new(ConnectionRateLimiter::default()),
             app_handle: app.handle().clone(),
         }
     }

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -118,7 +118,22 @@ pub fn run() {
         .plugin(tauri_plugin_clipboard_x::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_http::init())
-        .plugin(tauri_plugin_log::Builder::new().build())
+        .plugin(
+            // Silence verbose third-party crate logging (the browser-bridge axum
+            // server, the WebSocket layer, hyper, and the keychain) so a busy or
+            // reconnecting companion does not flood the console with connection
+            // TRACE lines. Asyar's own logs are unaffected.
+            tauri_plugin_log::Builder::new()
+                .level_for("axum", log::LevelFilter::Warn)
+                .level_for("hyper", log::LevelFilter::Warn)
+                .level_for("hyper_util", log::LevelFilter::Warn)
+                .level_for("tower_http", log::LevelFilter::Warn)
+                .level_for("tokio_tungstenite", log::LevelFilter::Warn)
+                .level_for("tungstenite", log::LevelFilter::Warn)
+                .level_for("keyring", log::LevelFilter::Warn)
+                .level_for("mio", log::LevelFilter::Warn)
+                .build(),
+        )
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
@@ -1444,7 +1459,8 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     {
         use crate::browser::bridge::{
             cache::TabSnapshotCache, connections::CompanionRegistry, pairing::PairingRegistry,
-            server::start_server, token_store::KeyringTokenStore, BridgeState,
+            rate_limit::ConnectionRateLimiter, server::start_server,
+            token_store::KeyringTokenStore, BridgeState,
         };
         use std::sync::Arc;
         use tauri::Emitter;
@@ -1456,6 +1472,7 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             cache: Arc::new(TabSnapshotCache::new()),
             events: Arc::new(crate::browser::events::BrowserEventsHub::new()),
             last_active: Arc::new(std::sync::RwLock::new(None)),
+            rate_limiter: Arc::new(ConnectionRateLimiter::default()),
             app_handle: app.handle().clone(),
         };
 

--- a/asyar-launcher/src-tauri/tests/browser_bridge_e2e.rs
+++ b/asyar-launcher/src-tauri/tests/browser_bridge_e2e.rs
@@ -1,6 +1,7 @@
 use asyar_lib::browser::bridge::{
     cache::TabSnapshotCache, connections::CompanionRegistry, pairing::PairingRegistry,
-    server::start_server, token_store::InMemoryTokenStore, BridgeState,
+    rate_limit::ConnectionRateLimiter, server::start_server, token_store::InMemoryTokenStore,
+    BridgeState,
 };
 use asyar_lib::browser::service::BrowserService;
 use asyar_lib::browser::types::{BrowserFamily, BrowserId, BrowserKey, PairDecision};
@@ -19,6 +20,9 @@ fn build_state() -> BridgeState<tauri::test::MockRuntime> {
         cache: Arc::new(TabSnapshotCache::new()),
         events: Arc::new(asyar_lib::browser::events::BrowserEventsHub::new()),
         last_active: Arc::new(std::sync::RwLock::new(None)),
+        // High capacity so the throttle never interferes with the multi-step
+        // pairing/round-trip flows exercised here.
+        rate_limiter: Arc::new(ConnectionRateLimiter::new(10_000.0, 10_000.0)),
         app_handle: app.handle().clone(),
     }
 }


### PR DESCRIPTION
Cache pairing tokens in memory (keychain hit once, not per connect),
add a per-peer connection throttle, and signal auth/throttle rejection
via WebSocket close codes (1008/1013) so a companion with a stale token
re-pairs instead of looping forever. Also quiet the noisy axum/keyring
dependency logging.