### PR TITLE
refactor(search): consume Rust-computed tier instead of re-deriving i…

### DIFF
--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -287,6 +287,7 @@ pub fn run() {
             search_engine::commands::search_items,
             search_engine::commands::merged_search,
             search_engine::commands::rank_items,
+            search_engine::commands::classify_items,
             search_engine::commands::sync_command_index,
             search_engine::commands::get_indexed_object_ids,
             search_engine::commands::delete_item,

--- a/asyar-launcher/src-tauri/src/search_engine/commands.rs
+++ b/asyar-launcher/src-tauri/src/search_engine/commands.rs
@@ -38,6 +38,18 @@ pub async fn rank_items(
     Ok(super::ranker::rank_ids(&query, &items))
 }
 
+/// Classify an arbitrary frontend-supplied list against a query, returning a
+/// tier per id with no filtering or sorting. Used to interleave data that
+/// isn't in the Rust search index (e.g. Run rows) against results that are
+/// already tiered by `merged_search`.
+#[tauri::command]
+pub async fn classify_items(
+    query: String,
+    items: Vec<super::ranker::RankInput>,
+) -> Result<Vec<super::ranker::TierResult>, SearchError> {
+    Ok(super::ranker::classify_many(&query, &items))
+}
+
 #[tauri::command]
 pub async fn index_item(
     item: SearchableItem,

--- a/asyar-launcher/src-tauri/src/search_engine/mod.rs
+++ b/asyar-launcher/src-tauri/src/search_engine/mod.rs
@@ -394,6 +394,10 @@ impl SearchState {
                     description: description_for(item),
                     style: None,
                     alias: None,
+                    // Untiered: this is the raw frecency/skim search, not the
+                    // classify pass merged_search runs. Frecency-only is the
+                    // honest placeholder for "not tier-ranked".
+                    tier: ranker::Tier::FrecencyOnly as u8,
                 });
             }
         } else {
@@ -438,6 +442,8 @@ impl SearchState {
                         description: description_for(item),
                         style: None,
                         alias: None,
+                        // Untiered: see comment on the empty-query branch above.
+                        tier: ranker::Tier::FrecencyOnly as u8,
                     });
                 }
             }
@@ -655,6 +661,8 @@ impl SearchState {
                     description: ext.description,
                     style: ext.style,
                     alias: None,
+                    // Empty-query short-circuit doesn't classify by tier.
+                    tier: ranker::Tier::FrecencyOnly as u8,
                 });
             }
             let mut seen = std::collections::HashSet::new();
@@ -727,6 +735,7 @@ impl SearchState {
             );
             // Normalize score for display/browser-fallback compatibility.
             ci.result.score = (ci.result.score / skim_max).min(1.0);
+            ci.result.tier = key.tier as u8;
             combined.push((ci.result, key));
         }
 
@@ -752,6 +761,7 @@ impl SearchState {
                 description: ext.description,
                 style: ext.style,
                 alias: None,
+                tier: key.tier as u8,
             };
             combined.push((result, key));
         }
