### PR TITLE
feat: link users to the Chrome companion from the browser extension

### DIFF
--- a/asyar-launcher/src/routes/settings/tabs/BrowsersTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/BrowsersTab.svelte
@@ -2,12 +2,33 @@
   import { onMount, onDestroy } from 'svelte';
   import { invoke } from '@tauri-apps/api/core';
   import { listen } from '@tauri-apps/api/event';
+  import { openUrl } from '@tauri-apps/plugin-opener';
   import { browserService } from '../../../services/browser/browserService';
   import { diagnosticsService } from '../../../services/diagnostics/diagnosticsService.svelte';
   import type { BrowserId, BrowserKey, BrowserFamily } from 'asyar-sdk/contracts';
 
   type PendingPairing = { id: string; family: string; variant: string };
   type PairRequestEvent = { pairing_id: string; family: string; variant: string };
+
+  // The Asyar Companion is a separate browser extension that pairs with this
+  // launcher over WebSocket. The Chromium build covers Chrome / Brave / Edge /
+  // Arc / Vivaldi. Firefox and Safari companions are not published yet.
+  const CHROME_STORE_URL =
+    'https://chromewebstore.google.com/detail/clgmndlecfeilanhmiohfjmgfgilpjic';
+
+  async function installChromiumCompanion() {
+    try {
+      await openUrl(CHROME_STORE_URL);
+    } catch (err) {
+      diagnosticsService.report({
+        source: 'frontend',
+        kind: 'browser:settings.install-link-failed',
+        severity: 'error',
+        retryable: true,
+        context: { message: err instanceof Error ? err.message : String(err) },
+      });
+    }
+  }
 
   let availableBrowsers = $state<BrowserId[]>([]);
   let pairedBrowsers = $state<BrowserKey[]>([]);
@@ -102,7 +123,10 @@
   <div class="paired-list" data-testid="paired-list">
     <h3>Connected browsers</h3>
     {#if pairedBrowsers.length === 0}
-      <p class="empty">No browsers paired yet. Install the Asyar companion in your browser to begin.</p>
+      <p class="empty">
+        No browsers paired yet. Install the Asyar Companion extension below — once it's
+        running, it pairs automatically and your browser shows up here.
+      </p>
     {:else}
       {#each pairedBrowsers as b (familyKey(b.family, b.variant))}
         <article class="paired-item">
@@ -119,12 +143,24 @@
   </div>
 
   <div class="install-links">
-    <h3>Install browser companion</h3>
-    <ul>
-      <li>Chromium (Chrome / Brave / Arc / Edge / Vivaldi): see docs/architecture/browser-bridge-protocol.md</li>
-      <li>Firefox: see docs/architecture/browser-bridge-protocol.md</li>
-      <li>Safari: see docs/architecture/browser-bridge-protocol.md</li>
-    </ul>
+    <h3>Install the Asyar Companion</h3>
+    <p class="companion-intro">
+      Asyar's browser features need a small companion extension installed in your browser.
+      The two work as a pair: the companion streams your open tabs, bookmarks, and history to
+      Asyar so you can search and control them from here. Install it, and it pairs with this
+      launcher automatically.
+    </p>
+    <button
+      class="btn btn-primary install-btn"
+      onclick={installChromiumCompanion}
+      data-testid="install-chromium"
+    >
+      Install for Chrome
+    </button>
+    <p class="companion-note">
+      Works for Chrome, Brave, Edge, Arc, and Vivaldi. Firefox and Safari companions are
+      coming soon.
+    </p>
   </div>
 </section>
 
@@ -194,14 +230,20 @@
     background: var(--bg-hover);
   }
 
-  .install-links ul {
-    margin: 0;
-    padding-left: var(--space-5);
+  .companion-intro {
+    margin: 0 0 var(--space-3) 0;
     color: var(--text-secondary);
     font-size: var(--font-size-sm);
+    line-height: 1.5;
   }
 
-  .install-links li {
-    padding: var(--space-1) 0;
+  .install-btn {
+    display: inline-flex;
+  }
+
+  .companion-note {
+    margin: var(--space-2) 0 0 0;
+    color: var(--text-tertiary);
+    font-size: var(--font-size-sm);
   }
 </style>

--- a/asyar-launcher/src/routes/settings/tabs/BrowsersTab.test.ts
+++ b/asyar-launcher/src/routes/settings/tabs/BrowsersTab.test.ts
@@ -8,6 +8,7 @@ const { invokeMock, listenMock } = vi.hoisted(() => ({
 }));
 vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
 vi.mock('@tauri-apps/api/event', () => ({ listen: listenMock }));
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn() }));
 
 vi.mock('../../../services/browser/browserService', () => ({
   browserService: {
@@ -33,6 +34,17 @@ describe('Settings → Browsers tab', () => {
     invokeMock.mockResolvedValue([]);
     render(BrowsersTab);
     await screen.findByText(/No browsers paired/i);
+  });
+
+  it('opens the Chrome Web Store companion listing when "Install for Chrome" is clicked', async () => {
+    invokeMock.mockResolvedValue([]);
+    const { openUrl } = await import('@tauri-apps/plugin-opener');
+    render(BrowsersTab);
+    const btn = await screen.findByTestId('install-chromium');
+    await fireEvent.click(btn);
+    expect(openUrl).toHaveBeenCalledWith(
+      'https://chromewebstore.google.com/detail/clgmndlecfeilanhmiohfjmgfgilpjic',
+    );
   });
 
   it('renders pending pairing requests and resolves on Allow', async () => {


### PR DESCRIPTION
Add an "Install for Chrome" button in Settings → Browsers that opens the Asyar Companion store listing, and show install guidance in the browser extension when no browser is paired yet.