@@ -1710,6 +1720,70 @@ mod service_tests {
             results[0].object_id, "ext_pinned_0",
             "Pinned (tier 0) result must beat app with usage_count 100 at tier 1"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // SearchResult.tier — exposes the tier merged_search already computes
+    // internally, so the frontend can stop re-deriving it with its own
+    // substring-based approximation (rust-first audit #2).
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn merged_search_exact_title_match_has_tier_exact_title() {
+        let state = make_state();
+        state.index_one(app("app_safari", "Safari", 0)).unwrap();
+        let results = state.merged_search("Safari", vec![], 10).unwrap();
+        let hit = results.iter().find(|r| r.object_id == "app_safari").unwrap();
+        assert_eq!(hit.tier, ranker::Tier::ExactTitle as u8);
+    }
+
+    #[test]
+    fn merged_search_pinned_external_result_has_tier_pinned() {
+        let state = make_state();
+        let external = vec![ext_result(
+            "ext_calc_42_0",
+            "42",
+            0.0,
+            Some(models::ResultPriority::Top),
+        )];
+        let results = state.merged_search("anything", external, 10).unwrap();
+        let hit = results.iter().find(|r| r.object_id == "ext_calc_42_0").unwrap();
+        assert_eq!(hit.tier, ranker::Tier::Pinned as u8);
+    }
+
+    #[test]
+    fn merged_search_subtitle_match_has_tier_subtitle_or_keyword() {
+        // Indexed items can't reach this tier through merged_search: the
+        // title-only skim prefilter in `search()` and classify()'s own
+        // title-fuzzy check run the same algorithm on the same title, so they
+        // always agree. Only external results (added unconditionally, no
+        // prefilter) can fall through title-fuzzy and land on subtitle/keyword.
+        let state = make_state();
+        let external = vec![models::ExternalSearchResult {
+            object_id: "ext_slack_0".to_string(),
+            name: "Slack".to_string(), // no 't', 'e', 'a', or 'm' — title-fuzzy can't match "team"
+            description: Some("Team chat".to_string()),
+            result_type: "command".to_string(),
+            score: 0.5,
+            icon: None,
+            extension_id: Some("test-ext".to_string()),
+            category: Some("extension".to_string()),
+            style: None,
+            priority: None,
+        }];
+        let results = state.merged_search("team", external, 10).unwrap();
+        let hit = results.iter().find(|r| r.object_id == "ext_slack_0").unwrap();
+        assert_eq!(hit.tier, ranker::Tier::SubtitleOrKeyword as u8);
+    }
+
+    #[test]
+    fn merged_search_backfill_items_have_tier_frecency_only() {
+        let state = make_state();
+        state.index_one(app("app_unrelated", "Unrelated App", 5)).unwrap();
+        // Query matches nothing, so the only results are frecency backfill.
+        let results = state.merged_search("zzz_no_match_zzz", vec![], 5).unwrap();
+        assert!(!results.is_empty());
+        assert!(results.iter().all(|r| r.tier == ranker::Tier::FrecencyOnly as u8));
     }
 
     // ------------------------------------------------------------------

--- a/asyar-launcher/src-tauri/src/search_engine/models.rs
+++ b/asyar-launcher/src-tauri/src/search_engine/models.rs
@@ -77,6 +77,10 @@ pub struct SearchResult {
     pub style: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
+    /// Tier ordinal from `ranker::Tier` (0=Pinned .. 5=FrecencyOnly), computed
+    /// by `merged_search`'s classify pass. Lets the frontend consume Rust's
+    /// tier directly instead of re-deriving it with its own approximation.
+    pub tier: u8,
 }
 
 /// Result-level priority hint. `Top` pins the result above all tier 1–5
@@ -344,6 +348,7 @@ mod bindings_export {
             .register::<ResultPriority>()
             .register::<UpdateCommandMetadataInput>()
             .register::<crate::search_engine::ranker::RankInput>()
+            .register::<crate::search_engine::ranker::TierResult>()
             .register::<AliasMatch>()
             .register::<MergedSearchResponse>()
             .register::<crate::aliases::ItemAlias>()

--- a/asyar-launcher/src-tauri/src/search_engine/ranker.rs
+++ b/asyar-launcher/src-tauri/src/search_engine/ranker.rs
@@ -166,6 +166,39 @@ pub fn rank_ids(query: &str, items: &[RankInput]) -> Vec<String> {
         .collect()
 }
 
+/// Per-item tier classification result, returned by `classify_many`.
+#[derive(Clone, Debug, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TierResult {
+    pub id: String,
+    pub tier: u8,
+}
+
+/// Classify every item against `query`, preserving input order and keeping
+/// every id (no filtering, no sorting) — unlike `rank_ids`. Used where the
+/// caller needs a tier value per item to interleave against data tiered
+/// elsewhere (e.g. Run rows interleaved with already-tiered search results).
+pub fn classify_many(query: &str, items: &[RankInput]) -> Vec<TierResult> {
+    items
+        .iter()
+        .map(|item| {
+            let keyword_refs: Vec<&str> = item.keywords.iter().map(|k| k.as_str()).collect();
+            let key = classify(
+                query,
+                &item.title,
+                item.subtitle.as_deref(),
+                &keyword_refs,
+                0.0,
+                false,
+            );
+            TierResult {
+                id: item.id.clone(),
+                tier: key.tier as u8,
+            }
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -304,5 +337,55 @@ mod tests {
     fn name_lower_carried_through() {
         let key = classify("Safari", "Safari", None, &[], 0.0, false);
         assert_eq!(key.name_lower, "safari");
+    }
+
+    #[test]
+    fn classify_many_preserves_input_order_unsorted() {
+        // "fuzzy" would sort after "exact" under rank_ids; classify_many must
+        // not reorder — callers need per-item tiers against their own list order.
+        let items = vec![
+            input("fuzzy", "Snow Safari", None, &[]),
+            input("exact", "Safari", None, &[]),
+        ];
+        let results = classify_many("safari", &items);
+        assert_eq!(
+            results.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+            vec!["fuzzy", "exact"]
+        );
+    }
+
+    #[test]
+    fn classify_many_does_not_filter_non_matches() {
+        // Unlike rank_ids, classify_many must keep every input id — callers
+        // need a tier value for non-matches too (e.g. to sink them below
+        // already-tiered data from elsewhere).
+        let items = vec![
+            input("hit", "Safari", None, &[]),
+            input("miss", "Notes", None, &[]),
+        ];
+        let results = classify_many("safari", &items);
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results.iter().find(|r| r.id == "miss").unwrap().tier,
+            Tier::FrecencyOnly as u8
+        );
+    }
+
+    #[test]
+    fn classify_many_tier_values_match_classify() {
+        let items = vec![input("exact", "Safari", None, &[])];
+        let results = classify_many("safari", &items);
+        let expected = classify("safari", "Safari", None, &[], 0.0, false);
+        assert_eq!(results[0].tier, expected.tier as u8);
+    }
+
+    #[test]
+    fn classify_many_empty_query_returns_frecency_only_for_all() {
+        let items = vec![
+            input("a", "Banana", None, &[]),
+            input("b", "Apple", None, &[]),
+        ];
+        let results = classify_many("", &items);
+        assert!(results.iter().all(|r| r.tier == Tier::FrecencyOnly as u8));
     }
 }

--- a/asyar-launcher/src/bindings.ts
+++ b/asyar-launcher/src/bindings.ts
@@ -109,9 +109,21 @@ export type SearchResult = {
 	description?: string | null,
 	style?: string | null,
 	alias?: string | null,
+	/**
+	 *  Tier ordinal from `ranker::Tier` (0=Pinned .. 5=FrecencyOnly), computed
+	 *  by `merged_search`'s classify pass. Lets the frontend consume Rust's
+	 *  tier directly instead of re-deriving it with its own approximation.
+	 */
+	tier: number,
 };
 
 export type SearchableItem = { category: "application" } & Application | { category: "command" } & Command;
+
+// Per-item tier classification result, returned by `classify_many`.
+export type TierResult = {
+	id: string,
+	tier: number,
+};
 
 // Input for updating a command's runtime metadata (currently: subtitle only).
 export type UpdateCommandMetadataInput = {

--- a/asyar-launcher/src/built-in-features/shortcuts/shortcutService.ts
+++ b/asyar-launcher/src/built-in-features/shortcuts/shortcutService.ts
@@ -126,6 +126,7 @@ class ShortcutService {
           path: shortcutInfo.itemPath || '',
           type: 'application',
           score: 1,
+          tier: 5, // untiered: opened directly from a shortcut binding, not search results
           icon: '' // Not used by opening logic
         });
       } catch (e) {

--- a/asyar-launcher/src/lib/classifyItems.test.ts
+++ b/asyar-launcher/src/lib/classifyItems.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+import { classifyItems } from './classifyItems';
+import { invoke } from '@tauri-apps/api/core';
+
+interface Item {
+  id: string;
+  name: string;
+  desc?: string;
+  tags?: string[];
+}
+
+const items: Item[] = [
+  { id: '1', name: 'Safari', desc: 'web browser', tags: ['apple'] },
+  { id: '2', name: 'Notes', desc: 'jot things' },
+];
+
+describe('classifyItems', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns an empty map for an empty query without calling Rust', async () => {
+    const result = await classifyItems('  ', items, {
+      id: (i) => i.id,
+      title: (i) => i.name,
+    });
+    expect(invoke).not.toHaveBeenCalled();
+    expect(result.size).toBe(0);
+  });
+
+  it('returns an empty map for an empty item list without calling Rust', async () => {
+    const result = await classifyItems('saf', [], {
+      id: (i: Item) => i.id,
+      title: (i: Item) => i.name,
+    });
+    expect(invoke).not.toHaveBeenCalled();
+    expect(result.size).toBe(0);
+  });
+
+  it('sends RankInput payload to the classify_items command', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce([]);
+    await classifyItems('saf', items, {
+      id: (i) => i.id,
+      title: (i) => i.name,
+      subtitle: (i) => i.desc,
+      keywords: (i) => i.tags ?? [],
+    });
+    expect(invoke).toHaveBeenCalledWith('classify_items', {
+      query: 'saf',
+      items: [
+        { id: '1', title: 'Safari', subtitle: 'web browser', keywords: ['apple'] },
+        { id: '2', title: 'Notes', subtitle: 'jot things', keywords: [] },
+      ],
+    });
+  });
+
+  it('builds a Map from id to tier using the command response, keeping every id', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce([
+      { id: '1', tier: 1 },
+      { id: '2', tier: 5 },
+    ]);
+    const result = await classifyItems('x', items, {
+      id: (i) => i.id,
+      title: (i) => i.name,
+    });
+    expect(result.get('1')).toBe(1);
+    expect(result.get('2')).toBe(5);
+  });
+
+  it('trims the query before sending', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce([]);
+    await classifyItems('  saf  ', items, { id: (i) => i.id, title: (i) => i.name });
+    expect(invoke).toHaveBeenCalledWith('classify_items', expect.objectContaining({ query: 'saf' }));
+  });
+});

--- a/asyar-launcher/src/lib/classifyItems.ts
+++ b/asyar-launcher/src/lib/classifyItems.ts
@@ -1,0 +1,46 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * Field accessors that project an arbitrary item onto the shape the Rust
+ * ranker understands. `title` is the primary match target; `subtitle` and
+ * `keywords` are secondary. Only `id` and `title` are required.
+ */
+export interface ClassifiableFields<T> {
+  id: (item: T) => string;
+  title: (item: T) => string;
+  subtitle?: (item: T) => string | undefined;
+  keywords?: (item: T) => string[];
+}
+
+/**
+ * Classify every item against `query` using the shared Rust tiered fuzzy
+ * ranker (`classify_items` command, backed by `search_engine::ranker::classify_many`).
+ * Unlike `rankItems`, this keeps every id (no filtering, no sorting) and
+ * returns the raw tier ordinal per id — for interleaving data that isn't in
+ * the Rust search index (e.g. Run rows) against results tiered elsewhere.
+ *
+ * An empty/whitespace query or empty item list returns an empty map without
+ * a round-trip; callers should fall back to their own "untiered" default.
+ */
+export async function classifyItems<T>(
+  query: string,
+  items: T[],
+  fields: ClassifiableFields<T>,
+): Promise<Map<string, number>> {
+  const trimmed = query.trim();
+  if (!trimmed || items.length === 0) return new Map();
+
+  const payload = items.map((item) => ({
+    id: fields.id(item),
+    title: fields.title(item),
+    subtitle: fields.subtitle?.(item) ?? null,
+    keywords: fields.keywords?.(item) ?? [],
+  }));
+
+  const results = await invoke<{ id: string; tier: number }[]>('classify_items', {
+    query: trimmed,
+    items: payload,
+  });
+
+  return new Map(results.map((r) => [r.id, r.tier]));
+}

--- a/asyar-launcher/src/lib/launcher/selectionEffects.svelte.ts
+++ b/asyar-launcher/src/lib/launcher/selectionEffects.svelte.ts
@@ -2,6 +2,8 @@ import { searchStores } from '../../services/search/stores/search.svelte';
 import { actionService } from '../../services/action/actionService.svelte';
 import { ActionContext } from 'asyar-sdk/contracts';
 import { buildMappedItems } from '../searchResultMapper';
+import { classifyItems } from '../classifyItems';
+import type { Run } from 'asyar-sdk/contracts';
 import type { ItemShortcut } from '../../built-in-features/shortcuts/shortcutStore.svelte';
 import type { LauncherState } from './launcherState.svelte';
 import { commandService } from '../../services/extension/commandService.svelte';
@@ -27,6 +29,33 @@ export function setupSelectionEffects(state: LauncherState) {
     actionService.setContext(currentView ? ActionContext.EXTENSION_VIEW : ActionContext.CORE);
   });
 
+  // Effect 7b: Classify run rows against the live query via Rust's shared
+  // tiered ranker. Runs aren't in the Rust search index, so they have no
+  // SearchResult.tier — this batches all of them into one classifyItems
+  // round-trip per query change so Effect 8 can interleave them by real tier
+  // instead of a TS-side substring guess. `runTierMap` is a snapshot from the
+  // last resolved round-trip; the staleness guard discards a response if a
+  // newer keystroke has since changed the query (mirrors the rankItems
+  // snapshot pattern used by snippets/store).
+  let runTierMap = $state(new Map<string, number>());
+  $effect(() => {
+    const q = state.localSearchValue.trim();
+    const runs: Run[] = [
+      ...runService.active,
+      ...runService.unacknowledgedFailures,
+      ...runService.keptAgents,
+      ...runService.unacknowledgedScriptResults,
+    ];
+    if (!q || runs.length === 0) {
+      runTierMap = new Map();
+      return;
+    }
+    classifyItems(q, runs, { id: (r) => r.id, title: (r) => r.label }).then((map) => {
+      if (state.localSearchValue.trim() !== q) return;
+      runTierMap = map;
+    });
+  });
+
   // Effect 8: Map search results to display items.
   // Depends on commandService.liveSubtitles so it re-runs every time an
   // extension calls updateCommandMetadata (e.g. the Pomodoro countdown).
@@ -44,6 +73,7 @@ export function setupSelectionEffects(state: LauncherState) {
       failedRuns: runService.unacknowledgedFailures,
       keptAgentRuns: runService.keptAgents,
       scriptResultRuns: runService.unacknowledgedScriptResults,
+      runTiers: runTierMap,
       query: state.localSearchValue,
       onError: (msg) => diagnosticsService.report({
         source: 'frontend', kind: 'action_failed', severity: 'error',

--- a/asyar-launcher/src/lib/searchResultMapper.test.ts
+++ b/asyar-launcher/src/lib/searchResultMapper.test.ts
@@ -436,12 +436,20 @@ describe('buildMappedItems run injection', () => {
   })
 
   // ── Tier-based interleaving when query is non-empty ──
+  // Tiers are now precomputed (Rust's ranker::Tier ordinal: 0=Pinned ..
+  // 5=FrecencyOnly/no-match) and consumed directly — mappedItems via
+  // `result.tier`, runs via the `runTiers` id→tier map. Neither is recomputed
+  // from title/label substrings here anymore (that duplication is the bug
+  // rust-first audit #2 flagged). A run/item with no precomputed tier
+  // defaults to 5 (no match).
 
-  // A higher-tier run beats a lower-tier mappedItem.
-  // (Prefix run "sdk-build" tier 2; non-matching mappedItem "ZZZ" tier 4 → run first.)
+  // A higher-tier (better-matching) run beats a lower-tier mappedItem.
+  // Adversarial labels: the run's label/item's title would rank the OPPOSITE
+  // way under substring matching, so this only passes if the explicit
+  // tier/runTiers values are what actually drive the order (not the strings).
   it('non-empty query: higher-tier run is inserted before lower-tier search result', () => {
-    const run = makeRun({ id: 'r-sdk', label: 'sdk-build', kind: 'shell-script' })
-    const searchItem = makeResult({ objectId: 'cmd_zzz', name: 'ZZZ' })
+    const run = makeRun({ id: 'r-sdk', label: 'totally unrelated label', kind: 'shell-script' })
+    const searchItem = makeResult({ objectId: 'cmd_zzz', name: 'sdk', tier: 4 })
 
     const { mappedItems } = buildMappedItems({
       searchItems: [searchItem],
@@ -451,6 +459,7 @@ describe('buildMappedItems run injection', () => {
       selectedIndex: 0,
       onError: vi.fn(),
       activeRuns: [run],
+      runTiers: new Map([['r-sdk', 2]]),
       query: 'sdk',
     })
 
@@ -460,10 +469,12 @@ describe('buildMappedItems run injection', () => {
   })
 
   // Catalog wins ties at the same tier (Rust's within-tier ordering is preserved).
-  // (Both "sdk-cli" mapped and "sdk-build" run are tier 2 prefix matches → catalog first.)
+  // Adversarial labels: substring matching would put the run first (exact
+  // label match) and the item last (no substring relation) — the opposite of
+  // the tie-break this test asserts.
   it('non-empty query: catalog wins ties within the same tier', () => {
-    const run = makeRun({ id: 'r-sdk-build', label: 'sdk-build', kind: 'shell-script' })
-    const searchItem = makeResult({ objectId: 'cmd_sdk_cli', name: 'sdk-cli' })
+    const run = makeRun({ id: 'r-sdk-build', label: 'sdk', kind: 'shell-script' })
+    const searchItem = makeResult({ objectId: 'cmd_sdk_cli', name: 'banana', tier: 2 })
 
     const { mappedItems } = buildMappedItems({
       searchItems: [searchItem],
@@ -473,6 +484,7 @@ describe('buildMappedItems run injection', () => {
       selectedIndex: 0,
       onError: vi.fn(),
       activeRuns: [run],
+      runTiers: new Map([['r-sdk-build', 2]]),
       query: 'sdk',
     })
 
@@ -482,9 +494,11 @@ describe('buildMappedItems run injection', () => {
   })
 
   // Exact-match run (tier 1) beats prefix mappedItem (tier 2).
+  // Adversarial labels: substring matching would rank the item first (exact
+  // title match) and the run last (no substring relation).
   it('non-empty query: exact-match run beats prefix-match search result', () => {
-    const run = makeRun({ id: 'r-sdk-exact', label: 'sdk', kind: 'shell-script' })
-    const searchItem = makeResult({ objectId: 'cmd_sdk_cli', name: 'sdk-cli' })
+    const run = makeRun({ id: 'r-sdk-exact', label: 'unrelated xyz', kind: 'shell-script' })
+    const searchItem = makeResult({ objectId: 'cmd_sdk_cli', name: 'sdk', tier: 2 })
 
     const { mappedItems } = buildMappedItems({
       searchItems: [searchItem],
@@ -494,6 +508,7 @@ describe('buildMappedItems run injection', () => {
       selectedIndex: 0,
       onError: vi.fn(),
       activeRuns: [run],
+      runTiers: new Map([['r-sdk-exact', 1]]),
       query: 'sdk',
     })
 
@@ -502,10 +517,14 @@ describe('buildMappedItems run injection', () => {
     expect(mappedItems[1].object_id).toBe('cmd_sdk_cli')
   })
 
-  // Non-matching runs (tier 4) go to the bottom of the list.
-  it('non-empty query: non-matching run sinks to the bottom', () => {
-    const run = makeRun({ id: 'r-ping', label: 'ping -c 30 127.0.0.1', kind: 'shell-script' })
-    const searchItem = makeResult({ objectId: 'cmd_sdk_play', name: 'SDK Playground' })
+  // A run missing from runTiers (e.g. the async classify round-trip hasn't
+  // resolved yet) defaults to tier 5 (no match) and sinks to the bottom.
+  // Adversarial label: the run's label is an exact substring match (would
+  // rank first under the old algorithm) but it's absent from runTiers, so
+  // the default-to-no-match behavior is what must place it last.
+  it('non-empty query: run absent from runTiers defaults to no-match and sinks to the bottom', () => {
+    const run = makeRun({ id: 'r-ping', label: 'sdk', kind: 'shell-script' })
+    const searchItem = makeResult({ objectId: 'cmd_sdk_play', name: 'zzz', tier: 2 })
 
     const { mappedItems } = buildMappedItems({
       searchItems: [searchItem],
@@ -515,6 +534,7 @@ describe('buildMappedItems run injection', () => {
       selectedIndex: 0,
       onError: vi.fn(),
       activeRuns: [run],
+      runTiers: new Map(),
       query: 'sdk',
     })
 
@@ -523,8 +543,34 @@ describe('buildMappedItems run injection', () => {
     expect(mappedItems[1].object_id).toBe('run_r-ping')
   })
 
+  // A mappedItem missing a `tier` (e.g. an extension result that hasn't been
+  // through Rust's tier pass) also defaults to 5 (no match).
+  // Adversarial title: the item's title is an exact substring match (would
+  // rank first under the old algorithm) but has no `tier` field, so the
+  // default-to-no-match behavior is what must place it last.
+  it('non-empty query: mappedItem missing tier defaults to no-match and sinks to the bottom', () => {
+    const run = makeRun({ id: 'r-sdk', label: 'zzz unrelated', kind: 'shell-script' })
+    const searchItem = makeResult({ objectId: 'cmd_untiered', name: 'sdk' }) // no tier field
+
+    const { mappedItems } = buildMappedItems({
+      searchItems: [searchItem],
+      activeContext: null,
+      shortcutStore: [],
+      localSearchValue: 'sdk',
+      selectedIndex: 0,
+      onError: vi.fn(),
+      activeRuns: [run],
+      runTiers: new Map([['r-sdk', 2]]),
+      query: 'sdk',
+    })
+
+    expect(mappedItems).toHaveLength(2)
+    expect(mappedItems[0].object_id).toBe('run_r-sdk')
+    expect(mappedItems[1].object_id).toBe('cmd_untiered')
+  })
+
   // End-to-end mix: matching runs interleave by tier; non-matching runs go last.
-  // mappedItems: ["sdk-cli" tier2, "weird" tier4]; runs: ["sdk-build" tier2, "ping" tier4].
+  // mappedItems: ["sdk-cli" tier2, "weird" tier4]; runs: ["sdk-build" tier2, "ping" tier5(no match)].
   // Walking mappedItems:
   //   sdk-cli (t2) → no tier<2 runs → push sdk-cli
   //   weird (t4) → sdk-build (t2 < 4) → push sdk-build → push weird
@@ -534,8 +580,8 @@ describe('buildMappedItems run injection', () => {
   it('non-empty query: matching runs interleave, non-matching stay at the bottom', () => {
     const runSdkBuild = makeRun({ id: 'r-sdk-build', label: 'sdk-build', kind: 'shell-script' })
     const runPing    = makeRun({ id: 'r-ping',      label: 'ping',      kind: 'shell-script' })
-    const sdkCli = makeResult({ objectId: 'cmd_sdk_cli', name: 'sdk-cli' })
-    const weird  = makeResult({ objectId: 'cmd_weird',   name: 'weird'   })
+    const sdkCli = makeResult({ objectId: 'cmd_sdk_cli', name: 'sdk-cli', tier: 2 })
+    const weird  = makeResult({ objectId: 'cmd_weird',   name: 'weird',   tier: 4 })
 
     const { mappedItems } = buildMappedItems({
       searchItems: [sdkCli, weird],
@@ -545,6 +591,7 @@ describe('buildMappedItems run injection', () => {
       selectedIndex: 0,
       onError: vi.fn(),
       activeRuns: [runSdkBuild, runPing],
+      runTiers: new Map([['r-sdk-build', 2]]), // runPing absent → defaults to 5
       query: 'sdk',
     })
 
@@ -556,14 +603,14 @@ describe('buildMappedItems run injection', () => {
   })
 
   // Failed and kept-agent runs participate in tier interleaving like active runs.
-  // mappedItem "foo" tier4; failedRun "ping failure" tier4 (no match); keptRun "sdk agent" tier2.
+  // mappedItem "foo" tier4; failedRun "ping failure" tier5 (no match); keptRun "sdk agent" tier2.
   // Walking foo (t4): kept "sdk agent" (t2 < 4) → push kept → push foo.
   // Non-matching at end: failed "ping failure".
   // → [sdk agent (kept), foo (mapped), ping failure (failed)]
   it('non-empty query: failed and kept runs obey the same tier interleaving', () => {
     const failedRun = makeRun({ id: 'r-fail-ping', label: 'ping failure', status: 'failed',    kind: 'shell-script' })
     const keptRun   = makeRun({ id: 'r-kept-sdk',  label: 'sdk agent',    status: 'succeeded', kind: 'agent'        })
-    const foo = makeResult({ objectId: 'cmd_foo', name: 'foo' })
+    const foo = makeResult({ objectId: 'cmd_foo', name: 'foo', tier: 4 })
 
     const { mappedItems } = buildMappedItems({
       searchItems: [foo],
@@ -574,6 +621,7 @@ describe('buildMappedItems run injection', () => {
       onError: vi.fn(),
       failedRuns: [failedRun],
       keptAgentRuns: [keptRun],
+      runTiers: new Map([['r-kept-sdk', 2]]), // failedRun absent → defaults to 5
       query: 'sdk',
     })
 
@@ -587,7 +635,7 @@ describe('buildMappedItems run injection', () => {
   // interleaved mappedItem (i.e., its UI position is no longer == baseItems index).
   it('non-empty query: selectedOriginal resolves the right SearchResult after interleaving', () => {
     const run = makeRun({ id: 'r-sdk', label: 'sdk-build', kind: 'shell-script' })
-    const zzz = makeResult({ objectId: 'cmd_zzz', name: 'ZZZ' })
+    const zzz = makeResult({ objectId: 'cmd_zzz', name: 'ZZZ', tier: 4 })
 
     // Layout: [run, zzz] — selectedIndex=1 points at zzz, which is baseItems[0].
     const { selectedOriginal } = buildMappedItems({
@@ -598,6 +646,7 @@ describe('buildMappedItems run injection', () => {
       selectedIndex: 1,
       onError: vi.fn(),
       activeRuns: [run],
+      runTiers: new Map([['r-sdk', 2]]),
       query: 'sdk',
     })
 
@@ -607,7 +656,7 @@ describe('buildMappedItems run injection', () => {
   // selectedOriginal is null when the user lands on a run row.
   it('non-empty query: selectedOriginal is null when selection is a run', () => {
     const run = makeRun({ id: 'r-sdk', label: 'sdk-build', kind: 'shell-script' })
-    const zzz = makeResult({ objectId: 'cmd_zzz', name: 'ZZZ' })
+    const zzz = makeResult({ objectId: 'cmd_zzz', name: 'ZZZ', tier: 4 })
 
     // Layout: [run, zzz] — selectedIndex=0 points at the run.
     const { selectedOriginal } = buildMappedItems({
@@ -618,6 +667,7 @@ describe('buildMappedItems run injection', () => {
       selectedIndex: 0,
       onError: vi.fn(),
       activeRuns: [run],
+      runTiers: new Map([['r-sdk', 2]]),
       query: 'sdk',
     })
 

--- a/asyar-launcher/src/lib/searchResultMapper.ts
+++ b/asyar-launcher/src/lib/searchResultMapper.ts
@@ -85,6 +85,12 @@ export type BuildMappedItemsParams = {
    * as `run-done` rows so script output (captured in `tailOutput`) stays
    * inspectable after the run ends. */
   scriptResultRuns?: Run[];
+  /** Precomputed tier per run id (Rust ranker::Tier ordinal), from a batched
+   * `classifyItems` round-trip. Runs aren't in the Rust search index, so
+   * there's no SearchResult.tier for them — this is how they get one.
+   * A run absent from this map (e.g. the round-trip hasn't resolved yet for
+   * the current query) defaults to NO_MATCH_TIER. */
+  runTiers?: Map<string, number>;
   /** When non-empty, runs are demoted below the mapped search results.
    * When empty, runs are prepended (default-mode browse view). */
   query?: string;
@@ -174,21 +180,11 @@ function buildRunMappedItem(run: Run): MappedSearchItem {
   };
 }
 
-// Mirrors the Rust ranker's tier classification (search_engine/ranker.rs) for
-// the bits we can compute from TS. Used to interleave runs with mappedItems by
-// match quality without re-running the Rust ranker. Note: tier 3 here is plain
-// substring rather than Skim fuzzy — the launcher only has Run.label and the
-// query string in TS, no access to fuzzy_score.
-type MatchTier = 1 | 2 | 3 | 4;
-
-function matchTier(text: string, query: string): MatchTier {
-  const t = text.toLowerCase();
-  const q = query.toLowerCase();
-  if (t === q) return 1;
-  if (t.startsWith(q)) return 2;
-  if (t.includes(q)) return 3;
-  return 4;
-}
+// Tier ordinal used when no precomputed Rust tier is available (e.g. a run
+// missing from `runTiers`, or a mappedItem whose SearchResult lacks `tier`).
+// Mirrors Rust's `Tier::FrecencyOnly` ordinal (search_engine/ranker.rs) — the
+// "no match" tier, so untiered items sink to the bottom rather than guessing.
+const NO_MATCH_TIER = 5;
 
 function getSectionWeight(item: MappedSearchItem): number {
   // Section Order: scripts (0), agents (1), commands (2)
@@ -227,6 +223,7 @@ export function buildMappedItems({
   failedRuns = [],
   keptAgentRuns = [],
   scriptResultRuns = [],
+  runTiers,
   query,
 }: BuildMappedItemsParams): BuildMappedItemsResult {
   // --- Portal injection for url/view-type contexts ---
@@ -238,6 +235,8 @@ export function buildMappedItems({
       name: ctx.provider.display.name,
       type: 'command' as const,
       score: 1.0,
+      // Always surfaces first — Tier::Pinned (0), matching its placement.
+      tier: 0,
       icon: ctx.provider.display.icon,
       extensionId: ctx.provider.type === 'url' ? 'portals' : ctx.provider.id,
     };
@@ -288,7 +287,7 @@ export function buildMappedItems({
       actionFunction = async () => {
         logService.debug(`Calling applicationService.open for ${name} (ID: ${objectId}, Path: ${path})`);
         try {
-          await applicationService.open({ objectId, name, path, score, type });
+          await applicationService.open({ objectId, name, path, score, type, tier: result.tier });
         } catch (err) {
           logService.error(`applicationService.open failed: ${err}`);
           onError(`Failed to open ${name}`);
@@ -340,6 +339,7 @@ export function buildMappedItems({
       typeLabel,
       icon,
       score,
+      tier: result.tier,
       action: actionFunction,
       style: result.style,
       shortcut: shortcutMap.get(objectId)?.shortcut,
@@ -352,8 +352,6 @@ export function buildMappedItems({
   // Definition rows and run rows are orthogonal channels: a def row says
   // "click to invoke", a run row says "this is happening / has happened".
   // Both render unconditionally — neither suppresses the other.
-  const q = (query ?? '').trim();
-
   const activeItems       = activeRuns.map(buildRunMappedItem);
   const failedItems       = failedRuns.map(buildRunMappedItem);
   const keptItems         = keptAgentRuns.map(buildRunMappedItem);
@@ -383,31 +381,37 @@ export function buildMappedItems({
   // with tier T is placed right before the first mappedItem whose tier > T,
   // so a stronger-match run can rise above weaker catalog hits. Within the
   // same tier, mappedItems come first to preserve Rust's within-tier ordering
-  // (fuzzy_score + frecency tiebreakers, which TS can't replicate). Runs
-  // that don't match (tier 4) sink to the bottom in active → failed → kept
-  // order.
+  // (fuzzy_score + frecency tiebreakers, which TS can't replicate). Tiers are
+  // precomputed by Rust — mappedItems carry `result.tier` from merged_search;
+  // runs are looked up in `runTiers` (a batched classifyItems round-trip,
+  // since runs aren't in the Rust search index). Neither is recomputed from
+  // title/label substrings here — that was the rust-first audit #2 bug.
+  // Items/runs with no precomputed tier sink to the bottom in active → failed
+  // → kept order.
   type Tagged =
-    | { kind: 'mapped'; item: MappedSearchItem; baseIdx: number; tier: MatchTier }
-    | { kind: 'run';    item: MappedSearchItem; tier: MatchTier };
+    | { kind: 'mapped'; item: MappedSearchItem; baseIdx: number; tier: number }
+    | { kind: 'run';    item: MappedSearchItem; tier: number };
+
+  const runTier = (runId: string): number => runTiers?.get(runId) ?? NO_MATCH_TIER;
 
   const taggedMapped: Tagged[] = mappedItems.map((item, idx) => ({
     kind: 'mapped',
     item,
     baseIdx: idx,
-    tier: matchTier(item.title ?? '', q),
+    tier: item.tier ?? NO_MATCH_TIER,
   }));
 
   const taggedRuns: Tagged[] = [
-    ...activeItems.map((item, i) => ({ kind: 'run' as const, item, tier: matchTier(activeRuns[i].label, q) })),
-    ...failedItems.map((item, i) => ({ kind: 'run' as const, item, tier: matchTier(failedRuns[i].label, q) })),
-    ...keptItems.map  ((item, i) => ({ kind: 'run' as const, item, tier: matchTier(keptAgentRuns[i].label, q) })),
-    ...scriptResultItems.map((item, i) => ({ kind: 'run' as const, item, tier: matchTier(scriptResultRuns[i].label, q) })),
+    ...activeItems.map((item, i) => ({ kind: 'run' as const, item, tier: runTier(activeRuns[i].id) })),
+    ...failedItems.map((item, i) => ({ kind: 'run' as const, item, tier: runTier(failedRuns[i].id) })),
+    ...keptItems.map  ((item, i) => ({ kind: 'run' as const, item, tier: runTier(keptAgentRuns[i].id) })),
+    ...scriptResultItems.map((item, i) => ({ kind: 'run' as const, item, tier: runTier(scriptResultRuns[i].id) })),
   ];
 
   // Stable-sort by tier ascending; Array.prototype.sort is stable in modern
   // engines, so active → failed → kept ordering is preserved within a tier.
-  const matchingRuns    = taggedRuns.filter(r => r.tier < 4).sort((a, b) => a.tier - b.tier);
-  const nonMatchingRuns = taggedRuns.filter(r => r.tier === 4);
+  const matchingRuns    = taggedRuns.filter(r => r.tier < NO_MATCH_TIER).sort((a, b) => a.tier - b.tier);
+  const nonMatchingRuns = taggedRuns.filter(r => r.tier === NO_MATCH_TIER);
 
   const merged: Tagged[] = [];
   let ri = 0;

--- a/asyar-launcher/src/services/application/applicationsService.test.ts
+++ b/asyar-launcher/src/services/application/applicationsService.test.ts
@@ -128,7 +128,8 @@ describe('open', () => {
       name: 'Finder', 
       path: '/Applications/Finder.app', 
       type: 'application' as const, 
-      score: 1 
+      score: 1,
+      tier: 1
     }
 
     await applicationService.open(app)
@@ -143,7 +144,8 @@ describe('open', () => {
       name: 'Finder', 
       path: '/Applications/Finder.app', 
       type: 'application' as const, 
-      score: 1 
+      score: 1,
+      tier: 1
     }
 
     await applicationService.open(app)
@@ -162,7 +164,8 @@ describe('open', () => {
       name: 'Unknown', 
       path: undefined as any, 
       type: 'application' as const, 
-      score: 1 
+      score: 1,
+      tier: 1
     }
 
     await applicationService.open(app)
@@ -177,7 +180,8 @@ describe('open', () => {
       name: 'Finder', 
       path: '/Applications/Finder.app', 
       type: 'application' as const, 
-      score: 1 
+      score: 1,
+      tier: 1
     }
 
     await applicationService.open(app)
@@ -192,7 +196,8 @@ describe('open', () => {
       name: 'Finder', 
       path: '/Applications/Finder.app', 
       type: 'application' as const, 
-      score: 1 
+      score: 1,
+      tier: 1
     }
 
     await applicationService.open(app)
@@ -207,7 +212,8 @@ describe('open', () => {
       name: 'Finder', 
       path: '/Applications/Finder.app', 
       type: 'application' as const, 
-      score: 1 
+      score: 1,
+      tier: 1
     }
 
     await applicationService.open(app)

--- a/asyar-launcher/src/services/search/types/MappedSearchItem.ts
+++ b/asyar-launcher/src/services/search/types/MappedSearchItem.ts
@@ -11,6 +11,8 @@ export type MappedSearchItem = {
   typeLabel?: string;
   icon?: string;
   score: number;
+  /** Tier ordinal from Rust's `ranker::Tier` (0=Pinned .. 5=FrecencyOnly). */
+  tier?: number;
   style?: "default" | "large";
   shortcut?: string;
   alias?: string;


### PR DESCRIPTION
…t in TS