### PR TITLE
refactor(ipc): route all Tauri invoke() calls through invokeSafe

### DIFF
--- a/asyar-launcher/src/built-in-features/agents/AgentEditView.svelte
+++ b/asyar-launcher/src/built-in-features/agents/AgentEditView.svelte
@@ -49,7 +49,7 @@
   $effect(() => {
     void (async () => {
       try {
-        descriptors = await agentsToolsList();
+        descriptors = (await agentsToolsList()) ?? [];
       } catch {
         descriptors = [];
       }

--- a/asyar-launcher/src/built-in-features/agents/agentLoop.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentLoop.ts
@@ -127,7 +127,7 @@ export async function runAgent(input: RunAgentInput): Promise<void> {
       await runTextOnly(input, agent, plugin, config as ProviderConfig, settings, handle, cancelController.signal, isCancelled);
     } else {
       // Fetch all available tool descriptors and filter to selected ones
-      const allDescriptors = await agentsToolsList();
+      const allDescriptors = (await agentsToolsList()) ?? [];
       const selectedDescriptors = allDescriptors.filter((d) =>
         toolSelection.includes(d.fullyQualifiedId),
       );

--- a/asyar-launcher/src/built-in-features/agents/agentService.svelte.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentService.svelte.ts
@@ -49,86 +49,82 @@ export class AgentService {
   }
 
   async refresh(): Promise<void> {
-    try {
-      const list = await agentsList();
-      this.agents = list;
-    } catch (err) {
+    const list = await agentsList();
+    if (list === null) {
       diagnosticsService.report({
         source: 'frontend',
         kind: 'agents_load_failed',
         severity: 'error',
         retryable: false,
-        developerDetail: String(err),
+        developerDetail: 'agents_list returned null',
       });
+      return;
     }
+    this.agents = list;
   }
 
   async init(): Promise<void> {
     if (this.initialized) return;
-    try {
-      const list = await agentsList();
-      this.agents = list;
-      this.initialized = true;
-    } catch (err) {
+    const list = await agentsList();
+    if (list === null) {
       diagnosticsService.report({
         source: 'frontend',
         kind: 'agents_load_failed',
         severity: 'error',
         retryable: false,
-        developerDetail: String(err),
+        developerDetail: 'agents_list returned null',
       });
-      throw err;
+      throw new Error('Failed to load agents');
     }
+    this.agents = list;
+    this.initialized = true;
   }
 
   async create(input: AgentCreateInput): Promise<AgentDef> {
-    try {
-      const row = await agentsCreate(input);
-      this.agents = [...this.agents, row];
-      return row;
-    } catch (err) {
+    const row = await agentsCreate(input);
+    if (row === null) {
       diagnosticsService.report({
         source: 'frontend',
         kind: 'agents_create_failed',
         severity: 'error',
         retryable: false,
-        developerDetail: String(err),
+        developerDetail: 'agents_create returned null',
       });
-      throw err;
+      throw new Error('Failed to create agent');
     }
+    this.agents = [...this.agents, row];
+    return row;
   }
 
   async update(input: AgentUpdateInput): Promise<AgentDef> {
-    try {
-      const row = await agentsUpdate(input);
-      this.agents = this.agents.map((a) => (a.id === row.id ? row : a));
-      return row;
-    } catch (err) {
+    const row = await agentsUpdate(input);
+    if (row === null) {
       diagnosticsService.report({
         source: 'frontend',
         kind: 'agents_update_failed',
         severity: 'error',
         retryable: false,
-        developerDetail: String(err),
+        developerDetail: 'agents_update returned null',
       });
-      throw err;
+      throw new Error('Failed to update agent');
     }
+    this.agents = this.agents.map((a) => (a.id === row.id ? row : a));
+    return row;
   }
 
   async delete(id: string): Promise<void> {
-    try {
-      await agentsDelete(id);
-      this.agents = this.agents.filter((a) => a.id !== id);
-    } catch (err) {
+    const ok = await agentsDelete(id);
+    if (!ok) {
       diagnosticsService.report({
         source: 'frontend',
         kind: 'agents_delete_failed',
         severity: 'error',
         retryable: false,
-        developerDetail: String(err),
+        developerDetail: 'agents_delete returned false',
       });
-      throw err;
+      throw new Error('Failed to delete agent');
     }
+    this.agents = this.agents.filter((a) => a.id !== id);
   }
 
   getById(id: string): AgentDef | undefined {
@@ -202,27 +198,35 @@ export class AgentService {
   }
 
   async listThreads(agentId: string): Promise<ThreadDef[]> {
-    return agentsThreadsList(agentId);
+    const result = await agentsThreadsList(agentId);
+    if (result === null) throw new Error('Failed to list agent threads');
+    return result;
   }
 
   async createThread(agentId: string, title?: string | null): Promise<ThreadDef> {
-    return agentsThreadCreate(agentId, title);
+    const result = await agentsThreadCreate(agentId, title);
+    if (result === null) throw new Error('Failed to create agent thread');
+    return result;
   }
 
   async deleteThread(id: string): Promise<void> {
-    return agentsThreadDelete(id);
+    await agentsThreadDelete(id);
   }
 
   async updateThreadTitle(id: string, title: string): Promise<void> {
-    return agentsThreadUpdateTitle(id, title);
+    await agentsThreadUpdateTitle(id, title);
   }
 
   async listMessages(threadId: string): Promise<MessageDef[]> {
-    return agentsMessagesList(threadId);
+    const result = await agentsMessagesList(threadId);
+    if (result === null) throw new Error('Failed to list agent messages');
+    return result;
   }
 
   async insertMessage(input: MessageInsertInput): Promise<MessageDef> {
-    return agentsMessageInsert(input);
+    const result = await agentsMessageInsert(input);
+    if (result === null) throw new Error('Failed to insert agent message');
+    return result;
   }
 }
 

--- a/asyar-launcher/src/built-in-features/agents/agentService.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentService.test.ts
@@ -188,7 +188,7 @@ describe('AgentService', () => {
     vi.mocked(commands.agentsList).mockResolvedValueOnce([a1, a2] as never);
     await service.init();
 
-    vi.mocked(commands.agentsDelete).mockResolvedValueOnce(undefined as never);
+    vi.mocked(commands.agentsDelete).mockResolvedValueOnce(true);
 
     await service.delete('a1');
 
@@ -241,10 +241,9 @@ describe('AgentService', () => {
     vi.mocked(commands.agentsList).mockResolvedValueOnce([] as never);
     await service.init();
 
-    const boom = new Error('boom');
-    vi.mocked(commands.agentsCreate).mockRejectedValueOnce(boom);
+    vi.mocked(commands.agentsCreate).mockResolvedValueOnce(null as never);
 
-    await expect(service.create(makeCreateInput())).rejects.toThrow('boom');
+    await expect(service.create(makeCreateInput())).rejects.toThrow();
     expect(diagnosticsService.report).toHaveBeenCalled();
   });
 
@@ -253,10 +252,9 @@ describe('AgentService', () => {
     vi.mocked(commands.agentsList).mockResolvedValueOnce([a1] as never);
     await service.init();
 
-    const boom = new Error('update-boom');
-    vi.mocked(commands.agentsUpdate).mockRejectedValueOnce(boom);
+    vi.mocked(commands.agentsUpdate).mockResolvedValueOnce(null as never);
 
-    await expect(service.update(makeUpdateInput('a1'))).rejects.toThrow('update-boom');
+    await expect(service.update(makeUpdateInput('a1'))).rejects.toThrow();
     expect(diagnosticsService.report).toHaveBeenCalled();
   });
 
@@ -265,10 +263,9 @@ describe('AgentService', () => {
     vi.mocked(commands.agentsList).mockResolvedValueOnce([a1] as never);
     await service.init();
 
-    const boom = new Error('delete-boom');
-    vi.mocked(commands.agentsDelete).mockRejectedValueOnce(boom);
+    vi.mocked(commands.agentsDelete).mockResolvedValueOnce(false);
 
-    await expect(service.delete('a1')).rejects.toThrow('delete-boom');
+    await expect(service.delete('a1')).rejects.toThrow();
     expect(diagnosticsService.report).toHaveBeenCalled();
   });
 });

--- a/asyar-launcher/src/built-in-features/agents/agentsManager.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentsManager.test.ts
@@ -135,7 +135,7 @@ describe('AgentsManager', () => {
 
     vi.mocked(commands.replaceDynamicCommandsBuiltin).mockClear();
 
-    vi.mocked(commands.agentsDelete).mockResolvedValueOnce(undefined as never);
+    vi.mocked(commands.agentsDelete).mockResolvedValueOnce(true);
     await service.delete('a1');
 
     await manager.refresh();

--- a/asyar-launcher/src/built-in-features/agents/silentDispatch.ts
+++ b/asyar-launcher/src/built-in-features/agents/silentDispatch.ts
@@ -366,7 +366,7 @@ async function runToolLoopSilent(
   // Resolve selected tool descriptors. Anthropic rejects `:` / `.` in tool
   // names so we wire-encode the FQID and map back when handling tool_use
   // events — same logic as agentLoop.ts.
-  const allDescriptors = await agentsToolsList();
+  const allDescriptors = (await agentsToolsList()) ?? [];
   const selectedDescriptors = allDescriptors.filter((d) =>
     toolSelection.includes(d.fullyQualifiedId),
   );

--- a/asyar-launcher/src/built-in-features/agents/toolDispatch.ts
+++ b/asyar-launcher/src/built-in-features/agents/toolDispatch.ts
@@ -8,7 +8,7 @@
  *   iframe, await the `asyar:tools:invoke:response` envelope.
  */
 
-import { invoke } from '@tauri-apps/api/core';
+import { invokeRaw } from '../../lib/ipc/invokeSafe';
 import { pickExtensionIframe } from '../../services/extension/extensionIframeSelector';
 import { getExtensionFrameOrigin } from '../../lib/ipc/extensionOrigin';
 import { mcpService } from '../mcp/mcpService.svelte';
@@ -57,7 +57,7 @@ export async function invokeTool(
   const id = fullyQualifiedId.slice(colonIdx + 1);
 
   if (source === 'builtin') {
-    return invoke('agents_invoke_builtin_tool', { id, args });
+    return invokeRaw('agents_invoke_builtin_tool', { id, args });
   }
 
   if (source === 'mcp') {
@@ -97,7 +97,7 @@ export async function invokeTool(
 }
 
 /**
- * Checks whether an error thrown by `invoke('mcp_invoke_tool')` signals that
+ * Checks whether an error thrown by `invokeRaw('mcp_invoke_tool')` signals that
  * permission is required before the tool can run.
  *
  * Rust serializes `AppError::McpPermissionRequired` to the Diagnostic shape:
@@ -140,7 +140,7 @@ async function invokeMcpTool(
   args: unknown,
 ): Promise<unknown> {
   try {
-    return await invoke('mcp_invoke_tool', { serverId, toolId, agentId, args });
+    return await invokeRaw('mcp_invoke_tool', { serverId, toolId, agentId, args });
   } catch (err) {
     if (!isMcpPermissionRequired(err)) throw err;
     const decision = await mcpService.requestPermission(
@@ -151,6 +151,6 @@ async function invokeMcpTool(
     if (decision === 'never' || decision === 'cancel') {
       throw new Error(`MCP tool ${toolId} blocked by user`);
     }
-    return await invoke('mcp_invoke_tool', { serverId, toolId, agentId, args });
+    return await invokeRaw('mcp_invoke_tool', { serverId, toolId, agentId, args });
   }
 }

--- a/asyar-launcher/src/built-in-features/ai/inlineEmojiFallback.ts
+++ b/asyar-launcher/src/built-in-features/ai/inlineEmojiFallback.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { recordInlineEmojiFallbackOutcome } from '../../lib/ipc/shortcodeCommands';
 import { dispatchSilentAgentCommand } from '../agents/silentDispatch';
 import { buildEmojiFallbackAgent } from '../agents/defaultAgent';
 import { agentService } from '../agents/agentService.svelte';
@@ -43,17 +43,9 @@ export async function handleEmojiFallback(p: EmojiFallbackPayload): Promise<void
       onFinalText: async (text: string) => {
         const trimmed = text.trim();
         if (isSingleEmoji(trimmed)) {
-          await invoke('record_inline_emoji_fallback_outcome', {
-            shortcode: p.shortcode,
-            outcome: 'hit',
-            emoji: trimmed,
-          });
+          await recordInlineEmojiFallbackOutcome(p.shortcode, 'hit', trimmed);
         } else {
-          await invoke('record_inline_emoji_fallback_outcome', {
-            shortcode: p.shortcode,
-            outcome: 'miss',
-            emoji: undefined,
-          });
+          await recordInlineEmojiFallbackOutcome(p.shortcode, 'miss', undefined);
         }
       },
     });
@@ -66,14 +58,6 @@ export async function handleEmojiFallback(p: EmojiFallbackPayload): Promise<void
       developerDetail: String(e),
       context: { message: 'inline emoji fallback failed', shortcode: p.shortcode } as never,
     });
-    try {
-      await invoke('record_inline_emoji_fallback_outcome', {
-        shortcode: p.shortcode,
-        outcome: 'miss',
-        emoji: undefined,
-      });
-    } catch {
-      // Swallow — already reported via diagnostics.
-    }
+    await recordInlineEmojiFallbackOutcome(p.shortcode, 'miss', undefined);
   }
 }

--- a/asyar-launcher/src/built-in-features/aliases/aliasService.ts
+++ b/asyar-launcher/src/built-in-features/aliases/aliasService.ts
@@ -14,7 +14,9 @@ export class AliasService {
     itemName: string,
     itemType: 'application' | 'command'
   ): Promise<ItemAlias> {
-    return commands.setAlias(objectId, alias, itemName, itemType);
+    const result = await commands.setAlias(objectId, alias, itemName, itemType);
+    if (result === null) throw new Error('set_alias failed');
+    return result;
   }
 
   async unregister(alias: string): Promise<void> {
@@ -22,7 +24,9 @@ export class AliasService {
   }
 
   async list(): Promise<ItemAlias[]> {
-    return commands.listAliases();
+    const result = await commands.listAliases();
+    if (result === null) throw new Error('list_aliases failed');
+    return result;
   }
 
   async findConflict(

--- a/asyar-launcher/src/built-in-features/create-extension/ai-builder/createdExtensions.ts
+++ b/asyar-launcher/src/built-in-features/create-extension/ai-builder/createdExtensions.ts
@@ -1,20 +1,17 @@
-import { invoke } from '@tauri-apps/api/core';
+import {
+  listCreatedExtensions as listCreatedExtensionsCommand,
+  searchCreatedExtensions as searchCreatedExtensionsCommand,
+  type CreatedExtension,
+} from '../../../lib/ipc/extensionBuilderCommands';
 
-export interface CreatedExtension {
-  id: string;
-  name: string;
-  version: string;
-  description: string;
-  icon?: string | null;
-  path: string;
-}
+export type { CreatedExtension };
 
-export function listCreatedExtensions(): Promise<CreatedExtension[]> {
-  return invoke('list_created_extensions');
+export async function listCreatedExtensions(): Promise<CreatedExtension[]> {
+  return (await listCreatedExtensionsCommand()) ?? [];
 }
 
 // Filtering lives in Rust (rust-first): the view sends the query and renders the
 // returned subset verbatim. An empty query returns every created extension.
-export function searchCreatedExtensions(query: string): Promise<CreatedExtension[]> {
-  return invoke('search_created_extensions', { query });
+export async function searchCreatedExtensions(query: string): Promise<CreatedExtension[]> {
+  return (await searchCreatedExtensionsCommand(query)) ?? [];
 }

--- a/asyar-launcher/src/built-in-features/create-extension/ai-builder/finalizeBuild.ts
+++ b/asyar-launcher/src/built-in-features/create-extension/ai-builder/finalizeBuild.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { registerDevExtension } from '../../../lib/ipc/commands';
 import { scanForSecret, type SecretScanResult } from './secretGuard';
 import { buildJobStore } from './buildJobStore.svelte';
 
@@ -8,7 +8,10 @@ export async function finalizeBuild(path: string, extensionId: string): Promise<
     const result = await scanForSecret(path, secret);
     if (result.leaked) return result;
   }
-  await invoke('register_dev_extension', { extensionId, path });
+  const registered = await registerDevExtension(extensionId, path);
+  if (!registered) {
+    throw new Error(`Failed to register dev extension "${extensionId}"`);
+  }
   const { ExtensionManagerProxy } = await import('asyar-sdk/contracts');
   await new ExtensionManagerProxy().reloadExtensions();
   return { leaked: false };

--- a/asyar-launcher/src/built-in-features/create-extension/ai-builder/secretGuard.ts
+++ b/asyar-launcher/src/built-in-features/create-extension/ai-builder/secretGuard.ts
@@ -1,13 +1,16 @@
-import { invoke } from '@tauri-apps/api/core';
+import { scanExtensionForSecret } from '../../../lib/ipc/extensionBuilderCommands';
 
 export type SecretScanResult = { leaked: false } | { leaked: true; path: string };
 
 // Ask Rust to scan a built extension directory for a build-time secret that
 // leaked into source. The scan runs in Rust because the build output lives at
 // $HOME/AsyarExtensions/<id>, which the frontend Tauri fs allowlist does not
-// cover. Fails closed: a non-empty secret found in any file returns `leaked`.
+// cover. Fails closed: a non-empty secret found in any file returns `leaked`,
+// and a scan that errors outright is also treated as `leaked` rather than
+// silently passing — see `invokeSafeOption`'s `ok` flag.
 export async function scanForSecret(path: string, secret: string): Promise<SecretScanResult> {
   if (secret.trim().length === 0) return { leaked: false };
-  const offending = await invoke<string | null>('scan_extension_for_secret', { path, secret });
-  return offending ? { leaked: true, path: offending } : { leaked: false };
+  const result = await scanExtensionForSecret(path, secret);
+  if (!result.ok) return { leaked: true, path };
+  return result.value ? { leaked: true, path: result.value } : { leaked: false };
 }

--- a/asyar-launcher/src/built-in-features/create-extension/ai-builder/sidecarClient.ts
+++ b/asyar-launcher/src/built-in-features/create-extension/ai-builder/sidecarClient.ts
@@ -1,19 +1,14 @@
-import { invoke } from '@tauri-apps/api/core';
+import { extBuilderStart, extBuilderAnswer, extBuilderCancel } from '../../../lib/ipc/extensionBuilderCommands';
 import { serializeBuilderCommand, type BuilderCommand } from './buildProtocol';
 
 export const sidecarClient = {
-  start(opts: { prompt: string; targetDir: string; capabilitySpecDir: string; anthropicKey: string }): Promise<void> {
-    return invoke('ext_builder_start', {
-      prompt: opts.prompt,
-      targetDir: opts.targetDir,
-      capabilitySpecDir: opts.capabilitySpecDir,
-      anthropicKey: opts.anthropicKey,
-    });
+  async start(opts: { prompt: string; targetDir: string; capabilitySpecDir: string; anthropicKey: string }): Promise<void> {
+    await extBuilderStart(opts);
   },
-  send(cmd: BuilderCommand): Promise<void> {
-    return invoke('ext_builder_answer', { line: serializeBuilderCommand(cmd) });
+  async send(cmd: BuilderCommand): Promise<void> {
+    await extBuilderAnswer(serializeBuilderCommand(cmd));
   },
-  cancel(): Promise<void> {
-    return invoke('ext_builder_cancel');
+  async cancel(): Promise<void> {
+    await extBuilderCancel();
   },
 };

--- a/asyar-launcher/src/built-in-features/create-extension/scaffoldService.ts
+++ b/asyar-launcher/src/built-in-features/create-extension/scaffoldService.ts
@@ -1,18 +1,23 @@
-import { invoke } from '@tauri-apps/api/core';
 import { Command } from '@tauri-apps/plugin-shell';
 import { openPath } from '@tauri-apps/plugin-opener';
 import { logService } from '../../services/log/logService';
+import {
+  writeTextFileAbsolute,
+  mkdirAbsolute,
+  checkPathExists,
+  registerDevExtension,
+} from '../../lib/ipc/commands';
 
 async function writeTextFile(path: string, content: string) {
-  await invoke('write_text_file_absolute', { pathStr: path, content });
+  await writeTextFileAbsolute(path, content);
 }
 
 async function mkdir(path: string) {
-  await invoke('mkdir_absolute', { pathStr: path });
+  await mkdirAbsolute(path);
 }
 
 async function exists(path: string): Promise<boolean> {
-  return await invoke('check_path_exists', { path });
+  return (await checkPathExists(path)) ?? false;
 }
 
 const isWindows = typeof navigator !== 'undefined' && navigator.userAgent.toLowerCase().includes('win');
@@ -209,10 +214,8 @@ export async function generateExtension(options: ScaffoldOptions): Promise<void>
 
   // ── Register dev extension ────────────────────────────────────────────────
   onProgress("Registering development extension...");
-  try {
-    await invoke('register_dev_extension', { extensionId: id, path: location });
-  } catch (error) {
-    logService.error(`Failed to register dev extension automatically: ${error}`);
+  const registered = await registerDevExtension(id, location);
+  if (!registered) {
     onProgress("Note: Failed to register for auto-loading. You may need to run 'asyar link'.");
   }
 

--- a/asyar-launcher/src/built-in-features/portals/index.svelte.ts
+++ b/asyar-launcher/src/built-in-features/portals/index.svelte.ts
@@ -1,7 +1,7 @@
 import type { Extension, ExtensionContext, IExtensionManager } from 'asyar-sdk/contracts';
 import DefaultView from './DefaultView.svelte';
 import { portalStore, type Portal } from './portalStore.svelte';
-import { invoke } from '@tauri-apps/api/core';
+import { openUrl, hideWindow } from '../../lib/ipc/commands';
 import { searchService } from '../../services/search/SearchService';
 import { commandService } from '../../services/extension/commandService.svelte';
 import { actionService } from '../../services/action/actionService.svelte';
@@ -31,7 +31,7 @@ export async function syncPortalToIndex(portal: Portal): Promise<void> {
     execute: async (args?: Record<string, any>) => {
       const query = args?.query ?? '';
       const url = await resolveTemplate(portal.url, { query }, { encodeValues: true });
-      await invoke('plugin:opener|open_url', { url });
+      await openUrl(url);
       return { type: 'no-view' };
     },
   }, 'portals');
@@ -92,9 +92,9 @@ function registerPortalContextProvider(portal: Portal): void {
       }
 
       const url = await resolveTemplate(portal.url, { query }, { encodeValues: true });
-      await invoke('plugin:opener|open_url', { url });
+      await openUrl(url);
       searchService.saveIndex();
-      await invoke('hide');
+      await hideWindow();
     },
   });
 }
@@ -128,7 +128,7 @@ class PortalsExtension implements Extension {
     if (portal) {
       const query = args?.query ?? '';
       const url = await resolveTemplate(portal.url, { query }, { encodeValues: true });
-      await invoke('plugin:opener|open_url', { url });
+      await openUrl(url);
       return { type: 'no-view' };
     }
   }

--- a/asyar-launcher/src/built-in-features/scripts/scriptsManager.svelte.ts
+++ b/asyar-launcher/src/built-in-features/scripts/scriptsManager.svelte.ts
@@ -61,13 +61,13 @@ export class ScriptsManager {
     // Abort every active inline timer + clear subtitles before unregistering
     // commands. Sending [] to the Rust scheduler will return all current ids
     // in `dropped`, which we then use to wipe liveSubtitles.
-    try {
-      const outcome = await scriptsSetInlineScripts([]);
+    const outcome = await scriptsSetInlineScripts([]);
+    if (outcome === null) {
+      logService.warn('[scripts] inline shutdown failed');
+    } else {
       for (const id of outcome.dropped) {
         this.clearLiveSubtitle(id);
       }
-    } catch (err) {
-      logService.warn(`[scripts] inline shutdown failed: ${err}`);
     }
     await replaceDynamicCommandsBuiltin(SCRIPTS_EXTENSION_ID, []);
     this.scripts = [];
@@ -89,6 +89,9 @@ export class ScriptsManager {
 
   private async refresh(): Promise<void> {
     const fresh = await scriptsRescan();
+    if (fresh === null) {
+      throw new Error('Failed to rescan scripts');
+    }
     const regs: DynamicCommandRegistration[] = fresh.map((s) => ({
       id: s.dynamicId,
       name: s.header.title ?? deriveFilenameTitle(s.absolutePath),
@@ -138,11 +141,9 @@ export class ScriptsManager {
       refreshTimeSeconds: s.header.refreshTimeSeconds!,
     }));
 
-    let outcome;
-    try {
-      outcome = await scriptsSetInlineScripts(specs);
-    } catch (err) {
-      logService.warn(`[scripts] scriptsSetInlineScripts failed: ${err}`);
+    const outcome = await scriptsSetInlineScripts(specs);
+    if (outcome === null) {
+      logService.warn('[scripts] scriptsSetInlineScripts failed');
       return;
     }
 

--- a/asyar-launcher/src/built-in-features/shortcuts/shortcutFormatter.ts
+++ b/asyar-launcher/src/built-in-features/shortcuts/shortcutFormatter.ts
@@ -54,8 +54,8 @@ export const VALID_KEYS = new Set<string>();
 
 export async function initValidKeys(): Promise<void> {
   if (VALID_KEYS.size > 0) return; // idempotent
-  const { invoke } = await import('@tauri-apps/api/core');
-  const keys = await invoke<string[]>('get_valid_shortcut_keys');
+  const { getValidShortcutKeys } = await import('../../lib/ipc/commands');
+  const keys = (await getValidShortcutKeys()) ?? [];
   for (const key of keys) VALID_KEYS.add(key);
 }
 

--- a/asyar-launcher/src/built-in-features/shortcuts/shortcutService.test.ts
+++ b/asyar-launcher/src/built-in-features/shortcuts/shortcutService.test.ts
@@ -1,11 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const mockInvoke = vi.hoisted(() => vi.fn().mockImplementation((cmd) => {
-  if (cmd === 'get_valid_shortcut_keys') {
-    return Promise.resolve(['A', 'B', 'Space']);
-  }
-  return Promise.resolve(undefined);
-}));
+const mockGetValidShortcutKeys = vi.hoisted(() => vi.fn().mockResolvedValue(['A', 'B', 'Space']))
+const mockRegisterItemShortcut = vi.hoisted(() => vi.fn().mockResolvedValue(true))
+const mockUnregisterItemShortcut = vi.hoisted(() => vi.fn().mockResolvedValue(true))
 const mockStoreGetAll = vi.hoisted(() => vi.fn().mockReturnValue([]))
 const mockStoreGetByObjectId = vi.hoisted(() => vi.fn().mockReturnValue(undefined))
 const mockStoreAdd = vi.hoisted(() => vi.fn())
@@ -26,8 +23,6 @@ const mockWithReplacementSemantics = vi.hoisted(() =>
 )
 const mockShowWindow = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
 const mockSearchStores = vi.hoisted(() => ({ query: '' }))
-
-vi.mock('@tauri-apps/api/core', () => ({ invoke: mockInvoke }))
 
 vi.mock('./shortcutStore.svelte', () => ({
   shortcutStore: {
@@ -82,6 +77,9 @@ vi.mock('../../services/log/logService', () => ({
 
 vi.mock('../../lib/ipc/commands', () => ({
   showWindow: mockShowWindow,
+  getValidShortcutKeys: mockGetValidShortcutKeys,
+  registerItemShortcut: mockRegisterItemShortcut,
+  unregisterItemShortcut: mockUnregisterItemShortcut,
 }))
 
 import { shortcutService } from './shortcutService'
@@ -108,6 +106,9 @@ beforeEach(() => {
   mockContextIsActive.mockReturnValue(false)
   mockViewManagerGetStackSize.mockReturnValue(0)
   mockSearchStores.query = ''
+  mockGetValidShortcutKeys.mockResolvedValue(['A', 'B', 'Space'])
+  mockRegisterItemShortcut.mockResolvedValue(true)
+  mockUnregisterItemShortcut.mockResolvedValue(true)
 })
 
 // ── init ──────────────────────────────────────────────────────────────────────
@@ -115,8 +116,8 @@ beforeEach(() => {
 describe('init', () => {
   it('does nothing when the store is empty', async () => {
     await shortcutService.init()
-    expect(mockInvoke).toHaveBeenCalledWith('get_valid_shortcut_keys')
-    expect(mockInvoke).toHaveBeenCalledTimes(1)
+    expect(mockGetValidShortcutKeys).toHaveBeenCalledTimes(1)
+    expect(mockRegisterItemShortcut).not.toHaveBeenCalled()
   })
 
   it('re-registers each shortcut from the store', async () => {
@@ -125,10 +126,9 @@ describe('init', () => {
       makeShortcut({ shortcut: 'Control+B', objectId: 'b' }),
     ])
     await shortcutService.init()
-    expect(mockInvoke).toHaveBeenCalledWith('get_valid_shortcut_keys')
-    expect(mockInvoke).toHaveBeenCalledWith('register_item_shortcut', { modifier: 'Alt', key: 'A', objectId: 'a' })
-    expect(mockInvoke).toHaveBeenCalledWith('register_item_shortcut', { modifier: 'Control', key: 'B', objectId: 'b' })
-    expect(mockInvoke).toHaveBeenCalledTimes(3)
+    expect(mockGetValidShortcutKeys).toHaveBeenCalledTimes(1)
+    expect(mockRegisterItemShortcut).toHaveBeenCalledWith('a', 'Alt', 'A')
+    expect(mockRegisterItemShortcut).toHaveBeenCalledWith('b', 'Control', 'B')
   })
 
   it('continues even when a registration fails', async () => {
@@ -136,12 +136,9 @@ describe('init', () => {
       makeShortcut({ shortcut: 'Alt+A', objectId: 'a' }),
       makeShortcut({ shortcut: 'Alt+B', objectId: 'b' }),
     ])
-    mockInvoke.mockImplementationOnce((cmd) => {
-      if (cmd === 'get_valid_shortcut_keys') return Promise.resolve(['A', 'B']);
-      return Promise.resolve(undefined);
-    }).mockRejectedValueOnce(new Error('conflict')) // Alt+A fails
+    mockRegisterItemShortcut.mockResolvedValueOnce(false) // Alt+A fails
     await expect(shortcutService.init()).resolves.not.toThrow()
-    expect(mockInvoke).toHaveBeenCalledTimes(3) // init + 2 shortcuts
+    expect(mockRegisterItemShortcut).toHaveBeenCalledTimes(2)
   })
 })
 
@@ -204,15 +201,15 @@ describe('register', () => {
     mockStoreGetAll.mockReturnValue([makeShortcut({ shortcut: 'Alt+A', objectId: 'other', itemName: 'Other' })])
     const result = await shortcutService.register('obj-new', 'New App', 'application', 'Alt+A')
     expect(result).toEqual({ ok: false, conflict: { objectId: 'other', itemName: 'Other' } })
-    expect(mockInvoke).not.toHaveBeenCalled()
+    expect(mockRegisterItemShortcut).not.toHaveBeenCalled()
   })
 
   it('unregisters existing shortcut for same item before registering a new one', async () => {
     const existing = makeShortcut({ shortcut: 'Alt+X', objectId: 'obj-1' })
     mockStoreGetByObjectId.mockReturnValue(existing)
     await shortcutService.register('obj-1', 'App', 'application', 'Alt+Y')
-    expect(mockInvoke).toHaveBeenCalledWith('unregister_item_shortcut', { modifier: 'Alt', key: 'X' })
-    expect(mockInvoke).toHaveBeenCalledWith('register_item_shortcut', { modifier: 'Alt', key: 'Y', objectId: 'obj-1' })
+    expect(mockUnregisterItemShortcut).toHaveBeenCalledWith('Alt', 'X')
+    expect(mockRegisterItemShortcut).toHaveBeenCalledWith('obj-1', 'Alt', 'Y')
   })
 
   it('adds the shortcut to the store and returns { ok: true } on success', async () => {
@@ -228,7 +225,7 @@ describe('register', () => {
   })
 
   it('returns { ok: false } when invoke throws', async () => {
-    mockInvoke.mockRejectedValueOnce(new Error('already registered'))
+    mockRegisterItemShortcut.mockResolvedValueOnce(false)
     const result = await shortcutService.register('obj-1', 'App', 'application', 'Alt+A')
     expect(result.ok).toBe(false)
     expect(mockStoreAdd).not.toHaveBeenCalled()
@@ -240,13 +237,13 @@ describe('register', () => {
 describe('unregister', () => {
   it('does nothing when no shortcut exists for the objectId', async () => {
     await shortcutService.unregister('nonexistent')
-    expect(mockInvoke).not.toHaveBeenCalled()
+    expect(mockUnregisterItemShortcut).not.toHaveBeenCalled()
   })
 
   it('invokes unregister_item_shortcut with the parsed modifier and key', async () => {
     mockStoreGetByObjectId.mockReturnValue(makeShortcut({ shortcut: 'Control+J', objectId: 'obj-1' }))
     await shortcutService.unregister('obj-1')
-    expect(mockInvoke).toHaveBeenCalledWith('unregister_item_shortcut', { modifier: 'Control', key: 'J' })
+    expect(mockUnregisterItemShortcut).toHaveBeenCalledWith('Control', 'J')
   })
 
   it('removes the item from the store on success', async () => {
@@ -257,7 +254,7 @@ describe('unregister', () => {
 
   it('does not remove from store when invoke fails', async () => {
     mockStoreGetByObjectId.mockReturnValue(makeShortcut({ objectId: 'obj-1' }))
-    mockInvoke.mockRejectedValueOnce(new Error('not registered'))
+    mockUnregisterItemShortcut.mockResolvedValueOnce(false)
     await shortcutService.unregister('obj-1')
     expect(mockStoreRemove).not.toHaveBeenCalled()
   })
@@ -270,7 +267,6 @@ describe('handleFiredShortcut', () => {
     await shortcutService.handleFiredShortcut('unknown')
     expect(mockAppOpen).not.toHaveBeenCalled()
     expect(mockExecuteCommand).not.toHaveBeenCalled()
-    expect(mockInvoke).not.toHaveBeenCalled()
   })
 
   it('opens an application when itemType is "application"', async () => {

--- a/asyar-launcher/src/built-in-features/shortcuts/shortcutService.ts
+++ b/asyar-launcher/src/built-in-features/shortcuts/shortcutService.ts
@@ -1,4 +1,3 @@
-import { invoke } from '@tauri-apps/api/core';
 import { tick } from 'svelte';
 import { shortcutStore, type ItemShortcut } from './shortcutStore.svelte';
 import { applicationService } from '../../services/application/applicationsService';
@@ -9,7 +8,7 @@ import { contextActivationId, contextModeService } from '../../services/context/
 import { viewManager } from '../../services/extension/viewManager.svelte';
 import { searchStores } from '../../services/search/stores/search.svelte';
 import { logService } from '../../services/log/logService';
-import { showWindow } from '../../lib/ipc/commands';
+import { showWindow, registerItemShortcut, unregisterItemShortcut } from '../../lib/ipc/commands';
 
 class ShortcutService {
   async init(): Promise<void> {
@@ -18,10 +17,9 @@ class ShortcutService {
     const shortcuts = shortcutStore.shortcuts;
     await Promise.all(shortcuts.map(async s => {
       const [modifier, key] = parseShortcut(s.shortcut);
-      try {
-        await invoke('register_item_shortcut', { modifier, key, objectId: s.objectId });
-      } catch (e) {
-        logService.warn(`Failed to re-register shortcut ${s.shortcut} for ${s.itemName}: ${e}`);
+      const ok = await registerItemShortcut(s.objectId, modifier, key);
+      if (!ok) {
+        logService.warn(`Failed to re-register shortcut ${s.shortcut} for ${s.itemName}`);
       }
     }));
   }
@@ -48,23 +46,22 @@ class ShortcutService {
     }
     const resolvedIcon = itemIcon ?? existing?.itemIcon;
 
-    try {
-      await invoke('register_item_shortcut', { modifier, key, objectId });
-      shortcutStore.add({
-        id: crypto.randomUUID(),
-        objectId,
-        itemName,
-        itemType,
-        itemPath,
-        itemIcon: resolvedIcon,
-        shortcut,
-        createdAt: Date.now()
-      });
-      return { ok: true };
-    } catch (e) {
-      logService.error(`Failed to register shortcut: ${e}`);
-      return { ok: false, conflict: { objectId: 'error', itemName: String(e) } };
+    const registered = await registerItemShortcut(objectId, modifier, key);
+    if (!registered) {
+      logService.error(`Failed to register shortcut for ${objectId}`);
+      return { ok: false, conflict: { objectId: 'error', itemName: 'Failed to register shortcut' } };
     }
+    shortcutStore.add({
+      id: crypto.randomUUID(),
+      objectId,
+      itemName,
+      itemType,
+      itemPath,
+      itemIcon: resolvedIcon,
+      shortcut,
+      createdAt: Date.now()
+    });
+    return { ok: true };
   }
 
   async unregister(objectId: string): Promise<void> {
@@ -72,11 +69,11 @@ class ShortcutService {
     if (!existing) return;
 
     const [modifier, key] = parseShortcut(existing.shortcut);
-    try {
-      await invoke('unregister_item_shortcut', { modifier, key });
+    const ok = await unregisterItemShortcut(modifier, key);
+    if (ok) {
       shortcutStore.remove(objectId);
-    } catch (e) {
-      logService.error(`Failed to unregister shortcut: ${e}`);
+    } else {
+      logService.error(`Failed to unregister shortcut for ${objectId}`);
     }
   }
 

--- a/asyar-launcher/src/built-in-features/snippets/snippetService.test.ts
+++ b/asyar-launcher/src/built-in-features/snippets/snippetService.test.ts
@@ -42,7 +42,7 @@ vi.mock('../../lib/persistence/extensionStore', () => ({
 }))
 
 vi.mock('../../services/log/logService', () => ({
-  logService: { warn: mockWarn }
+  logService: { warn: mockWarn, error: vi.fn() }
 }))
 
 const mockRedactIfEnabled = vi.hoisted(() => vi.fn())
@@ -172,7 +172,7 @@ describe('setEnabled', () => {
     mockInvoke.mockRejectedValueOnce(new Error('permission denied'))
     const result = await snippetService.setEnabled(true)
     expect(result.ok).toBe(false)
-    expect(result.error).toContain('permission denied')
+    expect(result.error).toContain('set_snippets_enabled failed')
   })
 })
 
@@ -181,7 +181,7 @@ describe('setEnabled', () => {
 describe('openAccessibilityPreferences', () => {
   it('invokes open_accessibility_preferences', async () => {
     await snippetService.openAccessibilityPreferences()
-    expect(mockInvoke).toHaveBeenCalledWith('open_accessibility_preferences')
+    expect(mockInvoke).toHaveBeenCalledWith('open_accessibility_preferences', undefined)
   })
 })
 

--- a/asyar-launcher/src/built-in-features/snippets/snippetService.ts
+++ b/asyar-launcher/src/built-in-features/snippets/snippetService.ts
@@ -31,6 +31,10 @@ export const snippetService = {
   async init(): Promise<void> {
     try {
       const permitted = await commands.checkSnippetPermission();
+      if (permitted === null) {
+        logService.warn('Snippet expansion init: check_snippet_permission failed');
+        return;
+      }
       if (!permitted) return;
 
       await this.syncToRust();
@@ -45,7 +49,7 @@ export const snippetService = {
   },
 
   async onViewOpen(): Promise<{ permissionGranted: boolean }> {
-    const granted = await commands.checkSnippetPermission();
+    const granted = (await commands.checkSnippetPermission()) ?? false;
     if (granted) await this.syncToRust();
     return { permissionGranted: granted };
   },
@@ -58,12 +62,8 @@ export const snippetService = {
   },
 
   async setEnabled(enabled: boolean): Promise<{ ok: boolean; error?: string }> {
-    try {
-      await commands.setSnippetsEnabled(enabled);
-      return { ok: true };
-    } catch (e) {
-      return { ok: false, error: String(e) };
-    }
+    const ok = await commands.setSnippetsEnabled(enabled);
+    return ok ? { ok: true } : { ok: false, error: 'set_snippets_enabled failed' };
   },
 
   async openAccessibilityPreferences(): Promise<void> {

--- a/asyar-launcher/src/built-in-features/store/DetailView.svelte
+++ b/asyar-launcher/src/built-in-features/store/DetailView.svelte
@@ -68,7 +68,7 @@
       return;
     }
     try {
-      const installedPaths: string[] = await commands.listInstalledExtensions();
+      const installedPaths: string[] = (await commands.listInstalledExtensions()) ?? [];
       isInstalled = installedPaths.some(p => p.endsWith(`/${extensionId}`) || p.endsWith(`\\${extensionId}`) || p === extensionId);
       storeExtension.notifyInstalledStateChanged(isInstalled, extensionId);
     } catch (e) {

--- a/asyar-launcher/src/built-in-features/store/index.svelte.ts
+++ b/asyar-launcher/src/built-in-features/store/index.svelte.ts
@@ -377,7 +377,7 @@ class StoreExtension implements Extension {
       
       // Override status based on local installation state
       try {
-        const installedPaths: string[] = await commands.listInstalledExtensions();
+        const installedPaths: string[] = (await commands.listInstalledExtensions()) ?? [];
         for (const ext of fetchedExtensions) {
           const extIdStr = String(ext.id);
           const isInstalled = installedPaths.some((p: string) => 

--- a/asyar-launcher/src/components/settings/ScheduledTasksSection.svelte
+++ b/asyar-launcher/src/components/settings/ScheduledTasksSection.svelte
@@ -18,7 +18,7 @@
 
   async function loadTasks() {
     try {
-      tasks = await getScheduledTasks();
+      tasks = (await getScheduledTasks()) ?? [];
     } catch (e) {
       logService.error(`Failed to load scheduled tasks: ${e}`);
       diagnosticsService.report({

--- a/asyar-launcher/src/components/settings/ShellTrustManager.svelte
+++ b/asyar-launcher/src/components/settings/ShellTrustManager.svelte
@@ -33,7 +33,10 @@
     for (const record of recordsWithShell) {
       try {
         const binaries = await shellListTrusted(record.manifest.id);
-        
+        if (binaries === null) {
+          throw new Error('shell_list_trusted failed');
+        }
+
         if (binaries.length > 0) {
           results.push({
             extensionId: record.manifest.id,

--- a/asyar-launcher/src/components/settings/usageShareState.svelte.ts
+++ b/asyar-launcher/src/components/settings/usageShareState.svelte.ts
@@ -4,11 +4,11 @@ class UsageShareState {
   anonId = $state('');
 
   async load() {
-    this.anonId = await getUsageAnonId();
+    this.anonId = (await getUsageAnonId()) ?? '';
   }
 
   async reset() {
-    this.anonId = await resetUsageAnonId();
+    this.anonId = (await resetUsageAnonId()) ?? '';
   }
 }
 

--- a/asyar-launcher/src/lib/classifyItems.ts
+++ b/asyar-launcher/src/lib/classifyItems.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { classifyItemsCommand } from './ipc/extensionLifecycleCommands';
 
 /**
  * Field accessors that project an arbitrary item onto the shape the Rust
@@ -37,10 +37,8 @@ export async function classifyItems<T>(
     keywords: fields.keywords?.(item) ?? [],
   }));
 
-  const results = await invoke<{ id: string; tier: number }[]>('classify_items', {
-    query: trimmed,
-    items: payload,
-  });
+  const results = await classifyItemsCommand(trimmed, payload);
+  if (results === null) return new Map();
 
   return new Map(results.map((r) => [r.id, r.tier]));
 }

--- a/asyar-launcher/src/lib/filterCompatibleExtensions.ts
+++ b/asyar-launcher/src/lib/filterCompatibleExtensions.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { filterCompatibleExtensionsCommand } from './ipc/extensionLifecycleCommands';
 
 export interface PlatformCheckFields<T> {
   id: (item: T) => string;
@@ -23,7 +23,8 @@ export async function filterCompatibleExtensions<T>(
     platforms: fields.platforms(item) ?? null,
   }));
 
-  const compatibleIds = await invoke<string[]>('filter_compatible_extensions', { items: payload });
+  const compatibleIds = await filterCompatibleExtensionsCommand(payload);
+  if (compatibleIds === null) return [];
 
   const byId = new Map(items.map((item) => [fields.id(item), item]));
   return compatibleIds

--- a/asyar-launcher/src/lib/ipc/applicationCommands.ts
+++ b/asyar-launcher/src/lib/ipc/applicationCommands.ts
@@ -1,0 +1,65 @@
+import { invokeSafe, invokeSafeVoid } from './invokeSafe';
+import type { FrontmostApplication } from 'asyar-sdk/contracts';
+
+export interface AppDataPath {
+  path: string;
+  sizeBytes: number;
+  category: string;
+}
+
+export interface UninstallScanResult {
+  appPath: string;
+  appSizeBytes: number;
+  dataPaths: AppDataPath[];
+  totalBytes: number;
+}
+
+export async function getFrontmostApplication(): Promise<FrontmostApplication | null> {
+  return invokeSafe<FrontmostApplication>('get_frontmost_application');
+}
+
+export async function appIsRunning(bundleId: string): Promise<boolean | null> {
+  return invokeSafe<boolean>('app_is_running', { bundleId });
+}
+
+// `uninstall_application`/`set_application_scan_paths` are `Result<(), AppError>`
+// on the Rust side — use invokeSafeVoid's boolean signal, not invokeSafe's null.
+
+export async function uninstallApplication(
+  path: string,
+  dataPaths: string[] = [],
+): Promise<boolean> {
+  return invokeSafeVoid('uninstall_application', { path, dataPaths });
+}
+
+export async function scanUninstallTargets(path: string): Promise<UninstallScanResult | null> {
+  return invokeSafe<UninstallScanResult>('scan_uninstall_targets', { path });
+}
+
+export async function applicationIndexSubscribe(
+  extensionId: string | null,
+  eventTypes: string[],
+): Promise<string | null> {
+  return invokeSafe<string>('application_index_subscribe', { extensionId, eventTypes });
+}
+
+export async function applicationIndexUnsubscribe(
+  extensionId: string | null,
+  subscriptionId: string,
+): Promise<boolean> {
+  return invokeSafeVoid('application_index_unsubscribe', { extensionId, subscriptionId });
+}
+
+export async function setApplicationScanPaths(paths: string[]): Promise<boolean> {
+  return invokeSafeVoid('set_application_scan_paths', { paths });
+}
+
+export async function appUpdaterShouldShowWhatsNew(
+  lastSeenVersion: string | undefined,
+  currentVersion: string,
+): Promise<boolean | null> {
+  return invokeSafe<boolean>('app_updater_should_show_whats_new', {
+    lastSeenVersion,
+    currentVersion,
+  });
+}

--- a/asyar-launcher/src/lib/ipc/browserCommands.ts
+++ b/asyar-launcher/src/lib/ipc/browserCommands.ts
@@ -1,0 +1,106 @@
+import { invokeSafe } from './invokeSafe';
+import type {
+  Bookmark,
+  BrowserFamily,
+  BrowserId,
+  BrowserKey,
+  HistoryEntry,
+  ListBookmarksFilter,
+  OpenUrlTarget,
+  SearchHistoryOptions,
+  Tab,
+  PageSnapshot,
+  PageMatch,
+  PageAction,
+} from 'asyar-sdk/contracts';
+
+export async function browserListAvailableBrowsers(): Promise<BrowserId[] | null> {
+  return invokeSafe<BrowserId[]>('browser_list_available_browsers');
+}
+
+export async function browserIsCompanionInstalled(family: BrowserFamily): Promise<boolean | null> {
+  return invokeSafe<boolean>('browser_is_companion_installed', { family });
+}
+
+export async function browserListBookmarks(filter?: ListBookmarksFilter): Promise<Bookmark[] | null> {
+  return invokeSafe<Bookmark[]>('browser_list_bookmarks', {
+    browser: filter?.browser,
+    query: filter?.query,
+  });
+}
+
+export async function browserSearchHistory(
+  query: string,
+  opts?: SearchHistoryOptions,
+): Promise<HistoryEntry[] | null> {
+  return invokeSafe<HistoryEntry[]>('browser_search_history', {
+    query,
+    limit: opts?.limit,
+    sinceMs: opts?.sinceMs,
+  });
+}
+
+export async function browserListTabs(
+  filter?: { browser?: BrowserId; query?: string },
+): Promise<Tab[] | null> {
+  return invokeSafe<Tab[]>('browser_list_tabs', {
+    browser: filter?.browser,
+    query: filter?.query,
+  });
+}
+
+export async function browserGetActiveTab(browser?: BrowserId): Promise<Tab | null> {
+  return invokeSafe<Tab | null>('browser_get_active_tab', { browser });
+}
+
+export async function browserActivateTab(tabId: string): Promise<void> {
+  await invokeSafe('browser_activate_tab', { tabId });
+}
+
+export async function browserCloseTab(tabId: string): Promise<void> {
+  await invokeSafe('browser_close_tab', { tabId });
+}
+
+export async function browserOpenUrl(url: string, target?: OpenUrlTarget): Promise<void> {
+  await invokeSafe('browser_open_url', { url, target });
+}
+
+export async function browserListPairedBrowsers(): Promise<BrowserKey[] | null> {
+  return invokeSafe<BrowserKey[]>('browser_list_paired_browsers');
+}
+
+export async function browserGetCurrentPage(browser?: BrowserId): Promise<PageSnapshot | null> {
+  return invokeSafe<PageSnapshot | null>('browser_get_current_page', { browser });
+}
+
+export async function browserQueryPage(
+  tabId: string,
+  selector: string,
+  attrs?: string[],
+): Promise<PageMatch[] | null> {
+  return invokeSafe<PageMatch[]>('browser_query_page', { tabId, selector, attrs });
+}
+
+export async function browserActOnPage(tabId: string, action: PageAction): Promise<void> {
+  await invokeSafe('browser_act_on_page', { tabId, action });
+}
+
+export async function browserSearchWeb(text: string, browser?: BrowserId): Promise<void> {
+  await invokeSafe('browser_search_web', { text, browser });
+}
+
+export async function browserGetMostRecentActiveBrowser(): Promise<BrowserKey | null> {
+  return invokeSafe<BrowserKey | null>('browser_get_most_recent_active_browser');
+}
+
+export async function browserSubscribeTabsChanged(): Promise<string | null> {
+  return invokeSafe<string>('browser_events_subscribe', { eventTypes: ['tabs.changed'] });
+}
+
+export async function browserUnsubscribeEvents(subscriptionId: string): Promise<void> {
+  await invokeSafe('browser_events_unsubscribe', { subscriptionId });
+}
+
+export async function browserSubscribePageChanged(): Promise<string | null> {
+  return invokeSafe<string>('browser_events_subscribe', { eventTypes: ['page.changed'] });
+}

--- a/asyar-launcher/src/lib/ipc/clipboardCommands.ts
+++ b/asyar-launcher/src/lib/ipc/clipboardCommands.ts
@@ -1,0 +1,9 @@
+import { invokeSafe } from './invokeSafe';
+
+export async function clipboardStripHtml(content: string): Promise<string> {
+  return (await invokeSafe<string>('clipboard_strip_html', { content })) ?? '';
+}
+
+export async function clipboardStripRtf(content: string): Promise<string> {
+  return (await invokeSafe<string>('clipboard_strip_rtf', { content })) ?? '';
+}

--- a/asyar-launcher/src/lib/ipc/commandArgDefaultsCommands.ts
+++ b/asyar-launcher/src/lib/ipc/commandArgDefaultsCommands.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { invokeSafe } from './invokeSafe';
 
 /**
  * Load the last-submitted argument values for a command.
@@ -9,8 +9,8 @@ import { invoke } from '@tauri-apps/api/core';
 export async function commandArgDefaultsGet(
   extensionId: string,
   commandId: string
-): Promise<Record<string, string>> {
-  return invoke<Record<string, string>>('command_arg_defaults_get', {
+): Promise<Record<string, string> | null> {
+  return invokeSafe<Record<string, string>>('command_arg_defaults_get', {
     extensionId,
     commandId,
   });
@@ -26,5 +26,5 @@ export async function commandArgDefaultsSet(
   commandId: string,
   values: Record<string, string>
 ): Promise<void> {
-  return invoke('command_arg_defaults_set', { extensionId, commandId, values });
+  await invokeSafe('command_arg_defaults_set', { extensionId, commandId, values });
 }

--- a/asyar-launcher/src/lib/ipc/commands.ts
+++ b/asyar-launcher/src/lib/ipc/commands.ts
@@ -1,6 +1,5 @@
 // asyar-launcher/src/lib/ipc/commands.ts
-import { invoke } from '@tauri-apps/api/core';
-import { invokeSafe } from './invokeSafe';
+import { invokeSafe, invokeSafeVoid } from './invokeSafe';
 import type {
   SearchableItem,
   SearchResult,
@@ -14,6 +13,18 @@ import type { AvailableUpdate } from '../../types/ExtensionUpdate';
 export * from './extensionPreferencesCommands';
 export * from './commandArgDefaultsCommands';
 export * from './iframeLifecycleCommands';
+export * from './browserCommands';
+export * from './extensionLifecycleCommands';
+export * from './shortcodeCommands';
+export * from './shellCommands';
+export * from './applicationCommands';
+export * from './statusBarCommands';
+export * from './extensionBuilderCommands';
+export * from './systemCommands';
+export * from './searchAccessoryCommands';
+export * from './clipboardCommands';
+export * from './settingsUiCommands';
+export * from './updateCommands';
 
 export type ExternalSearchResult = {
   objectId: string;
@@ -29,16 +40,19 @@ export type ExternalSearchResult = {
 
 // ── Search ────────────────────────────────────────────────────────────────────
 
-export async function searchItems(query: string): Promise<SearchResult[]> {
-  return invoke<SearchResult[]>('search_items', { query });
+// Shared with ExtensionIpcRouter's EXTENSION_INVOKE_DISPATCH table (which
+// relies on the default, non-silent report) — SearchService.performSearch
+// passes silent:true since it reports its own, more specific diagnostic.
+export async function searchItems(query: string, opts?: { silent?: boolean }): Promise<SearchResult[] | null> {
+  return invokeSafe<SearchResult[]>('search_items', { query }, opts);
 }
 
 export async function mergedSearch(
   query: string,
   externalResults: ExternalSearchResult[],
   minResults?: number
-): Promise<MergedSearchResponse> {
-  return invoke<MergedSearchResponse>('merged_search', { query, externalResults, minResults });
+): Promise<MergedSearchResponse | null> {
+  return invokeSafe<MergedSearchResponse>('merged_search', { query, externalResults, minResults });
 }
 
 // ── Aliases ───────────────────────────────────────────────────────────────────
@@ -48,55 +62,62 @@ export async function setAlias(
   alias: string,
   itemName: string,
   itemType: 'application' | 'command'
-): Promise<ItemAlias> {
-  return invoke('set_alias', { objectId, alias, itemName, itemType });
+): Promise<ItemAlias | null> {
+  return invokeSafe('set_alias', { objectId, alias, itemName, itemType });
 }
 
 export async function unsetAlias(alias: string): Promise<void> {
-  await invoke('unset_alias', { alias });
+  await invokeSafe('unset_alias', { alias });
 }
 
-export async function listAliases(): Promise<ItemAlias[]> {
-  return invoke('list_aliases');
+export async function listAliases(): Promise<ItemAlias[] | null> {
+  return invokeSafe('list_aliases');
 }
 
 export async function findAliasConflict(
   alias: string,
   excludingObjectId?: string
 ): Promise<AliasConflict | null> {
-  return invoke('find_alias_conflict', { alias, excludingObjectId });
+  return invokeSafe('find_alias_conflict', { alias, excludingObjectId });
 }
 
-export async function getIndexedItems(): Promise<SearchableItem[]> {
-  return invoke('get_indexed_items');
+export async function getIndexedItems(): Promise<SearchableItem[] | null> {
+  return invokeSafe('get_indexed_items');
 }
 
-export async function indexItem(item: SearchableItem): Promise<void> {
-  return invoke('index_item', { item });
+// boolean (not void): SearchService.indexItem needs to know whether indexing
+// actually succeeded to report its own specific diagnostic on failure.
+export async function indexItem(item: SearchableItem): Promise<boolean> {
+  return invokeSafeVoid('index_item', { item }, { silent: true });
 }
 
 export async function batchIndexItems(items: SearchableItem[]): Promise<void> {
-  return invoke('batch_index_items', { items });
+  await invokeSafe('batch_index_items', { items });
 }
 
 export async function deleteItem(objectId: string): Promise<void> {
-  return invoke('delete_item', { objectId });
+  await invokeSafe('delete_item', { objectId });
 }
 
-export async function getIndexedObjectIds(): Promise<Set<string>> {
-  return invoke<string[]>('get_indexed_object_ids').then(arr => new Set(arr));
+export async function getIndexedObjectIds(): Promise<Set<string> | null> {
+  const arr = await invokeSafe<string[]>('get_indexed_object_ids');
+  return arr === null ? null : new Set(arr);
 }
 
 export async function recordItemUsage(objectId: string): Promise<void> {
-  return invoke('record_item_usage', { objectId });
+  await invokeSafe('record_item_usage', { objectId });
 }
 
-export async function resetSearchIndex(): Promise<void> {
-  return invoke('reset_search_index');
+// boolean (not void): SearchService.resetIndex needs to know whether the
+// reset actually succeeded to report its own specific diagnostic on failure.
+export async function resetSearchIndex(): Promise<boolean> {
+  return invokeSafeVoid('reset_search_index', undefined, { silent: true });
 }
 
-export async function saveSearchIndex(): Promise<void> {
-  return invoke('save_search_index');
+// boolean (not void): SearchService.saveIndex needs to know whether the
+// save actually succeeded to report its own specific diagnostic on failure.
+export async function saveSearchIndex(): Promise<boolean> {
+  return invokeSafeVoid('save_search_index', undefined, { silent: true });
 }
 
 // ── Applications ──────────────────────────────────────────────────────────────
@@ -107,24 +128,24 @@ export interface SyncResult {
   total: number;
 }
 
-export async function syncApplicationIndex(extraPaths?: string[]): Promise<SyncResult> {
-  return invoke<SyncResult>('sync_application_index', { extraPaths });
+export async function syncApplicationIndex(extraPaths?: string[]): Promise<SyncResult | null> {
+  return invokeSafe<SyncResult>('sync_application_index', { extraPaths });
 }
 
-export async function listApplications(extraPaths?: string[]): Promise<Application[]> {
-  return invoke<Application[]>('list_applications', { extraPaths });
+export async function listApplications(extraPaths?: string[]): Promise<Application[] | null> {
+  return invokeSafe<Application[]>('list_applications', { extraPaths });
 }
 
 export async function openApplicationPath(path: string): Promise<void> {
-  return invoke('open_application_path', { path });
+  await invokeSafe('open_application_path', { path });
 }
 
-export async function getDefaultAppScanPaths(): Promise<string[]> {
-  return invoke<string[]>('get_default_app_scan_paths');
+export async function getDefaultAppScanPaths(): Promise<string[] | null> {
+  return invokeSafe<string[]>('get_default_app_scan_paths');
 }
 
-export async function normalizeScanPath(path: string): Promise<string> {
-  return invoke<string>('normalize_scan_path', { path });
+export async function normalizeScanPath(path: string): Promise<string | null> {
+  return invokeSafe<string>('normalize_scan_path', { path });
 }
 
 // ── Window ────────────────────────────────────────────────────────────────────
@@ -146,38 +167,37 @@ function twoFrames(): Promise<void> {
  */
 /** Mirrors the `asyar_visible` atomic. The JS side reads this to decide
  * between the two-phase reveal and the single-shot `show` fallback. */
-export async function isVisible(): Promise<boolean> {
-  return invoke<boolean>('is_visible');
+export async function isVisible(): Promise<boolean | null> {
+  return invokeSafe<boolean>('is_visible');
 }
 
 export async function showWindow(): Promise<void> {
   const wasVisible = await isVisible();
   if (wasVisible) {
-    return invoke('show');
+    await invokeSafe('show');
+    return;
   }
-  await invoke('prepare_show');
-  try {
-    await twoFrames();
-    await invoke('commit_show');
-  } catch (e) {
+  await invokeSafe('prepare_show');
+  await twoFrames();
+  const committed = await invokeSafe('commit_show');
+  if (committed === null) {
     // prepare_show left the panel mapped at alpha 0 (or off-screen on
     // win/linux). If commit_show never runs, the launcher is invisible
     // but active. Force the single-shot reveal so the user isn't stuck.
-    await invoke('show').catch(() => {});
-    throw e;
+    await invokeSafe('show');
   }
 }
 
 export async function hideWindow(): Promise<void> {
-  return invoke('hide');
+  await invokeSafe('hide');
 }
 
 export async function setFocusLock(locked: boolean): Promise<void> {
-  return invoke('set_focus_lock', { locked });
+  await invokeSafe('set_focus_lock', { locked });
 }
 
 export async function quitApp(): Promise<void> {
-  return invoke('quit_app');
+  await invokeSafe('quit_app');
 }
 
 
@@ -186,15 +206,15 @@ export async function setLauncherHeight(
   expanded?: boolean,
   deferUntilNextCaCommit?: boolean,
 ): Promise<void> {
-  return invoke('set_launcher_height', { height, expanded, deferUntilNextCaCommit });
+  await invokeSafe('set_launcher_height', { height, expanded, deferUntilNextCaCommit });
 }
 
 export async function markLauncherReady(expanded: boolean): Promise<void> {
-  return invoke('mark_launcher_ready', { expanded });
+  await invokeSafe('mark_launcher_ready', { expanded });
 }
 
 export async function setLauncherKeepExpanded(keepExpanded: boolean): Promise<void> {
-  return invoke('set_launcher_keep_expanded', { keepExpanded });
+  await invokeSafe('set_launcher_keep_expanded', { keepExpanded });
 }
 
 export interface ShowMoreBarStyle {
@@ -205,7 +225,7 @@ export interface ShowMoreBarStyle {
 }
 
 export async function updateShowMoreBarStyle(style: ShowMoreBarStyle): Promise<void> {
-  return invoke('update_show_more_bar_style', { style });
+  await invokeSafe('update_show_more_bar_style', { style });
 }
 
 export interface ShowMoreBarHudsPayload {
@@ -216,15 +236,15 @@ export interface ShowMoreBarHudsPayload {
 }
 
 export async function updateShowMoreBarHuds(huds: ShowMoreBarHudsPayload): Promise<void> {
-  return invoke('update_show_more_bar_huds', { huds });
+  await invokeSafe('update_show_more_bar_huds', { huds });
 }
 
 export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Promise<void> {
-  return invoke('set_panel_appearance', { pref });
+  await invokeSafe('set_panel_appearance', { pref });
 }
 
   export async function appRelaunch(): Promise<void> {
-    return invoke('app_relaunch');
+    await invokeSafe('app_relaunch');
   }
 
   /**
@@ -237,14 +257,14 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
    * exits — callers should not depend on a return value.
    */
   export async function factoryReset(): Promise<void> {
-    return invoke('factory_reset');
+    await invokeSafe('factory_reset');
   }
 
   export async function showSettingsWindow(tab?: string): Promise<void> {
     // Direct callers bypass the no-view command hide path, so reset here too.
     // Dynamic import breaks the commands ↔ extensionManager module cycle.
     const { resetLauncherState } = await import('../launcher/launcherReset');
-    await hideWindow().catch(() => {});
+    await hideWindow();
     resetLauncherState();
     const { WebviewWindow } = await import('@tauri-apps/api/webviewWindow');
     const settingsWindow = await WebviewWindow.getByLabel('settings');
@@ -274,12 +294,12 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     height?: number
   }
 
-  export async function windowGetBounds(): Promise<WindowBounds> {
-    return invoke<WindowBounds>('window_management_get_bounds')
+  export async function windowGetBounds(): Promise<WindowBounds | null> {
+    return invokeSafe<WindowBounds>('window_management_get_bounds')
   }
 
   export async function windowSetBounds(update: WindowBoundsUpdate): Promise<void> {
-    return invoke('window_management_set_bounds', {
+    await invokeSafe('window_management_set_bounds', {
       x: update.x ?? null,
       y: update.y ?? null,
       width: update.width ?? null,
@@ -288,15 +308,15 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
   }
 
   export async function windowSetFullscreen(enable: boolean): Promise<void> {
-    return invoke('window_management_set_fullscreen', { enable })
+    await invokeSafe('window_management_set_fullscreen', { enable })
   }
 
-  export async function windowGetMonitors(): Promise<WindowBounds[]> {
-    return invoke<WindowBounds[]>('window_management_get_monitors')
+  export async function windowGetMonitors(): Promise<WindowBounds[] | null> {
+    return invokeSafe<WindowBounds[]>('window_management_get_monitors')
   }
 
   export async function windowApplyPreset(presetId: string): Promise<void> {
-    return invoke('window_management_apply_preset', { presetId })
+    await invokeSafe('window_management_apply_preset', { presetId })
   }
 
   // ── HUD ───────────────────────────────────────────────────────────────────────
@@ -307,11 +327,11 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
   }
 
   export async function getHudState(): Promise<HudContent | null> {
-    return invoke<HudContent | null>('get_hud_state');
+    return invokeSafe<HudContent | null>('get_hud_state');
   }
 
   export async function showHud(args: { title: string; durationMs: number; spinning: boolean }): Promise<void> {
-    return invoke('show_hud', {
+    await invokeSafe('show_hud', {
       title: args.title,
       durationMs: args.durationMs,
       spinning: args.spinning,
@@ -319,21 +339,21 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
   }
 
   export async function hideHud(): Promise<void> {
-    return invoke('hide_hud');
+    await invokeSafe('hide_hud');
   }
 
   // ── Extensions ────────────────────────────────────────────────────────────────
 
-  export async function getExtensionsDir(): Promise<string> {
-    return invoke<string>('get_extensions_dir');
+  export async function getExtensionsDir(): Promise<string | null> {
+    return invokeSafe<string>('get_extensions_dir');
   }
 
-  export async function listInstalledExtensions(): Promise<string[]> {
-    return invoke<string[]>('list_installed_extensions');
+  export async function listInstalledExtensions(): Promise<string[] | null> {
+    return invokeSafe<string[]>('list_installed_extensions');
   }
 
   export async function uninstallExtension(extensionId: string): Promise<void> {
-    return invoke('uninstall_extension', { extensionId });
+    await invokeSafe('uninstall_extension', { extensionId });
   }
 
   export async function installExtensionFromUrl(params: {
@@ -344,7 +364,7 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     checksum: string | null;
   }): Promise<void> {
     const { url, extensionId, extensionName, version, checksum } = params;
-    return invoke('install_extension_from_url', {
+    await invokeSafe('install_extension_from_url', {
       downloadUrl: url,
       extensionId,
       extensionName,
@@ -353,50 +373,52 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     });
   }
 
-  export async function getBuiltinFeaturesPath(): Promise<string> {
-    return invoke<string>('get_builtin_features_path');
+  export async function getBuiltinFeaturesPath(): Promise<string | null> {
+    return invokeSafe<string>('get_builtin_features_path');
   }
 
-  export async function registerDevExtension(extensionId: string, path: string): Promise<void> {
-    return invoke('register_dev_extension', { extensionId, path });
+  // `register_dev_extension` is `Result<(), AppError>` on the Rust side —
+  // use invokeSafeVoid's boolean signal so callers can fall back on failure.
+  export async function registerDevExtension(extensionId: string, path: string): Promise<boolean> {
+    return invokeSafeVoid('register_dev_extension', { extensionId, path });
   }
 
-  export async function getDevExtensionPaths(): Promise<Record<string, string>> {
-    return invoke<Record<string, string>>('get_dev_extension_paths');
+  export async function getDevExtensionPaths(): Promise<Record<string, string> | null> {
+    return invokeSafe<Record<string, string>>('get_dev_extension_paths');
   }
 
   export async function spawnHeadlessExtension(extensionId: string, scriptPath: string): Promise<void> {
-    return invoke('spawn_headless_extension', { id: extensionId, path: scriptPath });
+    await invokeSafe('spawn_headless_extension', { id: extensionId, path: scriptPath });
   }
 
   export async function killExtension(extensionId: string): Promise<void> {
-    return invoke('kill_extension', { id: extensionId });
+    await invokeSafe('kill_extension', { id: extensionId });
   }
 
-  export async function discoverExtensions(): Promise<ExtensionRecord[]> {
-    return invoke<ExtensionRecord[]>('discover_extensions');
+  export async function discoverExtensions(): Promise<ExtensionRecord[] | null> {
+    return invokeSafe<ExtensionRecord[]>('discover_extensions');
   }
 
   export async function setExtensionEnabled(extensionId: string, enabled: boolean): Promise<void> {
-    return invoke('set_extension_enabled', { extensionId, enabled });
+    await invokeSafe('set_extension_enabled', { extensionId, enabled });
   }
 
-  export async function getExtension(extensionId: string): Promise<ExtensionRecord> {
-    return invoke<ExtensionRecord>('get_extension', { extensionId });
+  export async function getExtension(extensionId: string): Promise<ExtensionRecord | null> {
+    return invokeSafe<ExtensionRecord>('get_extension', { extensionId });
   }
 
   // -- Extension Updates --
 
-  export async function checkExtensionUpdates(storeApiBaseUrl: string): Promise<AvailableUpdate[]> {
-    return invoke<AvailableUpdate[]>('check_extension_updates', { storeApiBaseUrl });
+  export async function checkExtensionUpdates(storeApiBaseUrl: string): Promise<AvailableUpdate[] | null> {
+    return invokeSafe<AvailableUpdate[]>('check_extension_updates', { storeApiBaseUrl });
   }
 
   export async function updateExtension(update: AvailableUpdate): Promise<void> {
-    return invoke('update_extension', { update });
+    await invokeSafe('update_extension', { update });
   }
 
-  export async function updateAllExtensions(updates: AvailableUpdate[]): Promise<[string, { Ok?: null; Err?: string }][]> {
-    return invoke('update_all_extensions', { updates });
+  export async function updateAllExtensions(updates: AvailableUpdate[]): Promise<[string, { Ok?: null; Err?: string }][] | null> {
+    return invokeSafe('update_all_extensions', { updates });
   }
 
   export interface CommandSyncInput {
@@ -414,8 +436,8 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     total: number;
   }
 
-  export async function syncCommandIndex(commands: CommandSyncInput[]): Promise<CommandSyncResult> {
-    return invoke<CommandSyncResult>('sync_command_index', { commands });
+  export async function syncCommandIndex(commands: CommandSyncInput[]): Promise<CommandSyncResult | null> {
+    return invokeSafe<CommandSyncResult>('sync_command_index', { commands });
   }
 
   export interface UpdateCommandMetadataInput {
@@ -424,7 +446,7 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
   }
 
   export async function updateCommandMetadata(input: UpdateCommandMetadataInput): Promise<void> {
-    return invoke('update_command_metadata', { input });
+    await invokeSafe('update_command_metadata', { input });
   }
 
   /**
@@ -458,7 +480,7 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     extensionId: string,
     regs: DynamicCommandRegistrationInput[],
   ): Promise<void> {
-    return invoke('replace_dynamic_commands', { extensionId, regs });
+    await invokeSafe('replace_dynamic_commands', { extensionId, regs });
   }
 
   /**
@@ -482,7 +504,7 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
   export async function getDynamicCommandMeta(
     objectId: string,
   ): Promise<DynamicCommandMetaReply | null> {
-    return invoke<DynamicCommandMetaReply | null>('get_dynamic_command_meta', { objectId });
+    return invokeSafe<DynamicCommandMetaReply | null>('get_dynamic_command_meta', { objectId });
   }
 
   export interface ScheduledTaskInfo {
@@ -494,8 +516,8 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     active: boolean;
   }
 
-  export async function getScheduledTasks(): Promise<ScheduledTaskInfo[]> {
-    return invoke<ScheduledTaskInfo[]>('get_scheduled_tasks');
+  export async function getScheduledTasks(): Promise<ScheduledTaskInfo[] | null> {
+    return invokeSafe<ScheduledTaskInfo[]>('get_scheduled_tasks');
   }
 
   // -- Theme types --
@@ -515,85 +537,104 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
   // -- Plugin system commands --
 
   export async function installExtensionFromFile(filePath: string): Promise<void> {
-    return invoke('install_extension_from_file', { filePath });
+    await invokeSafe('install_extension_from_file', { filePath });
   }
 
   export async function showOpenExtensionDialog(): Promise<string | null> {
-    return invoke<string | null>('show_open_extension_dialog');
+    return invokeSafe<string | null>('show_open_extension_dialog');
   }
 
-  export async function getThemeDefinition(extensionId: string): Promise<ThemeDefinition> {
-    return invoke<ThemeDefinition>('get_theme_definition', { extensionId });
+  export async function getThemeDefinition(extensionId: string): Promise<ThemeDefinition | null> {
+    return invokeSafe<ThemeDefinition>('get_theme_definition', { extensionId });
   }
 
   // ── Shortcuts ─────────────────────────────────────────────────────────────────
 
-  export async function registerItemShortcut(objectId: string, modifier: string, key: string): Promise<void> {
-    return invoke('register_item_shortcut', { objectId, modifier, key });
+  // `register_item_shortcut`/`unregister_item_shortcut` are `Result<(), AppError>`
+  // on the Rust side — use invokeSafeVoid's boolean signal so callers can
+  // detect a conflict/failure instead of assuming the shortcut took effect.
+  export async function registerItemShortcut(objectId: string, modifier: string, key: string): Promise<boolean> {
+    return invokeSafeVoid('register_item_shortcut', { objectId, modifier, key });
   }
 
-  export async function unregisterItemShortcut(modifier: string, key: string): Promise<void> {
-    return invoke('unregister_item_shortcut', { modifier, key });
+  export async function unregisterItemShortcut(modifier: string, key: string): Promise<boolean> {
+    return invokeSafeVoid('unregister_item_shortcut', { modifier, key });
   }
 
-  export async function updateGlobalShortcut(modifier: string, key: string): Promise<void> {
-    return invoke('update_global_shortcut', { modifier, key });
+  // `update_global_shortcut` is `Result<(), AppError>` on the Rust side —
+  // use invokeSafeVoid's boolean signal so callers can detect failure.
+  export async function updateGlobalShortcut(modifier: string, key: string): Promise<boolean> {
+    return invokeSafeVoid('update_global_shortcut', { modifier, key });
   }
 
-  export async function getPersistedShortcut(): Promise<{ modifier: string; key: string }> {
-    return invoke<{ modifier: string; key: string }>('get_persisted_shortcut');
+  export async function getPersistedShortcut(): Promise<{ modifier: string; key: string } | null> {
+    return invokeSafe<{ modifier: string; key: string }>('get_persisted_shortcut');
   }
 
   export async function initializeShortcutFromSettings(modifier: string, key: string): Promise<void> {
-    return invoke('initialize_shortcut_from_settings', { modifier, key });
+    await invokeSafe('initialize_shortcut_from_settings', { modifier, key });
   }
 
   export async function pauseUserShortcuts(): Promise<void> {
-    return invoke('pause_user_shortcuts');
+    await invokeSafe('pause_user_shortcuts');
   }
 
   export async function resumeUserShortcuts(): Promise<void> {
-    return invoke('resume_user_shortcuts');
+    await invokeSafe('resume_user_shortcuts');
+  }
+
+  // Distinct from pause/resumeUserShortcuts: these also pause/resume the
+  // launcher's own global shortcut, not just user item shortcuts.
+  export async function pauseAllShortcuts(): Promise<void> {
+    await invokeSafe('pause_all_shortcuts');
+  }
+
+  export async function resumeAllShortcuts(): Promise<void> {
+    await invokeSafe('resume_all_shortcuts');
+  }
+
+  export async function getValidShortcutKeys(): Promise<string[] | null> {
+    return invokeSafe<string[]>('get_valid_shortcut_keys');
   }
 
   // ── Autostart ─────────────────────────────────────────────────────────────────
 
-  export async function getAutostartStatus(): Promise<boolean> {
-    return invoke<boolean>('get_autostart_status');
+  export async function getAutostartStatus(): Promise<boolean | null> {
+    return invokeSafe<boolean>('get_autostart_status');
   }
 
   export async function initializeAutostartFromSettings(enabled: boolean): Promise<void> {
-    return invoke('initialize_autostart_from_settings', { enable: enabled });
+    await invokeSafe('initialize_autostart_from_settings', { enable: enabled });
   }
 
   // ── File I/O ──────────────────────────────────────────────────────────────────
 
-  export async function checkPathExists(path: string): Promise<boolean> {
-    return invoke<boolean>('check_path_exists', { path });
+  export async function checkPathExists(path: string): Promise<boolean | null> {
+    return invokeSafe<boolean>('check_path_exists', { path });
   }
 
-  export async function readTextFileAbsolute(pathStr: string): Promise<string> {
-    return invoke<string>('read_text_file_absolute', { pathStr });
+  export async function readTextFileAbsolute(pathStr: string): Promise<string | null> {
+    return invokeSafe<string>('read_text_file_absolute', { pathStr });
   }
 
   export async function writeTextFileAbsolute(pathStr: string, content: string): Promise<void> {
-    return invoke('write_text_file_absolute', { pathStr, content });
+    await invokeSafe('write_text_file_absolute', { pathStr, content });
   }
 
   export async function writeBinaryFileRecursive(pathStr: string, content: number[]): Promise<void> {
-    return invoke('write_binary_file_recursive', { pathStr, content });
+    await invokeSafe('write_binary_file_recursive', { pathStr, content });
   }
 
   export async function mkdirAbsolute(pathStr: string): Promise<void> {
-    return invoke('mkdir_absolute', { pathStr });
+    await invokeSafe('mkdir_absolute', { pathStr });
   }
 
   export async function showInFileManager(pathStr: string): Promise<void> {
-    return invoke('show_in_file_manager', { pathStr });
+    await invokeSafe('show_in_file_manager', { pathStr });
   }
 
   export async function trashPath(pathStr: string): Promise<void> {
-    return invoke('trash_path', { pathStr });
+    await invokeSafe('trash_path', { pathStr });
   }
 
   // ── System ────────────────────────────────────────────────────────────────────
@@ -605,8 +646,8 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     body?: string;
     timeoutMs?: number;
     callerExtensionId?: string | null;
-  }): Promise<{ status: number; statusText: string; headers: Record<string, string>; body: string; ok: boolean }> {
-    return invoke('fetch_url', {
+  }): Promise<{ status: number; statusText: string; headers: Record<string, string>; body: string; ok: boolean } | null> {
+    return invokeSafe('fetch_url', {
       url: params.url,
       method: params.method ?? 'GET',
       headers: params.headers,
@@ -633,8 +674,8 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     body?: string;
     actions?: NotificationActionInput[];
     callerExtensionId?: string | null;
-  }): Promise<string> {
-    return invoke<string>('send_notification', {
+  }): Promise<string | null> {
+    return invokeSafe<string>('send_notification', {
       title: params.title,
       body: params.body ?? '',
       actions: params.actions ?? null,
@@ -646,22 +687,22 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     notificationId: string;
     callerExtensionId?: string | null;
   }): Promise<void> {
-    return invoke('dismiss_notification', {
+    await invokeSafe('dismiss_notification', {
       notificationId: params.notificationId,
       callerExtensionId: params.callerExtensionId ?? null,
     });
   }
 
   export async function simulatePaste(): Promise<void> {
-    return invoke('simulate_paste');
+    await invokeSafe('simulate_paste');
   }
 
   export async function expandAndPaste(keywordLen: number): Promise<void> {
-    return invoke('expand_and_paste', { keywordLen });
+    await invokeSafe('expand_and_paste', { keywordLen });
   }
 
   export async function openAccessibilityPreferences(): Promise<void> {
-    return invoke('open_accessibility_preferences');
+    await invokeSafe('open_accessibility_preferences');
   }
 
   /**
@@ -669,12 +710,12 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
    * other platforms). Required before simulating a paste keystroke, which the OS
    * silently drops without this permission.
    */
-  export async function checkAccessibilityPermission(): Promise<boolean> {
-    return invoke<boolean>('check_accessibility_permission');
+  export async function checkAccessibilityPermission(): Promise<boolean | null> {
+    return invokeSafe<boolean>('check_accessibility_permission');
   }
 
   export async function openUrl(url: string): Promise<void> {
-    return invoke('plugin:opener|open_url', { url });
+    await invokeSafe('plugin:opener|open_url', { url });
   }
 
   // ── Storage: Clipboard ───────────────────────────────────────────────────────
@@ -747,47 +788,47 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     removedImagePaths: string[];
   }
 
-  export async function clipboardListInitial(limit: number): Promise<ClipboardInitialPage> {
-    return invoke<ClipboardInitialPage>('clipboard_list_initial', { limit });
+  export async function clipboardListInitial(limit: number): Promise<ClipboardInitialPage | null> {
+    return invokeSafe<ClipboardInitialPage>('clipboard_list_initial', { limit });
   }
 
-  export async function clipboardListOlder(cursor: ClipboardCursor, limit: number): Promise<ClipboardOlderPage> {
-    return invoke<ClipboardOlderPage>('clipboard_list_older', { cursor, limit });
+  export async function clipboardListOlder(cursor: ClipboardCursor, limit: number): Promise<ClipboardOlderPage | null> {
+    return invokeSafe<ClipboardOlderPage>('clipboard_list_older', { cursor, limit });
   }
 
-  export async function clipboardSearch(query: string, limit: number): Promise<ClipboardSearchResult> {
-    return invoke<ClipboardSearchResult>('clipboard_search', { query, limit });
+  export async function clipboardSearch(query: string, limit: number): Promise<ClipboardSearchResult | null> {
+    return invokeSafe<ClipboardSearchResult>('clipboard_search', { query, limit });
   }
 
   export async function clipboardGetItem(id: string): Promise<StoredClipboardItem | null> {
-    return invoke<StoredClipboardItem | null>('clipboard_get_item', { id });
+    return invokeSafe<StoredClipboardItem | null>('clipboard_get_item', { id });
   }
 
   export async function clipboardExportForSync(
     cursor: ClipboardCursor | undefined,
     limit: number,
-  ): Promise<ClipboardExportPage> {
-    return invoke<ClipboardExportPage>('clipboard_export_for_sync', { cursor, limit });
+  ): Promise<ClipboardExportPage | null> {
+    return invokeSafe<ClipboardExportPage>('clipboard_export_for_sync', { cursor, limit });
   }
 
-  export async function clipboardCount(): Promise<ClipboardCount> {
-    return invoke<ClipboardCount>('clipboard_count');
+  export async function clipboardCount(): Promise<ClipboardCount | null> {
+    return invokeSafe<ClipboardCount>('clipboard_count');
   }
 
-  export async function clipboardRecordCapture(item: StoredClipboardItem): Promise<ClipboardCaptureResult> {
-    return invoke<ClipboardCaptureResult>('clipboard_record_capture', { item });
+  export async function clipboardRecordCapture(item: StoredClipboardItem): Promise<ClipboardCaptureResult | null> {
+    return invokeSafe<ClipboardCaptureResult>('clipboard_record_capture', { item });
   }
 
-  export async function clipboardToggleFavorite(id: string): Promise<boolean> {
-    return invoke<boolean>('clipboard_toggle_favorite', { id });
+  export async function clipboardToggleFavorite(id: string): Promise<boolean | null> {
+    return invokeSafe<boolean>('clipboard_toggle_favorite', { id });
   }
 
-  export async function clipboardDeleteItem(id: string): Promise<ClipboardDeleteResult> {
-    return invoke<ClipboardDeleteResult>('clipboard_delete_item', { id });
+  export async function clipboardDeleteItem(id: string): Promise<ClipboardDeleteResult | null> {
+    return invokeSafe<ClipboardDeleteResult>('clipboard_delete_item', { id });
   }
 
-  export async function clipboardClearNonFavorites(): Promise<ClipboardClearResult> {
-    return invoke<ClipboardClearResult>('clipboard_clear_non_favorites');
+  export async function clipboardClearNonFavorites(): Promise<ClipboardClearResult | null> {
+    return invokeSafe<ClipboardClearResult>('clipboard_clear_non_favorites');
   }
 
   // ── Storage: Snippets ────────────────────────────────────────────────────────
@@ -802,23 +843,23 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
   }
 
   export async function snippetUpsert(snippet: StoredSnippet): Promise<void> {
-    return invoke('snippet_upsert', { snippet });
+    await invokeSafe('snippet_upsert', { snippet });
   }
 
-  export async function snippetGetAll(): Promise<StoredSnippet[]> {
-    return invoke<StoredSnippet[]>('snippet_get_all');
+  export async function snippetGetAll(): Promise<StoredSnippet[] | null> {
+    return invokeSafe<StoredSnippet[]>('snippet_get_all');
   }
 
   export async function snippetRemove(id: string): Promise<void> {
-    return invoke('snippet_remove', { id });
+    await invokeSafe('snippet_remove', { id });
   }
 
-  export async function snippetTogglePin(id: string): Promise<boolean> {
-    return invoke<boolean>('snippet_toggle_pin', { id });
+  export async function snippetTogglePin(id: string): Promise<boolean | null> {
+    return invokeSafe<boolean>('snippet_toggle_pin', { id });
   }
 
   export async function snippetClearAll(): Promise<void> {
-    return invoke('snippet_clear_all');
+    await invokeSafe('snippet_clear_all');
   }
 
   // ── Storage: Shortcuts ───────────────────────────────────────────────────────
@@ -834,15 +875,15 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
   }
 
   export async function shortcutUpsert(shortcut: StoredItemShortcut): Promise<void> {
-    return invoke('shortcut_upsert', { shortcut });
+    await invokeSafe('shortcut_upsert', { shortcut });
   }
 
-  export async function shortcutGetAll(): Promise<StoredItemShortcut[]> {
-    return invoke<StoredItemShortcut[]>('shortcut_get_all');
+  export async function shortcutGetAll(): Promise<StoredItemShortcut[] | null> {
+    return invokeSafe<StoredItemShortcut[]>('shortcut_get_all');
   }
 
   export async function shortcutRemove(objectId: string): Promise<void> {
-    return invoke('shortcut_remove', { objectId });
+    await invokeSafe('shortcut_remove', { objectId });
   }
 
   // ── Storage: Extension Key-Value ──────────────────────────────────────────────
@@ -853,29 +894,29 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
   }
 
   export async function extKvGet(extensionId: string, key: string): Promise<string | null> {
-    return invoke<string | null>('ext_kv_get', { extensionId, key });
+    return invokeSafe<string | null>('ext_kv_get', { extensionId, key });
   }
 
   export async function extKvSet(extensionId: string, key: string, value: string): Promise<void> {
-    return invoke('ext_kv_set', { extensionId, key, value });
+    await invokeSafe('ext_kv_set', { extensionId, key, value });
   }
 
-  export async function extKvDelete(extensionId: string, key: string): Promise<boolean> {
-    return invoke<boolean>('ext_kv_delete', { extensionId, key });
+  export async function extKvDelete(extensionId: string, key: string): Promise<boolean | null> {
+    return invokeSafe<boolean>('ext_kv_delete', { extensionId, key });
   }
 
-  export async function extKvGetAll(extensionId: string): Promise<KvEntry[]> {
-    return invoke<KvEntry[]>('ext_kv_get_all', { extensionId });
+  export async function extKvGetAll(extensionId: string): Promise<KvEntry[] | null> {
+    return invokeSafe<KvEntry[]>('ext_kv_get_all', { extensionId });
   }
 
-  export async function extKvClear(extensionId: string): Promise<number> {
-    return invoke<number>('ext_kv_clear', { extensionId });
+  export async function extKvClear(extensionId: string): Promise<number | null> {
+    return invokeSafe<number>('ext_kv_clear', { extensionId });
   }
 
   // ── Storage: Extension Cache ─────────────────────────────────────────────────
 
   export async function extCacheGet(extensionId: string, key: string): Promise<string | null> {
-    return invoke<string | null>('ext_cache_get', { extensionId, key });
+    return invokeSafe<string | null>('ext_cache_get', { extensionId, key });
   }
 
   export async function extCacheSet(
@@ -884,29 +925,31 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     value: string,
     expiresAt?: number
   ): Promise<void> {
-    return invoke('ext_cache_set', { extensionId, key, value, expiresAt });
+    await invokeSafe('ext_cache_set', { extensionId, key, value, expiresAt });
   }
 
-  export async function extCacheDelete(extensionId: string, key: string): Promise<boolean> {
-    return invoke<boolean>('ext_cache_delete', { extensionId, key });
+  export async function extCacheDelete(extensionId: string, key: string): Promise<boolean | null> {
+    return invokeSafe<boolean>('ext_cache_delete', { extensionId, key });
   }
 
-  export async function extCacheClear(extensionId: string): Promise<number> {
-    return invoke<number>('ext_cache_clear', { extensionId });
+  export async function extCacheClear(extensionId: string): Promise<number | null> {
+    return invokeSafe<number>('ext_cache_clear', { extensionId });
   }
 
   // ── Snippets (legacy — text expansion sync) ──────────────────────────────────
 
   export async function syncSnippetsToRust(snippets: [string, string][]): Promise<void> {
-    return invoke('sync_snippets_to_rust', { snippets });
+    await invokeSafe('sync_snippets_to_rust', { snippets });
   }
 
-  export async function setSnippetsEnabled(enabled: boolean): Promise<void> {
-    return invoke('set_snippets_enabled', { enabled });
+  // boolean (not void): snippetService.setEnabled's { ok, error } contract
+  // needs to distinguish success from failure.
+  export async function setSnippetsEnabled(enabled: boolean): Promise<boolean> {
+    return invokeSafeVoid('set_snippets_enabled', { enabled }, { silent: true });
   }
 
-  export async function checkSnippetPermission(): Promise<boolean> {
-    return invoke<boolean>('check_snippet_permission');
+  export async function checkSnippetPermission(): Promise<boolean | null> {
+    return invokeSafe<boolean>('check_snippet_permission');
   }
 
   // ── Permissions ───────────────────────────────────────────────────────────────
@@ -922,7 +965,7 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     permissions: string[],
     permissionArgs?: Record<string, unknown> | null,
   ): Promise<void> {
-    return invoke('register_extension_permissions', {
+    await invokeSafe('register_extension_permissions', {
       extensionId,
       permissions,
       permissionArgs: permissionArgs ?? null,
@@ -932,8 +975,8 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
   export async function checkExtensionPermission(
     extensionId: string,
     callType: string
-  ): Promise<PermissionCheckResult> {
-    return invoke<PermissionCheckResult>('check_extension_permission', { extensionId, callType });
+  ): Promise<PermissionCheckResult | null> {
+    return invokeSafe<PermissionCheckResult>('check_extension_permission', { extensionId, callType });
   }
 
   // ── Shell Trust ──────────────────────────────────────────────────────────────
@@ -943,12 +986,13 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     trustedAt: number;
   }
 
-  export async function shellListTrusted(extensionId: string): Promise<TrustedBinary[]> {
-    return invoke<TrustedBinary[]>('shell_list_trusted', { extensionId });
+  // Silent: ShellTrustManager.svelte is the sole caller and reports its own diagnostic.
+  export async function shellListTrusted(extensionId: string): Promise<TrustedBinary[] | null> {
+    return invokeSafe<TrustedBinary[]>('shell_list_trusted', { extensionId }, { silent: true });
   }
 
   export async function shellRevokeTrust(extensionId: string, binaryPath: string): Promise<void> {
-    return invoke('shell_revoke_trust', { extensionId, binaryPath });
+    await invokeSafe('shell_revoke_trust', { extensionId, binaryPath });
   }
 
   // ── Profile Import/Export ────────────────────────────────────────────────────
@@ -976,8 +1020,8 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     binaryAssets: ProfileAssetEntry[],
     password: string | null,
     destination: string,
-  ): Promise<string> {
-    return invoke<string>('export_profile', {
+  ): Promise<string | null> {
+    return invokeSafe<string>('export_profile', {
       manifestJson,
       categories,
       binaryAssets,
@@ -989,8 +1033,8 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
   export async function importProfile(
     filePath: string,
     password: string | null,
-  ): Promise<ProfileArchiveContents> {
-    return invoke<ProfileArchiveContents>('import_profile', {
+  ): Promise<ProfileArchiveContents | null> {
+    return invokeSafe<ProfileArchiveContents>('import_profile', {
       filePath,
       password,
     });
@@ -999,11 +1043,11 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
   export async function showSaveProfileDialog(
     defaultFilename: string,
   ): Promise<string | null> {
-    return invoke<string | null>('show_save_profile_dialog', { defaultFilename });
+    return invokeSafe<string | null>('show_save_profile_dialog', { defaultFilename });
   }
 
   export async function showOpenProfileDialog(): Promise<string | null> {
-    return invoke<string | null>('show_open_profile_dialog');
+    return invokeSafe<string | null>('show_open_profile_dialog');
   }
 
   // ── Auth ──────────────────────────────────────────────────────────────────────
@@ -1034,32 +1078,32 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     entitlements?: string[];
   }
 
-  export async function authInitiate(provider: string): Promise<AuthInitResponse> {
-    return invoke<AuthInitResponse>('auth_initiate', { provider });
+  export async function authInitiate(provider: string): Promise<AuthInitResponse | null> {
+    return invokeSafe<AuthInitResponse>('auth_initiate', { provider });
   }
 
-  export async function authPoll(sessionCode: string): Promise<PollResponse> {
-    return invoke<PollResponse>('auth_poll', { sessionCode });
+  export async function authPoll(sessionCode: string): Promise<PollResponse | null> {
+    return invokeSafe<PollResponse>('auth_poll', { sessionCode });
   }
 
   export async function authLoadCached(): Promise<AuthStateResponse | null> {
-    return invoke<AuthStateResponse | null>('auth_load_cached');
+    return invokeSafe<AuthStateResponse | null>('auth_load_cached');
   }
 
-  export async function authGetState(): Promise<AuthStateResponse> {
-    return invoke<AuthStateResponse>('auth_get_state');
+  export async function authGetState(): Promise<AuthStateResponse | null> {
+    return invokeSafe<AuthStateResponse>('auth_get_state');
   }
 
-  export async function authRefreshEntitlements(): Promise<string[]> {
-    return invoke<string[]>('auth_refresh_entitlements');
+  export async function authRefreshEntitlements(): Promise<string[] | null> {
+    return invokeSafe<string[]>('auth_refresh_entitlements');
   }
 
-  export async function authCheckEntitlement(entitlement: string): Promise<boolean> {
-    return invoke<boolean>('auth_check_entitlement', { entitlement });
+  export async function authCheckEntitlement(entitlement: string): Promise<boolean | null> {
+    return invokeSafe<boolean>('auth_check_entitlement', { entitlement });
   }
 
   export async function authLogout(): Promise<void> {
-    return invoke('auth_logout');
+    await invokeSafe('auth_logout');
   }
 
   // ── Cloud Sync ────────────────────────────────────────────────────────────────
@@ -1162,8 +1206,8 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
    * Get the current E2EE state. Cheap — reads local mirror + keychain only.
    * No HTTP. Suitable for polling on dialog mount.
    */
-  export async function syncE2eeGetStatus(): Promise<SyncE2eeStatusReport> {
-    return invoke<SyncE2eeStatusReport>('sync_e2ee_get_status');
+  export async function syncE2eeGetStatus(): Promise<SyncE2eeStatusReport | null> {
+    return invokeSafe<SyncE2eeStatusReport>('sync_e2ee_get_status');
   }
 
   /**
@@ -1175,8 +1219,8 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
    */
   export async function syncE2eeEnrol(
     passphrase: string,
-  ): Promise<SyncE2eeEnrolmentResult> {
-    return invoke<SyncE2eeEnrolmentResult>('sync_e2ee_enrol', { passphrase });
+  ): Promise<SyncE2eeEnrolmentResult | null> {
+    return invokeSafe<SyncE2eeEnrolmentResult>('sync_e2ee_enrol', { passphrase });
   }
 
   /**
@@ -1185,8 +1229,8 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
    * AppError::Validation — the service catches this and translates to
    * the `e2ee_passphrase_required` diagnostic kind.
    */
-  export async function syncE2eeUnlock(passphrase: string): Promise<void> {
-    return invoke<void>('sync_e2ee_unlock', { passphrase });
+  export async function syncE2eeUnlock(passphrase: string): Promise<boolean> {
+    return invokeSafeVoid('sync_e2ee_unlock', { passphrase }, { silent: true });
   }
 
   /**
@@ -1197,8 +1241,8 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
   export async function syncE2eeRotate(
     oldPassphrase: string,
     newPassphrase: string,
-  ): Promise<void> {
-    return invoke<void>('sync_e2ee_rotate', { oldPassphrase, newPassphrase });
+  ): Promise<boolean> {
+    return invokeSafeVoid('sync_e2ee_rotate', { oldPassphrase, newPassphrase });
   }
 
   /**
@@ -1211,8 +1255,8 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     phrase: string,
     newPassphrase: string,
     verifyWithPayload?: string,
-  ): Promise<void> {
-    return invoke<void>('sync_e2ee_recover_with_mnemonic', {
+  ): Promise<boolean> {
+    return invokeSafeVoid('sync_e2ee_recover_with_mnemonic', {
       phrase,
       newPassphrase,
       verifyWithPayload: verifyWithPayload ?? null,
@@ -1225,8 +1269,8 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
    * existing items are re-uploaded as plaintext on the next mark-all-
    * dirty pass.
    */
-  export async function syncE2eeDisable(): Promise<void> {
-    return invoke<void>('sync_e2ee_disable');
+  export async function syncE2eeDisable(): Promise<boolean> {
+    return invokeSafeVoid('sync_e2ee_disable');
   }
 
   /**
@@ -1236,8 +1280,8 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
    */
   export async function syncE2eeShowRecoveryPhrase(
     passphrase: string,
-  ): Promise<string> {
-    return invoke<string>('sync_e2ee_show_recovery_phrase', { passphrase });
+  ): Promise<string | null> {
+    return invokeSafe<string>('sync_e2ee_show_recovery_phrase', { passphrase });
   }
 
   // ── OAuth PKCE for Extensions ─────────────────────────────────────────────────
@@ -1270,8 +1314,8 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
     tokenUrl: string,
     scopes: string[],
     flowId: string,
-  ): Promise<OAuthStartResponse> {
-    return invoke<OAuthStartResponse>('oauth_start_flow', {
+  ): Promise<OAuthStartResponse | null> {
+    return invokeSafe<OAuthStartResponse>('oauth_start_flow', {
       extensionId,
       providerId,
       clientId,
@@ -1285,22 +1329,22 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
   export async function oauthExchangeCode(
     stateParam: string,
     code: string,
-  ): Promise<OAuthExchangeResponse> {
-    return invoke<OAuthExchangeResponse>('oauth_exchange_code', { stateParam, code });
+  ): Promise<OAuthExchangeResponse | null> {
+    return invokeSafe<OAuthExchangeResponse>('oauth_exchange_code', { stateParam, code });
   }
 
   export async function oauthGetStoredToken(
     extensionId: string,
     providerId: string,
   ): Promise<OAuthTokenPayload | null> {
-    return invoke<OAuthTokenPayload | null>('oauth_get_stored_token', { extensionId, providerId });
+    return invokeSafe<OAuthTokenPayload | null>('oauth_get_stored_token', { extensionId, providerId });
   }
 
   export async function oauthRevokeExtensionToken(
     extensionId: string,
     providerId: string,
   ): Promise<void> {
-    return invoke('oauth_revoke_extension_token', { extensionId, providerId });
+    await invokeSafe('oauth_revoke_extension_token', { extensionId, providerId });
   }
 
   // ── Onboarding ────────────────────────────────────────────────────────────────
@@ -1328,37 +1372,38 @@ export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Pro
 
   export const onboardingCommands = {
     getState: () =>
-      invoke<OnboardingState>('get_onboarding_state'),
+      invokeSafe<OnboardingState>('get_onboarding_state'),
     advance: () =>
-      invoke<OnboardingState>('advance_onboarding_step'),
+      invokeSafe<OnboardingState>('advance_onboarding_step'),
     goBack: () =>
-      invoke<OnboardingState>('go_back_onboarding_step'),
+      invokeSafe<OnboardingState>('go_back_onboarding_step'),
     complete: () =>
-      invoke<void>('complete_onboarding'),
+      invokeSafe<void>('complete_onboarding'),
     dismiss: () =>
-      invoke<void>('dismiss_onboarding'),
+      invokeSafe<void>('dismiss_onboarding'),
     reset: () =>
-      invoke<void>('reset_onboarding'),
+      invokeSafe<void>('reset_onboarding'),
   }
 
   export async function completeAiOnboarding(): Promise<void> {
-    return invoke<void>('complete_ai_onboarding');
+    await invokeSafe<void>('complete_ai_onboarding');
   }
 
-  export async function isAiOnboardingCompleted(): Promise<boolean> {
-    return invoke<boolean>('is_ai_onboarding_completed');
+  // Silent: onboardingService.svelte.ts is the sole caller and reports its own diagnostic.
+  export async function isAiOnboardingCompleted(): Promise<boolean | null> {
+    return invokeSafe<boolean>('is_ai_onboarding_completed', undefined, { silent: true });
   }
 
-  export function resetExtensionOnboarding(extensionId: string): Promise<void> {
-    return invoke('reset_extension_onboarding', { extensionId })
+  export async function resetExtensionOnboarding(extensionId: string): Promise<void> {
+    await invokeSafe('reset_extension_onboarding', { extensionId })
   }
 
   /** Whether the given extension has completed its onboarding flow. Used by
    *  the launcher's frontend interception for Tier 2 view-mode commands
    *  (which bypass the Rust dispatch path and therefore Plan B's Rust
    *  interception). */
-  export function isExtensionOnboarded(extensionId: string): Promise<boolean> {
-    return invoke<boolean>('is_extension_onboarded', { extensionId })
+  export function isExtensionOnboarded(extensionId: string): Promise<boolean | null> {
+    return invokeSafe<boolean>('is_extension_onboarded', { extensionId })
   }
 
 // ── Clipboard Capture-Time Privacy Filter ─────────────────────────────────────
@@ -1451,23 +1496,23 @@ export async function cryptoDecrypt(value: string): Promise<string | null> {
 // ── Scripts ───────────────────────────────────────────────────────────────────
 
 export async function scriptsAddDirectory(path: string): Promise<void> {
-  return invoke('scripts_add_directory', { path });
+  await invokeSafe('scripts_add_directory', { path });
 }
 
 export async function scriptsRemoveDirectory(path: string): Promise<void> {
-  return invoke('scripts_remove_directory', { path });
+  await invokeSafe('scripts_remove_directory', { path });
 }
 
-export async function scriptsListDirectories(): Promise<string[]> {
-  return invoke<string[]>('scripts_list_directories');
+export async function scriptsListDirectories(): Promise<string[] | null> {
+  return invokeSafe<string[]>('scripts_list_directories');
 }
 
 export async function scriptsPickDirectory(): Promise<string | null> {
-  return invoke<string | null>('scripts_pick_directory');
+  return invokeSafe<string | null>('scripts_pick_directory');
 }
 
-export async function scriptsRescan(): Promise<import('../../built-in-features/scripts/types').ScannedScript[]> {
-  return invoke('scripts_rescan');
+export async function scriptsRescan(): Promise<import('../../built-in-features/scripts/types').ScannedScript[] | null> {
+  return invokeSafe('scripts_rescan');
 }
 
 /**
@@ -1511,58 +1556,63 @@ export interface SetInlineScriptsOutcome {
  */
 export async function scriptsSetInlineScripts(
   specs: InlineScriptSpec[],
-): Promise<SetInlineScriptsOutcome> {
-  return invoke('scripts_set_inline_scripts', { specs });
+): Promise<SetInlineScriptsOutcome | null> {
+  return invokeSafe('scripts_set_inline_scripts', { specs });
 }
 
 export async function replaceDynamicCommandsBuiltin(
   extensionId: string,
   regs: import('asyar-sdk/contracts').DynamicCommandRegistration[],
 ): Promise<void> {
-  return invoke('replace_dynamic_commands_builtin', { extensionId, regs });
+  await invokeSafe('replace_dynamic_commands_builtin', { extensionId, regs });
 }
 
 // ── Agents ────────────────────────────────────────────────────────────────────
 
+// agentsCreate/agentsUpdate/agentsList are silent: agentService.svelte.ts is
+// their sole caller and already reports its own (more specific) diagnostic
+// on a null result — letting invokeSafe also report would double-report.
 export async function agentsCreate(
   input: import('../../built-in-features/agents/types').AgentCreateInput,
-): Promise<import('../../built-in-features/agents/types').AgentDef> {
-  return invoke('agents_create', { input });
+): Promise<import('../../built-in-features/agents/types').AgentDef | null> {
+  return invokeSafe('agents_create', { input }, { silent: true });
 }
 
 export async function agentsUpdate(
   input: import('../../built-in-features/agents/types').AgentUpdateInput,
-): Promise<import('../../built-in-features/agents/types').AgentDef> {
-  return invoke('agents_update', { input });
+): Promise<import('../../built-in-features/agents/types').AgentDef | null> {
+  return invokeSafe('agents_update', { input }, { silent: true });
 }
 
-export async function agentsDelete(id: string): Promise<void> {
-  return invoke('agents_delete', { id });
+// boolean (not void): agentService.svelte.ts gates its optimistic local
+// state update on success, and reports its own diagnostic on failure.
+export async function agentsDelete(id: string): Promise<boolean> {
+  return invokeSafeVoid('agents_delete', { id }, { silent: true });
 }
 
-export async function agentsList(): Promise<import('../../built-in-features/agents/types').AgentDef[]> {
-  return invoke('agents_list');
+export async function agentsList(): Promise<import('../../built-in-features/agents/types').AgentDef[] | null> {
+  return invokeSafe('agents_list', undefined, { silent: true });
 }
 
 export async function agentsGet(
   id: string,
 ): Promise<import('../../built-in-features/agents/types').AgentDef | null> {
-  return invoke('agents_get', { id });
+  return invokeSafe('agents_get', { id });
 }
 
 export async function agentsThreadCreate(
   agentId: string,
   title?: string | null,
-): Promise<import('../../built-in-features/agents/types').ThreadDef> {
-  return invoke('agents_thread_create', { input: { agentId, title: title ?? null } });
+): Promise<import('../../built-in-features/agents/types').ThreadDef | null> {
+  return invokeSafe('agents_thread_create', { input: { agentId, title: title ?? null } });
 }
 
 export async function agentsThreadDelete(id: string): Promise<void> {
-  return invoke('agents_thread_delete', { id });
+  await invokeSafe('agents_thread_delete', { id });
 }
 
 export async function agentsThreadUpdateTitle(id: string, title: string): Promise<void> {
-  return invoke('agents_thread_update_title', { id, title });
+  await invokeSafe('agents_thread_update_title', { id, title });
 }
 
 export interface AgentRunOrigin {
@@ -1571,51 +1621,51 @@ export interface AgentRunOrigin {
 }
 
 export async function agentsFindRunOrigin(runId: string): Promise<AgentRunOrigin | null> {
-  return invoke('agents_find_run_origin', { runId });
+  return invokeSafe('agents_find_run_origin', { runId });
 }
 
-export async function agentsBackfillThreadTitles(): Promise<number> {
-  return invoke('agents_backfill_thread_titles');
+export async function agentsBackfillThreadTitles(): Promise<number | null> {
+  return invokeSafe('agents_backfill_thread_titles');
 }
 
 export async function agentsThreadsList(
   agentId: string,
-): Promise<import('../../built-in-features/agents/types').ThreadDef[]> {
-  return invoke('agents_threads_list', { agentId });
+): Promise<import('../../built-in-features/agents/types').ThreadDef[] | null> {
+  return invokeSafe('agents_threads_list', { agentId });
 }
 
 export async function agentsMessageInsert(
   input: import('../../built-in-features/agents/types').MessageInsertInput,
-): Promise<import('../../built-in-features/agents/types').MessageDef> {
-  return invoke('agents_message_insert', { input });
+): Promise<import('../../built-in-features/agents/types').MessageDef | null> {
+  return invokeSafe('agents_message_insert', { input });
 }
 
 export async function agentsMessagesList(
   threadId: string,
-): Promise<import('../../built-in-features/agents/types').MessageDef[]> {
-  return invoke('agents_messages_list', { threadId });
+): Promise<import('../../built-in-features/agents/types').MessageDef[] | null> {
+  return invokeSafe('agents_messages_list', { threadId });
 }
 
 export async function agentsToolsRegisterTier2(
   extensionId: string,
   tools: import('asyar-sdk/contracts').ManifestTool[],
 ): Promise<void> {
-  return invoke('agents_tools_register_tier2', { extensionId, tools });
+  await invokeSafe('agents_tools_register_tier2', { extensionId, tools });
 }
 
 export async function agentsToolsUnregisterTier2(extensionId: string): Promise<void> {
-  return invoke('agents_tools_unregister_tier2', { extensionId });
+  await invokeSafe('agents_tools_unregister_tier2', { extensionId });
 }
 
-export async function agentsToolsList(): Promise<import('asyar-sdk/contracts').ToolDescriptor[]> {
-  return invoke('agents_tools_list');
+export async function agentsToolsList(): Promise<import('asyar-sdk/contracts').ToolDescriptor[] | null> {
+  return invokeSafe('agents_tools_list');
 }
 
 export async function agentsInvokeBuiltinTool(
   id: string,
   args: unknown,
-): Promise<unknown> {
-  return invoke('agents_invoke_builtin_tool', { id, args });
+): Promise<unknown | null> {
+  return invokeSafe('agents_invoke_builtin_tool', { id, args });
 }
 
 // ── Feedback submission ───────────────────────────────────────────────────────
@@ -1627,8 +1677,10 @@ export interface FeedbackInput {
   email?: string | null;
 }
 
-export async function submitFeedback(input: FeedbackInput): Promise<void> {
-  return invoke('submit_feedback', { input });
+// boolean (not void): feedbackSubmitService needs to know whether submission
+// actually succeeded before showing the "thank you" confirmation.
+export async function submitFeedback(input: FeedbackInput): Promise<boolean> {
+  return invokeSafeVoid('submit_feedback', { input });
 }
 
 // ── Crash report prompt (Ask mode) ───────────────────────────────────────────
@@ -1640,25 +1692,25 @@ export interface CrashPayload {
 }
 
 export async function getPendingCrash(): Promise<CrashPayload | null> {
-  return invoke<CrashPayload | null>('get_pending_crash');
+  return invokeSafe<CrashPayload | null>('get_pending_crash');
 }
 
 export async function sendPendingCrash(email: string): Promise<void> {
-  return invoke('send_pending_crash', { email });
+  await invokeSafe('send_pending_crash', { email });
 }
 
 export async function dismissPendingCrash(): Promise<void> {
-  return invoke('dismiss_pending_crash');
+  await invokeSafe('dismiss_pending_crash');
 }
 
 // ── Usage insights ────────────────────────────────────────────────────────────
 
 export interface UsageTopItem { id: string; label?: string | null; count: number }
 export interface UsageStats { activeDays: number; totalLaunches: number; top: UsageTopItem[] }
-export async function getUsageStats(): Promise<UsageStats> { return invoke('get_usage_stats'); }
-export async function recordActiveDay(): Promise<void> { return invoke('record_active_day'); }
-export async function getUsageAnonId(): Promise<string> { return invoke('get_usage_anon_id'); }
-export async function resetUsageAnonId(): Promise<string> { return invoke('reset_usage_anon_id'); }
-export async function sendPendingUsage(day: string): Promise<void> { return invoke('send_pending_usage', { day }); }
+export async function getUsageStats(): Promise<UsageStats | null> { return invokeSafe('get_usage_stats'); }
+export async function recordActiveDay(): Promise<void> { await invokeSafe('record_active_day'); }
+export async function getUsageAnonId(): Promise<string | null> { return invokeSafe('get_usage_anon_id'); }
+export async function resetUsageAnonId(): Promise<string | null> { return invokeSafe('reset_usage_anon_id'); }
+export async function sendPendingUsage(day: string): Promise<void> { await invokeSafe('send_pending_usage', { day }); }
 /** Explicit user action: send today's usage snapshot now. Returns the count of distinct launch entries sent. */
-export async function sendUsageNow(): Promise<number> { return invoke('send_usage_now'); }
+export async function sendUsageNow(): Promise<number | null> { return invokeSafe('send_usage_now'); }

--- a/asyar-launcher/src/lib/ipc/devCommands.ts
+++ b/asyar-launcher/src/lib/ipc/devCommands.ts
@@ -1,0 +1,43 @@
+import { invokeSafe, invokeSafeVoid } from './invokeSafe';
+
+export interface DevStateEntry {
+  key: string;
+  value: unknown;
+  updatedAt: number;
+}
+
+export interface DevSubscriptionSummary {
+  key: string;
+  role: 'worker' | 'view';
+  installedAt: number;
+  listenerCount: number;
+}
+
+// All dev-inspector calls are silent — this is dev-only background polling
+// tooling (1s tick); a transient failure should stay a console debug log,
+// not spam the diagnostics panel every second.
+
+export async function forceRemountWorker(
+  extensionId: string,
+  hasBackgroundMain: boolean,
+): Promise<boolean> {
+  return invokeSafeVoid(
+    'force_remount_worker',
+    { extensionId, hasBackgroundMain },
+    { silent: true },
+  );
+}
+
+export async function stateGetAll(extensionId: string): Promise<DevStateEntry[] | null> {
+  return invokeSafe<DevStateEntry[]>('state_get_all', { extensionId }, { silent: true });
+}
+
+export async function stateGetSubscriptions(
+  extensionId: string,
+): Promise<DevSubscriptionSummary[] | null> {
+  return invokeSafe<DevSubscriptionSummary[]>(
+    'state_get_subscriptions',
+    { extensionId },
+    { silent: true },
+  );
+}

--- a/asyar-launcher/src/lib/ipc/extensionBuilderCommands.ts
+++ b/asyar-launcher/src/lib/ipc/extensionBuilderCommands.ts
@@ -1,0 +1,57 @@
+import { invokeSafe, invokeSafeVoid, invokeSafeOption } from './invokeSafe';
+
+export interface CreatedExtension {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  icon?: string | null;
+  path: string;
+}
+
+// `ext_builder_*` are all `Result<(), String>` on the Rust side — use
+// invokeSafeVoid's boolean signal, not invokeSafe's ambiguous null.
+
+export async function extBuilderStart(opts: {
+  prompt: string;
+  targetDir: string;
+  capabilitySpecDir: string;
+  anthropicKey: string;
+}): Promise<boolean> {
+  return invokeSafeVoid('ext_builder_start', {
+    prompt: opts.prompt,
+    targetDir: opts.targetDir,
+    capabilitySpecDir: opts.capabilitySpecDir,
+    anthropicKey: opts.anthropicKey,
+  });
+}
+
+export async function extBuilderAnswer(line: string): Promise<boolean> {
+  return invokeSafeVoid('ext_builder_answer', { line });
+}
+
+export async function extBuilderCancel(): Promise<boolean> {
+  return invokeSafeVoid('ext_builder_cancel');
+}
+
+export async function listCreatedExtensions(): Promise<CreatedExtension[] | null> {
+  return invokeSafe<CreatedExtension[]>('list_created_extensions');
+}
+
+export async function searchCreatedExtensions(query: string): Promise<CreatedExtension[] | null> {
+  return invokeSafe<CreatedExtension[]>('search_created_extensions', { query });
+}
+
+/**
+ * `scan_extension_for_secret` is `Result<Option<String>, AppError>` — a
+ * clean scan (`Ok(None)`) and a failed scan both serialize to `null`. The
+ * secret guard fails closed, so the caller needs the explicit `ok` flag
+ * to tell "no secret found" apart from "the scan itself errored" — see
+ * `invokeSafeOption`.
+ */
+export async function scanExtensionForSecret(
+  path: string,
+  secret: string,
+): Promise<{ ok: true; value: string | null } | { ok: false }> {
+  return invokeSafeOption<string>('scan_extension_for_secret', { path, secret });
+}

--- a/asyar-launcher/src/lib/ipc/extensionLifecycleCommands.ts
+++ b/asyar-launcher/src/lib/ipc/extensionLifecycleCommands.ts
@@ -1,0 +1,74 @@
+import { invokeSafe } from './invokeSafe';
+import type { IpcDispatchOutcome } from './iframeLifecycleCommands';
+
+export async function stateGet(extensionId: string, key: string): Promise<unknown> {
+  return invokeSafe<unknown>('state_get', { extensionId, key });
+}
+
+export async function stateSet(extensionId: string, key: string, value: unknown): Promise<void> {
+  await invokeSafe('state_set', { extensionId, key, value });
+}
+
+export async function stateSubscribe(
+  extensionId: string,
+  key: string,
+  role: 'worker' | 'view',
+): Promise<number | null> {
+  return invokeSafe<number>('state_subscribe', { extensionId, key, role });
+}
+
+export async function stateUnsubscribe(subscriptionId: number): Promise<void> {
+  await invokeSafe('state_unsubscribe', { subscriptionId });
+}
+
+export async function stateRpcRequest(
+  extensionId: string,
+  id: string,
+  correlationId: string,
+  payload: unknown,
+): Promise<IpcDispatchOutcome | null> {
+  return invokeSafe<IpcDispatchOutcome>('state_rpc_request', {
+    extensionId,
+    id,
+    correlationId,
+    payload,
+  });
+}
+
+export async function stateRpcAbort(
+  extensionId: string,
+  correlationId: string,
+): Promise<IpcDispatchOutcome | null> {
+  return invokeSafe<IpcDispatchOutcome>('state_rpc_abort', { extensionId, correlationId });
+}
+
+export async function stateRpcReply(
+  extensionId: string,
+  correlationId: string,
+  result?: unknown,
+  error?: string,
+): Promise<void> {
+  await invokeSafe('state_rpc_reply', {
+    extensionId,
+    correlationId,
+    result: result ?? null,
+    error: error ?? null,
+  });
+}
+
+export async function classifyItemsCommand(
+  query: string,
+  items: { id: string; title: string; subtitle: string | null; keywords: string[] }[],
+): Promise<{ id: string; tier: number }[] | null> {
+  return invokeSafe<{ id: string; tier: number }[]>('classify_items', { query, items });
+}
+
+export async function filterCompatibleExtensionsCommand(
+  items: { id: string; platforms: string[] | null }[],
+): Promise<string[] | null> {
+  return invokeSafe<string[]>('filter_compatible_extensions', { items });
+}
+
+export async function completeExtensionOnboarding(extensionId: string): Promise<void> {
+  await invokeSafe('complete_extension_onboarding', { extensionId });
+}

--- a/asyar-launcher/src/lib/ipc/extensionPreferencesCommands.ts
+++ b/asyar-launcher/src/lib/ipc/extensionPreferencesCommands.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { invokeSafe } from './invokeSafe';
 
 export interface PreferenceExportRow {
   extensionId: string;
@@ -11,8 +11,8 @@ export interface PreferenceExportRow {
 
 export async function extensionPreferencesGetAll(
   extensionId: string
-): Promise<PreferenceExportRow[]> {
-  return invoke('extension_preferences_get_all', { extensionId });
+): Promise<PreferenceExportRow[] | null> {
+  return invokeSafe('extension_preferences_get_all', { extensionId });
 }
 
 export async function extensionPreferencesSet(
@@ -22,7 +22,7 @@ export async function extensionPreferencesSet(
   value: string,
   isEncrypted: boolean
 ): Promise<void> {
-  return invoke('extension_preferences_set', {
+  await invokeSafe('extension_preferences_set', {
     extensionId,
     commandId,
     key,
@@ -32,7 +32,7 @@ export async function extensionPreferencesSet(
 }
 
 export async function extensionPreferencesReset(extensionId: string): Promise<void> {
-  return invoke('extension_preferences_reset', { extensionId });
+  await invokeSafe('extension_preferences_reset', { extensionId });
 }
 
 export interface PreferencesExport {
@@ -50,8 +50,8 @@ export interface PreferencesImportResult {
  * Encrypted (password-type) rows are filtered at the Rust SQL layer and
  * never leave the device.
  */
-export async function extensionPreferencesExportAll(): Promise<PreferencesExport> {
-  return invoke('extension_preferences_export_all');
+export async function extensionPreferencesExportAll(): Promise<PreferencesExport | null> {
+  return invokeSafe('extension_preferences_export_all');
 }
 
 /**
@@ -62,6 +62,6 @@ export async function extensionPreferencesExportAll(): Promise<PreferencesExport
 export async function extensionPreferencesImportAll(
   payload: PreferencesExport,
   strategy: 'replace' | 'merge'
-): Promise<PreferencesImportResult> {
-  return invoke('extension_preferences_import_all', { payload, strategy });
+): Promise<PreferencesImportResult | null> {
+  return invokeSafe('extension_preferences_import_all', { payload, strategy });
 }

--- a/asyar-launcher/src/lib/ipc/iframeLifecycleCommands.test.ts
+++ b/asyar-launcher/src/lib/ipc/iframeLifecycleCommands.test.ts
@@ -68,7 +68,7 @@ describe('iframeLifecycleCommands', () => {
     const snap = [{ extensionId: 'ext.a', state: 'ready', mailboxLen: 0, role: 'view' }];
     vi.mocked(invoke).mockResolvedValueOnce(snap);
     const res = await getExtensionRuntimeSnapshot();
-    expect(invoke).toHaveBeenCalledWith('get_extension_runtime_snapshot');
+    expect(invoke).toHaveBeenCalledWith('get_extension_runtime_snapshot', undefined);
     expect(res).toEqual(snap);
   });
 

--- a/asyar-launcher/src/lib/ipc/iframeLifecycleCommands.ts
+++ b/asyar-launcher/src/lib/ipc/iframeLifecycleCommands.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { invokeSafe } from './invokeSafe';
 
 export type DispatchMessageKind =
   | 'command'
@@ -40,33 +40,34 @@ export function dispatchToExtension(
   extensionId: string,
   message: IpcPendingMessage,
   role: 'view' | 'worker',
-): Promise<IpcDispatchOutcome> {
-  return invoke('dispatch_to_extension', { extensionId, message, role });
+): Promise<IpcDispatchOutcome | null> {
+  return invokeSafe('dispatch_to_extension', { extensionId, message, role });
 }
 
 export function iframeReadyAck(
   extensionId: string,
   mountToken: number,
   role: 'view' | 'worker',
-): Promise<IpcPendingMessage[]> {
-  return invoke('iframe_ready_ack', { extensionId, mountToken, role });
+): Promise<IpcPendingMessage[] | null> {
+  return invokeSafe('iframe_ready_ack', { extensionId, mountToken, role });
 }
 
-export function iframeUnmountAck(extensionId: string, role: 'view' | 'worker'): Promise<void> {
-  return invoke('iframe_unmount_ack', { extensionId, role });
+export async function iframeUnmountAck(extensionId: string, role: 'view' | 'worker'): Promise<void> {
+  await invokeSafe('iframe_unmount_ack', { extensionId, role });
 }
 
-export function iframeMountTimeoutReported(
+export async function iframeMountTimeoutReported(
   extensionId: string,
   mountToken: number,
 ): Promise<void> {
-  return invoke('iframe_mount_timeout_reported', { extensionId, mountToken });
+  await invokeSafe('iframe_mount_timeout_reported', { extensionId, mountToken });
 }
 
-export function getExtensionRuntimeSnapshot(): Promise<IframeLifecycleSnapshotEntry[]> {
-  return invoke('get_extension_runtime_snapshot');
+export function getExtensionRuntimeSnapshot(): Promise<IframeLifecycleSnapshotEntry[] | null> {
+  return invokeSafe('get_extension_runtime_snapshot');
 }
 
-export function restoreWorkers(): Promise<string[]> {
-  return invoke('restore_workers');
+// Silent: appInitializer.ts is the sole caller and reports its own diagnostic.
+export function restoreWorkers(): Promise<string[] | null> {
+  return invokeSafe('restore_workers', undefined, { silent: true });
 }

--- a/asyar-launcher/src/lib/ipc/invokeSafe.ts
+++ b/asyar-launcher/src/lib/ipc/invokeSafe.ts
@@ -47,3 +47,78 @@ export async function invokeSafe<T>(
     return null;
   }
 }
+
+/**
+ * For Rust commands that return `Result<(), AppError>`: the Ok(()) success
+ * value and invokeSafe's failure sentinel both serialize to `null`, so a
+ * caller checking `=== null` can't tell success from failure. Use this
+ * instead when the caller genuinely needs that signal (e.g. "was the
+ * passphrase accepted?") — it distinguishes via whether `invoke()` actually
+ * threw, not via the ambiguous resolved value.
+ */
+export async function invokeSafeVoid(
+  cmd: string,
+  args?: Record<string, unknown>,
+  opts?: InvokeSafeOpts,
+): Promise<boolean> {
+  try {
+    await invoke(cmd, args);
+    return true;
+  } catch (raw) {
+    const d: Diagnostic = isDiagnosticShape(raw) ? { ...raw } : fallback(cmd, raw);
+    logService.error(`[invokeSafe] ${cmd}: ${d.developerDetail ?? String(raw)}`);
+    if (opts?.retry) {
+      const id = diagnosticsService.registerRetry(opts.retry);
+      d.retryActionId = id;
+      d.retryable = true;
+    }
+    if (!opts?.silent) {
+      void diagnosticsService.report(d);
+    }
+    return false;
+  }
+}
+
+/**
+ * Deliberate escape hatch: a thin, undiagnosed passthrough to the real
+ * `invoke()` for the rare caller that has its own meaningful catch logic
+ * depending on a genuine rejection (e.g. inspecting a structured error to
+ * decide whether to retry) — `invokeSafe`'s never-throws contract would
+ * destroy that. No diagnostic reporting here; the caller's own catch is
+ * responsible for that, same as before this command was ever wrapped.
+ */
+export async function invokeRaw<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+  return invoke<T>(cmd, args);
+}
+
+/**
+ * For Rust commands that return `Result<Option<T>, AppError>`: a successful
+ * "nothing found" (`Ok(None)`) and invokeSafe's failure sentinel both
+ * serialize to `null`, so a caller checking `=== null` can't tell "found
+ * nothing" from "the call failed" — security-relevant when the caller must
+ * fail closed (e.g. a secret scan returning "no secret" must not be
+ * indistinguishable from "the scan itself errored"). Use this instead to get
+ * an explicit `ok` flag alongside the (possibly null) value.
+ */
+export async function invokeSafeOption<T>(
+  cmd: string,
+  args?: Record<string, unknown>,
+  opts?: InvokeSafeOpts,
+): Promise<{ ok: true; value: T | null } | { ok: false }> {
+  try {
+    const value = await invoke<T | null>(cmd, args);
+    return { ok: true, value };
+  } catch (raw) {
+    const d: Diagnostic = isDiagnosticShape(raw) ? { ...raw } : fallback(cmd, raw);
+    logService.error(`[invokeSafe] ${cmd}: ${d.developerDetail ?? String(raw)}`);
+    if (opts?.retry) {
+      const id = diagnosticsService.registerRetry(opts.retry);
+      d.retryActionId = id;
+      d.retryable = true;
+    }
+    if (!opts?.silent) {
+      void diagnosticsService.report(d);
+    }
+    return { ok: false };
+  }
+}

--- a/asyar-launcher/src/lib/ipc/mcpCommands.test.ts
+++ b/asyar-launcher/src/lib/ipc/mcpCommands.test.ts
@@ -1,11 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('./invokeSafe', () => ({ invokeSafe: vi.fn() }));
-vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
-vi.mock('../../services/log/logService', () => ({ logService: { warn: vi.fn() } }));
+vi.mock('./invokeSafe', () => ({ invokeSafe: vi.fn(), invokeSafeVoid: vi.fn() }));
 
-import { invokeSafe } from './invokeSafe';
-import { invoke } from '@tauri-apps/api/core';
+import { invokeSafe, invokeSafeVoid } from './invokeSafe';
 import {
   mcpListServers,
   mcpInstallServer,
@@ -22,7 +19,7 @@ import {
 import type { McpServerInstallInput } from '../../built-in-features/mcp/types';
 
 const mockInvoke = invokeSafe as ReturnType<typeof vi.fn>;
-const mockTauriInvoke = invoke as ReturnType<typeof vi.fn>;
+const mockInvokeVoid = invokeSafeVoid as ReturnType<typeof vi.fn>;
 
 const sampleInput: McpServerInstallInput = {
   id: 'my-server',
@@ -77,17 +74,17 @@ describe('mcpTestServer', () => {
 
 describe('mcpSetServerEnabled', () => {
   it('passes serverId + enabled correctly and returns true on success', async () => {
-    mockTauriInvoke.mockResolvedValue(undefined);
+    mockInvokeVoid.mockResolvedValue(true);
     const result = await mcpSetServerEnabled('my-server', true);
-    expect(mockTauriInvoke).toHaveBeenCalledWith('mcp_set_server_enabled', {
+    expect(mockInvokeVoid).toHaveBeenCalledWith('mcp_set_server_enabled', {
       serverId: 'my-server',
       enabled: true,
     });
     expect(result).toBe(true);
   });
 
-  it('returns false when invoke throws', async () => {
-    mockTauriInvoke.mockRejectedValue(new Error('Rust error'));
+  it('returns false when invokeSafeVoid reports failure', async () => {
+    mockInvokeVoid.mockResolvedValue(false);
     const result = await mcpSetServerEnabled('my-server', true);
     expect(result).toBe(false);
   });
@@ -95,14 +92,14 @@ describe('mcpSetServerEnabled', () => {
 
 describe('mcpUninstallServer', () => {
   it('passes serverId correctly and returns true on success', async () => {
-    mockTauriInvoke.mockResolvedValue(undefined);
+    mockInvokeVoid.mockResolvedValue(true);
     const result = await mcpUninstallServer('my-server');
-    expect(mockTauriInvoke).toHaveBeenCalledWith('mcp_uninstall_server', { serverId: 'my-server' });
+    expect(mockInvokeVoid).toHaveBeenCalledWith('mcp_uninstall_server', { serverId: 'my-server' });
     expect(result).toBe(true);
   });
 
-  it('returns false when invoke throws', async () => {
-    mockTauriInvoke.mockRejectedValue(new Error('Rust error'));
+  it('returns false when invokeSafeVoid reports failure', async () => {
+    mockInvokeVoid.mockResolvedValue(false);
     const result = await mcpUninstallServer('my-server');
     expect(result).toBe(false);
   });
@@ -155,9 +152,9 @@ describe('null returns from wrappers', () => {
 
 describe('mcpSetPermission', () => {
   it('passes correct args and command name', async () => {
-    mockTauriInvoke.mockResolvedValue(undefined);
+    mockInvokeVoid.mockResolvedValue(true);
     const result = await mcpSetPermission('my-server', 'create_user', 'agent-1', 'allow_once');
-    expect(mockTauriInvoke).toHaveBeenCalledWith('mcp_set_permission', {
+    expect(mockInvokeVoid).toHaveBeenCalledWith('mcp_set_permission', {
       serverId: 'my-server',
       toolId: 'create_user',
       agentId: 'agent-1',
@@ -166,8 +163,8 @@ describe('mcpSetPermission', () => {
     expect(result).toBe(true);
   });
 
-  it('returns false when invoke throws', async () => {
-    mockTauriInvoke.mockRejectedValue(new Error('Rust error'));
+  it('returns false when invokeSafeVoid reports failure', async () => {
+    mockInvokeVoid.mockResolvedValue(false);
     const result = await mcpSetPermission('my-server', 'create_user', 'agent-1', 'allow_always');
     expect(result).toBe(false);
   });

--- a/asyar-launcher/src/lib/ipc/mcpCommands.ts
+++ b/asyar-launcher/src/lib/ipc/mcpCommands.ts
@@ -1,6 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
-import { invokeSafe } from './invokeSafe';
-import { logService } from '../../services/log/logService';
+import { invokeSafe, invokeSafeVoid } from './invokeSafe';
 import type {
   McpServerInstallInput,
   McpServerSummary,
@@ -31,23 +29,11 @@ export async function mcpSetServerEnabled(
   serverId: string,
   enabled: boolean,
 ): Promise<boolean> {
-  try {
-    await invoke<void>('mcp_set_server_enabled', { serverId, enabled });
-    return true;
-  } catch (err) {
-    await logService.warn(`mcp_set_server_enabled failed: ${err}`);
-    return false;
-  }
+  return invokeSafeVoid('mcp_set_server_enabled', { serverId, enabled });
 }
 
 export async function mcpUninstallServer(serverId: string): Promise<boolean> {
-  try {
-    await invoke<void>('mcp_uninstall_server', { serverId });
-    return true;
-  } catch (err) {
-    await logService.warn(`mcp_uninstall_server failed: ${err}`);
-    return false;
-  }
+  return invokeSafeVoid('mcp_uninstall_server', { serverId });
 }
 
 export async function mcpListAudit(
@@ -82,13 +68,7 @@ export async function mcpSetPermission(
   agentId: string,
   decision: 'allow_once' | 'allow_always' | 'never',
 ): Promise<boolean> {
-  try {
-    await invoke<void>('mcp_set_permission', { serverId, toolId, agentId, decision });
-    return true;
-  } catch (err) {
-    await logService.warn(`mcp_set_permission failed: ${err}`);
-    return false;
-  }
+  return invokeSafeVoid('mcp_set_permission', { serverId, toolId, agentId, decision });
 }
 
 export async function mcpGetPermission(
@@ -119,13 +99,7 @@ export async function mcpDeletePermission(
   toolId: string,
   agentId: string,
 ): Promise<boolean> {
-  try {
-    await invoke<void>('mcp_delete_permission', { serverId, toolId, agentId });
-    return true;
-  } catch (err) {
-    await logService.warn(`mcp_delete_permission failed: ${err}`);
-    return false;
-  }
+  return invokeSafeVoid('mcp_delete_permission', { serverId, toolId, agentId });
 }
 
 export async function mcpGetStrictMode(): Promise<boolean> {
@@ -133,11 +107,5 @@ export async function mcpGetStrictMode(): Promise<boolean> {
 }
 
 export async function mcpSetStrictMode(enabled: boolean): Promise<boolean> {
-  try {
-    await invoke<void>('mcp_set_strict_mode', { enabled });
-    return true;
-  } catch (err) {
-    await logService.warn(`mcp_set_strict_mode failed: ${err}`);
-    return false;
-  }
+  return invokeSafeVoid('mcp_set_strict_mode', { enabled });
 }

--- a/asyar-launcher/src/lib/ipc/searchAccessoryCommands.ts
+++ b/asyar-launcher/src/lib/ipc/searchAccessoryCommands.ts
@@ -1,0 +1,24 @@
+import { invokeSafe, invokeSafeVoid } from './invokeSafe';
+
+export async function rankItemsCommand(query: string, items: unknown[]): Promise<string[] | null> {
+  return invokeSafe<string[]>('rank_items', { query, items });
+}
+
+export async function searchbarAccessoryGet(
+  extensionId: string,
+  commandId: string,
+  opts?: { silent?: boolean },
+): Promise<string | null> {
+  return invokeSafe<string | null>('searchbar_accessory_get', { extensionId, commandId }, opts);
+}
+
+// `searchbar_accessory_set` is `Result<(), AppError>` on the Rust side — use
+// invokeSafeVoid's boolean signal so callers can abort before mutating
+// in-memory state on a persistence failure.
+export async function searchbarAccessorySet(
+  extensionId: string,
+  commandId: string,
+  value: string,
+): Promise<boolean> {
+  return invokeSafeVoid('searchbar_accessory_set', { extensionId, commandId, value });
+}

--- a/asyar-launcher/src/lib/ipc/selectionCommands.ts
+++ b/asyar-launcher/src/lib/ipc/selectionCommands.ts
@@ -1,0 +1,15 @@
+import { invokeRaw } from './invokeSafe';
+
+/**
+ * `selectionService` deliberately classifies raw Rust error text into a
+ * structured `SelectionErrorCode` and rethrows — `invokeSafe`'s never-throws
+ * contract would destroy that, so this uses the `invokeRaw` escape hatch
+ * (see `selectionService.ts`'s `throwSelectionError`).
+ */
+export async function getSelectedTextRaw(): Promise<string | null> {
+  return invokeRaw<string | null>('get_selected_text');
+}
+
+export async function getSelectedFinderItemsRaw(): Promise<string[]> {
+  return invokeRaw<string[]>('get_selected_finder_items');
+}

--- a/asyar-launcher/src/lib/ipc/settingsUiCommands.ts
+++ b/asyar-launcher/src/lib/ipc/settingsUiCommands.ts
@@ -1,0 +1,26 @@
+import { invokeSafe, invokeSafeVoid } from './invokeSafe';
+
+export interface PendingPairing {
+  id: string;
+  family: string;
+  variant: string;
+}
+
+export async function browserListPendingPairings(): Promise<PendingPairing[] | null> {
+  return invokeSafe<PendingPairing[]>('browser_list_pending_pairings');
+}
+
+// `browser_resolve_pairing`/`browser_revoke_pairing` are `Result<(), String>`
+// on the Rust side — use invokeSafeVoid's boolean signal, silent because
+// callers report their own specific diagnostic kind on failure.
+
+export async function browserResolvePairing(
+  pairingId: string,
+  decision: 'allow' | 'deny',
+): Promise<boolean> {
+  return invokeSafeVoid('browser_resolve_pairing', { pairingId, decision }, { silent: true });
+}
+
+export async function browserRevokePairing(family: string, variant: string): Promise<boolean> {
+  return invokeSafeVoid('browser_revoke_pairing', { family, variant }, { silent: true });
+}

--- a/asyar-launcher/src/lib/ipc/shellCommands.ts
+++ b/asyar-launcher/src/lib/ipc/shellCommands.ts
@@ -1,0 +1,52 @@
+import { invokeSafe, invokeSafeVoid } from './invokeSafe';
+
+export interface ShellDescriptor {
+  spawnId: string;
+  program: string;
+  args: string[];
+  pid: number;
+  startedAt: number;
+}
+
+export async function shellResolvePath(program: string): Promise<string | null> {
+  return invokeSafe<string>('shell_resolve_path', { program });
+}
+
+// `shell_kill`/`shell_spawn`/`shell_grant_trust` are all `Result<(), AppError>`
+// on the Rust side — Ok(()) and invokeSafe's failure sentinel both serialize
+// to `null`, so these use invokeSafeVoid's boolean signal instead.
+
+export async function shellKill(spawnId: string): Promise<boolean> {
+  return invokeSafeVoid('shell_kill', { spawnId });
+}
+
+export async function shellSpawn(
+  extensionId: string,
+  spawnId: string,
+  program: string,
+  args: string[],
+): Promise<boolean> {
+  return invokeSafeVoid('shell_spawn', { extensionId, spawnId, program, args });
+}
+
+export async function shellList(extensionId: string): Promise<ShellDescriptor[] | null> {
+  return invokeSafe<ShellDescriptor[]>('shell_list', { extensionId });
+}
+
+export async function shellAttach(
+  extensionId: string,
+  spawnId: string,
+): Promise<ShellDescriptor | null> {
+  return invokeSafe<ShellDescriptor>('shell_attach', { extensionId, spawnId });
+}
+
+export async function shellCheckTrust(
+  extensionId: string,
+  binaryPath: string,
+): Promise<boolean | null> {
+  return invokeSafe<boolean>('shell_check_trust', { extensionId, binaryPath });
+}
+
+export async function shellGrantTrust(extensionId: string, binaryPath: string): Promise<boolean> {
+  return invokeSafeVoid('shell_grant_trust', { extensionId, binaryPath });
+}

--- a/asyar-launcher/src/lib/ipc/shortcodeCommands.ts
+++ b/asyar-launcher/src/lib/ipc/shortcodeCommands.ts
@@ -1,0 +1,47 @@
+import { invokeSafe, invokeSafeVoid } from './invokeSafe';
+
+// `contribute_shortcodes`/`revoke_shortcodes`/`promote_learned_to_snippet`/
+// `set_inline_emoji_fallback_enabled`/`record_inline_emoji_fallback_outcome`
+// are all `Result<(), AppError>` on the Rust side — Ok(()) and invokeSafe's
+// failure sentinel both serialize to `null`, so these use invokeSafeVoid's
+// boolean signal instead. `list_learned_shortcodes`/`forget_learned_shortcode`/
+// `clear_learned_shortcodes` are plain (non-Result) commands and keep invokeSafe.
+
+export async function contributeShortcodes(
+  extensionId: string | undefined,
+  map: Record<string, string>,
+): Promise<boolean> {
+  return invokeSafeVoid('contribute_shortcodes', { extensionId, map });
+}
+
+export async function revokeShortcodes(extensionId: string | undefined): Promise<boolean> {
+  return invokeSafeVoid('revoke_shortcodes', { extensionId });
+}
+
+export async function listLearnedShortcodes(): Promise<[string, string][] | null> {
+  return invokeSafe<[string, string][]>('list_learned_shortcodes');
+}
+
+export async function promoteLearnedToSnippet(shortcode: string): Promise<boolean> {
+  return invokeSafeVoid('promote_learned_to_snippet', { shortcode });
+}
+
+export async function forgetLearnedShortcode(shortcode: string): Promise<void> {
+  await invokeSafe('forget_learned_shortcode', { shortcode });
+}
+
+export async function clearLearnedShortcodes(): Promise<void> {
+  await invokeSafe('clear_learned_shortcodes');
+}
+
+export async function setInlineEmojiFallbackEnabled(enabled: boolean): Promise<boolean> {
+  return invokeSafeVoid('set_inline_emoji_fallback_enabled', { enabled });
+}
+
+export async function recordInlineEmojiFallbackOutcome(
+  shortcode: string,
+  outcome: 'hit' | 'miss',
+  emoji: string | undefined,
+): Promise<boolean> {
+  return invokeSafeVoid('record_inline_emoji_fallback_outcome', { shortcode, outcome, emoji });
+}

--- a/asyar-launcher/src/lib/ipc/statusBarCommands.ts
+++ b/asyar-launcher/src/lib/ipc/statusBarCommands.ts
@@ -1,0 +1,38 @@
+import { invokeSafeVoid } from './invokeSafe';
+
+/**
+ * Launcher-side image of the SDK's `IStatusBarItem` plus the
+ * `extensionId` the proxy injects before IPC. Mirrors the Rust
+ * `StatusBarItem` so we can forward verbatim to the tray manager.
+ */
+export interface StatusBarItem {
+  id: string;
+  extensionId: string;
+  icon?: string;
+  iconPath?: string;
+  text: string;
+  checked?: boolean;
+  submenu?: StatusBarItem[];
+  enabled?: boolean;
+  separator?: boolean;
+}
+
+// Silent: callers throw on failure (see statusBarService.svelte.ts) so the
+// extension-facing IPC router's own catch reports the diagnostic — avoids
+// reporting the same failure twice.
+
+export async function trayRegisterItem(item: StatusBarItem): Promise<boolean> {
+  return invokeSafeVoid('tray_register_item', { item }, { silent: true });
+}
+
+export async function trayUpdateItem(item: StatusBarItem): Promise<boolean> {
+  return invokeSafeVoid('tray_update_item', { item }, { silent: true });
+}
+
+export async function trayUnregisterItem(extensionId: string, id: string): Promise<boolean> {
+  return invokeSafeVoid('tray_unregister_item', { extensionId, id }, { silent: true });
+}
+
+export async function trayRemoveAllForExtension(extensionId: string): Promise<boolean> {
+  return invokeSafeVoid('tray_remove_all_for_extension', { extensionId }, { silent: true });
+}

--- a/asyar-launcher/src/lib/ipc/systemCommands.ts
+++ b/asyar-launcher/src/lib/ipc/systemCommands.ts
@@ -1,0 +1,113 @@
+import { invokeSafe, invokeSafeVoid } from './invokeSafe';
+import type {
+  ScheduleTimerOptions,
+  TimerDescriptor,
+  KeepAwakeOptions,
+  ActiveInhibitor,
+  AppGroup,
+  KillResult,
+  ProcessSortBy,
+} from 'asyar-sdk/contracts';
+
+type RawTimerRow = {
+  timerId: string;
+  extensionId: string;
+  commandId: string;
+  argsJson: string;
+  fireAt: number;
+  createdAt: number;
+};
+
+export async function timerSchedule(
+  extensionId: string | null,
+  commandId: string,
+  argsJson: string,
+  fireAt: number,
+): Promise<string | null> {
+  return invokeSafe<string>('timer_schedule', { extensionId, commandId, argsJson, fireAt });
+}
+
+export async function timerCancel(extensionId: string | null, timerId: string): Promise<boolean> {
+  return invokeSafeVoid('timer_cancel', { extensionId, timerId });
+}
+
+export async function timerList(extensionId: string | null): Promise<RawTimerRow[] | null> {
+  return invokeSafe<RawTimerRow[]>('timer_list', { extensionId });
+}
+
+export async function powerKeepAwake(
+  extensionId: string | null,
+  options: KeepAwakeOptions,
+): Promise<string | null> {
+  return invokeSafe<string>('power_keep_awake', { extensionId, options });
+}
+
+export async function powerRelease(extensionId: string | null, token: string): Promise<boolean> {
+  return invokeSafeVoid('power_release', { extensionId, token });
+}
+
+export async function powerList(extensionId: string | null): Promise<ActiveInhibitor[] | null> {
+  return invokeSafe<ActiveInhibitor[]>('power_list', { extensionId });
+}
+
+export async function systemEventsSubscribe(
+  extensionId: string | null,
+  eventTypes: string[],
+): Promise<string | null> {
+  return invokeSafe<string>('system_events_subscribe', { extensionId, eventTypes });
+}
+
+export async function systemEventsUnsubscribe(
+  extensionId: string | null,
+  subscriptionId: string,
+): Promise<boolean> {
+  return invokeSafeVoid('system_events_unsubscribe', { extensionId, subscriptionId });
+}
+
+export async function processListCommand(
+  extensionId: string | null,
+  query: string | undefined,
+  sortBy: ProcessSortBy,
+): Promise<AppGroup[] | null> {
+  return invokeSafe<AppGroup[]>('process_list', { extensionId, query, sortBy });
+}
+
+export async function processKillCommand(
+  extensionId: string | null,
+  pids: number[],
+  force: boolean,
+  confirmedProtected: boolean,
+): Promise<KillResult | null> {
+  return invokeSafe<KillResult>('process_kill', { extensionId, pids, force, confirmedProtected });
+}
+
+export async function fsWatchCreate(
+  extensionId: string | null,
+  paths: string[],
+  opts: { recursive?: boolean; debounceMs?: number } | null = null,
+): Promise<string | null> {
+  return invokeSafe<string>('fs_watch_create', { extensionId, paths, opts });
+}
+
+export async function fsWatchDispose(
+  extensionId: string | null,
+  handleId: string,
+): Promise<boolean> {
+  return invokeSafeVoid('fs_watch_dispose', { extensionId, handleId });
+}
+
+export async function appEventsSubscribe(
+  extensionId: string | null,
+  eventTypes: string[],
+): Promise<string | null> {
+  return invokeSafe<string>('app_events_subscribe', { extensionId, eventTypes });
+}
+
+export async function appEventsUnsubscribe(
+  extensionId: string | null,
+  subscriptionId: string,
+): Promise<boolean> {
+  return invokeSafeVoid('app_events_unsubscribe', { extensionId, subscriptionId });
+}
+
+export type { ScheduleTimerOptions, TimerDescriptor };

--- a/asyar-launcher/src/lib/ipc/updateCommands.ts
+++ b/asyar-launcher/src/lib/ipc/updateCommands.ts
@@ -1,0 +1,22 @@
+import { invokeSafe, invokeSafeOption } from './invokeSafe';
+
+export interface PendingUpdate {
+  version: string;
+}
+
+/**
+ * `app_updater_check_now` is `Result<Option<String>, String>` — a clean
+ * "up to date" (`Ok(None)`) and a failed check both serialize to `null`, so
+ * this uses `invokeSafeOption` to keep the two distinguishable: callers need
+ * to surface a real check failure to the user, not silently report
+ * "up to date".
+ */
+export async function appUpdaterCheckNow(): Promise<
+  { ok: true; value: string | null } | { ok: false }
+> {
+  return invokeSafeOption<string>('app_updater_check_now');
+}
+
+export async function appUpdaterGetPending(): Promise<PendingUpdate | null> {
+  return invokeSafe<PendingUpdate>('app_updater_get_pending');
+}

--- a/asyar-launcher/src/lib/ipc/usageCommands.test.ts
+++ b/asyar-launcher/src/lib/ipc/usageCommands.test.ts
@@ -22,7 +22,7 @@ describe('getUsageStats', () => {
   it('calls invoke with get_usage_stats', async () => {
     mockInvoke.mockResolvedValue({ activeDays: 3, totalLaunches: 42, top: [] });
     await getUsageStats();
-    expect(mockInvoke).toHaveBeenCalledWith('get_usage_stats');
+    expect(mockInvoke).toHaveBeenCalledWith('get_usage_stats', undefined);
   });
 
   it('returns the UsageStats payload', async () => {
@@ -37,7 +37,7 @@ describe('recordActiveDay', () => {
   it('calls invoke with record_active_day', async () => {
     mockInvoke.mockResolvedValue(undefined);
     await recordActiveDay();
-    expect(mockInvoke).toHaveBeenCalledWith('record_active_day');
+    expect(mockInvoke).toHaveBeenCalledWith('record_active_day', undefined);
   });
 });
 
@@ -45,7 +45,7 @@ describe('getUsageAnonId', () => {
   it('calls invoke with get_usage_anon_id', async () => {
     mockInvoke.mockResolvedValue('some-uuid');
     await getUsageAnonId();
-    expect(mockInvoke).toHaveBeenCalledWith('get_usage_anon_id');
+    expect(mockInvoke).toHaveBeenCalledWith('get_usage_anon_id', undefined);
   });
 
   it('returns the anon id string', async () => {
@@ -59,7 +59,7 @@ describe('resetUsageAnonId', () => {
   it('calls invoke with reset_usage_anon_id', async () => {
     mockInvoke.mockResolvedValue('new-uuid');
     await resetUsageAnonId();
-    expect(mockInvoke).toHaveBeenCalledWith('reset_usage_anon_id');
+    expect(mockInvoke).toHaveBeenCalledWith('reset_usage_anon_id', undefined);
   });
 
   it('returns the new anon id string', async () => {
@@ -81,7 +81,7 @@ describe('sendUsageNow', () => {
   it('calls invoke with send_usage_now', async () => {
     mockInvoke.mockResolvedValue(0);
     await sendUsageNow();
-    expect(mockInvoke).toHaveBeenCalledWith('send_usage_now');
+    expect(mockInvoke).toHaveBeenCalledWith('send_usage_now', undefined);
   });
 
   it('returns the number of events sent', async () => {

--- a/asyar-launcher/src/lib/rankItems.ts
+++ b/asyar-launcher/src/lib/rankItems.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { rankItemsCommand } from './ipc/searchAccessoryCommands';
 
 /**
  * Field accessors that project an arbitrary item onto the shape the Rust
@@ -35,7 +35,7 @@ export async function rankItems<T>(
     keywords: fields.keywords?.(item) ?? [],
   }));
 
-  const orderedIds = await invoke<string[]>('rank_items', { query: trimmed, items: payload });
+  const orderedIds = (await rankItemsCommand(trimmed, payload)) ?? [];
 
   const byId = new Map(items.map((item) => [fields.id(item), item]));
   return orderedIds

--- a/asyar-launcher/src/lib/useShortcutCapture.svelte.test.ts
+++ b/asyar-launcher/src/lib/useShortcutCapture.svelte.test.ts
@@ -40,7 +40,7 @@ describe('useShortcutCapture', () => {
     const capture = useShortcutCapture({ onCapture: async () => true });
     capture.startRecording();
     expect(capture.state.isRecording).toBe(true);
-    expect(vi.mocked(invoke)).toHaveBeenCalledWith('pause_all_shortcuts');
+    expect(vi.mocked(invoke)).toHaveBeenCalledWith('pause_all_shortcuts', undefined);
   });
 
   it('stopRecording resumes OS shortcuts', () => {
@@ -49,7 +49,7 @@ describe('useShortcutCapture', () => {
     vi.mocked(invoke).mockClear();
     capture.stopRecording();
     expect(capture.state.isRecording).toBe(false);
-    expect(vi.mocked(invoke)).toHaveBeenCalledWith('resume_all_shortcuts');
+    expect(vi.mocked(invoke)).toHaveBeenCalledWith('resume_all_shortcuts', undefined);
   });
 
   it('Escape cancels recording and calls onCancel', () => {

--- a/asyar-launcher/src/lib/useShortcutCapture.svelte.ts
+++ b/asyar-launcher/src/lib/useShortcutCapture.svelte.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { resumeAllShortcuts, pauseAllShortcuts } from './ipc/commands';
 import {
   MODIFIER_KEYS,
   MODIFIER_ORDER,
@@ -127,7 +127,7 @@ export function useShortcutCapture(config: CaptureConfig) {
     window.removeEventListener('keydown', handleKeyDown, true);
     window.removeEventListener('keyup', handleKeyUp, true);
     window.removeEventListener('blur', handleWindowBlur);
-    invoke('resume_all_shortcuts').catch(console.error);
+    void resumeAllShortcuts();
   }
 
   function stopRecording() {
@@ -154,7 +154,7 @@ export function useShortcutCapture(config: CaptureConfig) {
     partialModifiers = [];
     savedWithoutCancel = false;
 
-    invoke('pause_all_shortcuts').catch(console.error);
+    void pauseAllShortcuts();
     window.addEventListener('keydown', handleKeyDown, true);
     window.addEventListener('keyup', handleKeyUp, true);
     window.addEventListener('blur', handleWindowBlur);

--- a/asyar-launcher/src/routes/onboarding/steps/AccessibilityGate.svelte
+++ b/asyar-launcher/src/routes/onboarding/steps/AccessibilityGate.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte'
-  import { invoke } from '@tauri-apps/api/core'
   import { platform } from '@tauri-apps/plugin-os'
   import Button from '../../../components/base/Button.svelte'
+  import { checkSnippetPermission, openAccessibilityPreferences } from '../../../lib/ipc/commands'
 
   let { granted = $bindable(false) }: { granted?: boolean } = $props()
 
@@ -10,20 +10,13 @@
   let loading = $state(false)
 
   async function check() {
-    try {
-      granted = await invoke<boolean>('check_snippet_permission')
-    } catch {
-      granted = false
-    }
+    granted = (await checkSnippetPermission()) ?? false
   }
 
   async function openPrefs() {
     loading = true
-    try {
-      await invoke('open_accessibility_preferences')
-    } finally {
-      loading = false
-    }
+    await openAccessibilityPreferences()
+    loading = false
   }
 
   onMount(async () => {

--- a/asyar-launcher/src/routes/onboarding/steps/PickTheme.svelte
+++ b/asyar-launcher/src/routes/onboarding/steps/PickTheme.svelte
@@ -29,6 +29,10 @@
   async function refreshDiscovery() {
     try {
       const records = await discoverExtensions();
+      if (records === null) {
+        logService.warn('[onboarding] discoverExtensions failed');
+        return;
+      }
       const next: Record<string, string> = {};
       for (const r of records) {
         if (r.manifest.type === 'theme') next[r.manifest.name] = r.manifest.id;

--- a/asyar-launcher/src/routes/onboarding/steps/emojiSetup.ts
+++ b/asyar-launcher/src/routes/onboarding/steps/emojiSetup.ts
@@ -4,7 +4,7 @@ import { listInstalledExtensions } from '../../../lib/ipc/commands'
 const EMOJI_ID = 'org.asyar.emoji'
 
 export async function installEmoji(): Promise<boolean> {
-  const installed = await listInstalledExtensions()
+  const installed = (await listInstalledExtensions()) ?? []
   if (installed.includes(EMOJI_ID)) return true
   await storeExtension.installExtension('emoji', EMOJI_ID, 'Emoji')
   return true

--- a/asyar-launcher/src/routes/settings/tabs/AppearanceTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/AppearanceTab.svelte
@@ -21,7 +21,7 @@
   onMount(async () => {
     try {
       const records = await discoverExtensions();
-      themeExtensions = records
+      themeExtensions = (records ?? [])
         .filter((r: any) => r.manifest.type === 'theme' && r.enabled)
         .map((r: any) => ({
           id: r.manifest.id,

--- a/asyar-launcher/src/routes/settings/tabs/ApplicationsTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/ApplicationsTab.svelte
@@ -69,8 +69,8 @@
         getDefaultAppScanPaths(),
         listApplications(userPaths),
       ]);
-      defaultPaths = paths;
-      apps = withIds(loaded);
+      defaultPaths = paths ?? [];
+      apps = withIds(loaded ?? []);
       void aliasStore.refresh().catch((e) => {
         logService.warn(`Failed to refresh alias store: ${e}`);
       });
@@ -83,7 +83,7 @@
 
   async function reloadApps() {
     try {
-      apps = withIds(await listApplications(userPaths));
+      apps = withIds((await listApplications(userPaths)) ?? []);
     } catch (err) {
       logService.warn(`Failed to reload applications: ${err}`);
     }

--- a/asyar-launcher/src/routes/settings/tabs/BrowsersTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/BrowsersTab.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import { invoke } from '@tauri-apps/api/core';
   import { listen } from '@tauri-apps/api/event';
   import { openUrl } from '@tauri-apps/plugin-opener';
   import { browserService } from '../../../services/browser/browserService';
   import { diagnosticsService } from '../../../services/diagnostics/diagnosticsService.svelte';
+  import {
+    browserListPendingPairings,
+    browserResolvePairing,
+    browserRevokePairing,
+    type PendingPairing,
+  } from '../../../lib/ipc/settingsUiCommands';
   import type { BrowserId, BrowserKey, BrowserFamily } from 'asyar-sdk/contracts';
 
-  type PendingPairing = { id: string; family: string; variant: string };
   type PairRequestEvent = { pairing_id: string; family: string; variant: string };
 
   // The Asyar Companion is a separate browser extension that pairs with this
@@ -40,54 +44,44 @@
   }
 
   async function refresh() {
-    try {
-      availableBrowsers = await browserService.listAvailableBrowsers();
-      pairedBrowsers = await browserService.listPairedBrowsers();
-      pendingPairings = await invoke<PendingPairing[]>('browser_list_pending_pairings');
-      const status: Record<string, boolean> = {};
-      for (const fam of ['chromium', 'firefox', 'safari'] as const) {
-        status[fam] = await browserService.isCompanionInstalled(fam as BrowserFamily);
-      }
-      connectionStatus = status;
-    } catch (err) {
-      diagnosticsService.report({
-        source: 'frontend',
-        kind: 'browser:settings.refresh-failed',
-        severity: 'warning',
-        retryable: true,
-        context: { message: err instanceof Error ? err.message : String(err) },
-      });
+    availableBrowsers = await browserService.listAvailableBrowsers();
+    pairedBrowsers = await browserService.listPairedBrowsers();
+    pendingPairings = (await browserListPendingPairings()) ?? [];
+    const status: Record<string, boolean> = {};
+    for (const fam of ['chromium', 'firefox', 'safari'] as const) {
+      status[fam] = await browserService.isCompanionInstalled(fam as BrowserFamily);
     }
+    connectionStatus = status;
   }
 
   async function resolve(id: string, decision: 'allow' | 'deny') {
-    try {
-      await invoke('browser_resolve_pairing', { pairingId: id, decision });
-      await refresh();
-    } catch (err) {
+    const ok = await browserResolvePairing(id, decision);
+    if (!ok) {
       diagnosticsService.report({
         source: 'frontend',
         kind: 'browser:settings.resolve-failed',
         severity: 'error',
         retryable: false,
-        context: { message: err instanceof Error ? err.message : String(err) },
+        context: { message: 'browser_resolve_pairing failed' },
       });
+      return;
     }
+    await refresh();
   }
 
   async function revoke(family: string, variant: string) {
-    try {
-      await invoke('browser_revoke_pairing', { family, variant });
-      await refresh();
-    } catch (err) {
+    const ok = await browserRevokePairing(family, variant);
+    if (!ok) {
       diagnosticsService.report({
         source: 'frontend',
         kind: 'browser:settings.revoke-failed',
         severity: 'error',
         retryable: false,
-        context: { message: err instanceof Error ? err.message : String(err) },
+        context: { message: 'browser_revoke_pairing failed' },
       });
+      return;
     }
+    await refresh();
   }
 
   let unlisteners: Array<() => void> = [];

--- a/asyar-launcher/src/routes/settings/tabs/DeveloperTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/DeveloperTab.svelte
@@ -8,10 +8,11 @@
     EmptyState,
   } from '../../../components';
   import type { SettingsHandler } from '../settingsHandlers.svelte';
-  import { invoke } from '@tauri-apps/api/core';
   import extensionManager from '../../../services/extension/extensionManager.svelte';
   import { feedbackService } from '../../../services/feedback/feedbackService.svelte';
   import { logService } from '../../../services/log/logService';
+  import { getDevExtensionPaths } from '../../../lib/ipc/commands';
+  import { forceRemountWorker } from '../../../lib/ipc/devCommands';
 
   let { handler }: { handler: SettingsHandler } = $props();
 
@@ -29,35 +30,31 @@
   async function loadDevExtensions() {
     isLoadingDevExts = true;
     devExtError = '';
-    try {
-      devExtensions = await invoke<Record<string, string>>('get_dev_extension_paths');
-    } catch (err) {
-      logService.error(`Failed to load dev extensions: ${err}`);
+    const result = await getDevExtensionPaths();
+    if (result === null) {
+      logService.error('Failed to load dev extensions');
       devExtError = 'Failed to load dev extensions.';
       devExtensions = {};
-    } finally {
-      isLoadingDevExts = false;
+    } else {
+      devExtensions = result;
     }
+    isLoadingDevExts = false;
   }
 
   async function hotReload(extensionId: string) {
     if (reloadingExt) return;
     reloadingExt = extensionId;
-    try {
-      const manifest = extensionManager.getManifestById(extensionId) as
-        | { background?: { main?: string } }
-        | undefined;
-      await invoke('force_remount_worker', {
-        extensionId,
-        hasBackgroundMain: !!manifest?.background?.main,
-      });
+    const manifest = extensionManager.getManifestById(extensionId) as
+      | { background?: { main?: string } }
+      | undefined;
+    const ok = await forceRemountWorker(extensionId, !!manifest?.background?.main);
+    if (ok) {
       feedbackService.showToast({ title: `Reloaded ${extensionId}` });
-    } catch (err) {
-      logService.error(`Failed to hot-reload ${extensionId}: ${err}`);
+    } else {
+      logService.error(`Failed to hot-reload ${extensionId}`);
       feedbackService.showToast({ title: 'Reload failed' });
-    } finally {
-      reloadingExt = null;
     }
+    reloadingExt = null;
   }
 
   async function detachDevExtension(extensionId: string) {

--- a/asyar-launcher/src/routes/settings/tabs/GeneralTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/GeneralTab.svelte
@@ -32,7 +32,7 @@
   onMount(async () => {
     try {
       const records = await discoverExtensions();
-      themeExtensions = records
+      themeExtensions = (records ?? [])
         .filter((r: any) => r.manifest.type === 'theme' && r.enabled)
         .map((r: any) => ({
           id: r.manifest.id,

--- a/asyar-launcher/src/routes/settings/tabs/ScriptsTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/ScriptsTab.svelte
@@ -16,7 +16,7 @@
 
   async function fetchDirectories() {
     try {
-      directories = await scriptsListDirectories();
+      directories = (await scriptsListDirectories()) ?? [];
     } catch (err) {
       logService.warn(`Failed to list script directories: ${err}`);
     }

--- a/asyar-launcher/src/routes/settings/tabs/backupHandler.svelte.ts
+++ b/asyar-launcher/src/routes/settings/tabs/backupHandler.svelte.ts
@@ -148,6 +148,9 @@ export class BackupHandler {
 
     try {
       const contents = await importProfile(filePath, null);
+      if (contents === null) {
+        throw new Error('Failed to read profile archive');
+      }
       const manifest: ArchiveManifest = JSON.parse(contents.manifest_json);
 
       if (manifest.encryptionScheme) {
@@ -172,6 +175,9 @@ export class BackupHandler {
 
     try {
       const contents = await importProfile(this.importFile, this.importPassword);
+      if (contents === null) {
+        throw new Error('Failed to read profile archive');
+      }
       const manifest: ArchiveManifest = JSON.parse(contents.manifest_json);
       await this._populatePreview(contents, manifest);
       this.importNeedsPassword = false;

--- a/asyar-launcher/src/services/action/actionService.svelte.ts
+++ b/asyar-launcher/src/services/action/actionService.svelte.ts
@@ -476,15 +476,15 @@ export class ActionService implements IActionService {
         let confirmMessage: string;
 
         if (IS_MACOS) {
-          try {
-            const scan = await applicationService.scanUninstallTargets(appPath);
-            dataPaths = scan.dataPaths.map((p) => p.path);
-            confirmMessage = buildMacosConfirmMessage(appName, scan);
-          } catch (err) {
+          const scan = await applicationService.scanUninstallTargets(appPath);
+          if (scan === null) {
             logService.warn(
-              `Uninstall scan failed for '${appPath}': ${err}. Falling back to app-only confirm.`,
+              `Uninstall scan failed for '${appPath}'. Falling back to app-only confirm.`,
             );
             confirmMessage = `This will move ${appName} to the Trash. You can restore it from there later.`;
+          } else {
+            dataPaths = scan.dataPaths.map((p) => p.path);
+            confirmMessage = buildMacosConfirmMessage(appName, scan);
           }
         } else {
           // Windows

--- a/asyar-launcher/src/services/action/actionService.test.ts
+++ b/asyar-launcher/src/services/action/actionService.test.ts
@@ -964,9 +964,7 @@ describe('uninstall_application built-in action', () => {
     const svc = freshService()
     mockSearchOrchestrator.items = [makeAppResult({ name: 'Broken' })]
     mockSearchStores.selectedIndex = 0
-    mockApplicationService.scanUninstallTargets.mockRejectedValueOnce(
-      new Error('disk full or whatever'),
-    )
+    mockApplicationService.scanUninstallTargets.mockResolvedValueOnce(null)
 
     await svc.executeAction('uninstall_application')
 
@@ -1062,7 +1060,7 @@ describe('factory_reset built-in action', () => {
 
     await svc.executeAction('factory_reset')
 
-    expect(invoke).toHaveBeenCalledWith('factory_reset')
+    expect(invoke).toHaveBeenCalledWith('factory_reset', undefined)
   })
 
   it('execute is a no-op when the user cancels the confirm dialog', async () => {

--- a/asyar-launcher/src/services/appEvents/appEventsService.ts
+++ b/asyar-launcher/src/services/appEvents/appEventsService.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { appEventsSubscribe, appEventsUnsubscribe } from '../../lib/ipc/systemCommands';
 
 /**
  * Host-side thin wrapper over the Rust `app_events_*` Tauri commands.
@@ -16,10 +16,10 @@ import { invoke } from '@tauri-apps/api/core';
  */
 export const appEventsService = {
   async subscribe(extensionId: string | null, eventTypes: string[]): Promise<string> {
-    return invoke<string>('app_events_subscribe', { extensionId, eventTypes });
+    return (await appEventsSubscribe(extensionId, eventTypes)) ?? '';
   },
 
   async unsubscribe(extensionId: string | null, subscriptionId: string): Promise<void> {
-    return invoke<void>('app_events_unsubscribe', { extensionId, subscriptionId });
+    await appEventsUnsubscribe(extensionId, subscriptionId);
   },
 };

--- a/asyar-launcher/src/services/appInitializer.ts
+++ b/asyar-launcher/src/services/appInitializer.ts
@@ -202,14 +202,16 @@ export const appInitializer = {
       // Failure here means every always-on extension is dormant until the
       // user re-enables it, so it surfaces through the diagnostics channel
       // rather than a quiet log.
-      restoreWorkers().catch((err: unknown) => {
-        void diagnosticsService.report({
-          source: 'frontend',
-          kind: 'extension-runtime/restore-workers-failed',
-          severity: 'error',
-          retryable: false,
-          developerDetail: String(err),
-        });
+      restoreWorkers().then((result) => {
+        if (result === null) {
+          void diagnosticsService.report({
+            source: 'frontend',
+            kind: 'extension-runtime/restore-workers-failed',
+            severity: 'error',
+            retryable: false,
+            developerDetail: 'restore_workers failed',
+          });
+        }
       });
 
       // Initialize extension update service for silent auto-updates
@@ -232,7 +234,7 @@ export const appInitializer = {
       // Check whether to show What's New panel (shown once after each update)
       try {
         const { getVersion } = await import('@tauri-apps/api/app')
-        const { invoke } = await import('@tauri-apps/api/core')
+        const { appUpdaterShouldShowWhatsNew } = await import('../lib/ipc/applicationCommands')
         const { whatsNewStore } = await import('./update/whatsNewStore.svelte')
         const currentVersion = await getVersion()
         const lastSeen = settingsService.currentSettings.updates?.lastSeenVersion
@@ -240,10 +242,7 @@ export const appInitializer = {
           // Fresh install — record silently so next update shows the panel
           await settingsService.updateSettings('updates', { lastSeenVersion: currentVersion })
         } else {
-          const shouldShow = await invoke<boolean>('app_updater_should_show_whats_new', {
-            lastSeenVersion: lastSeen,
-            currentVersion,
-          })
+          const shouldShow = await appUpdaterShouldShowWhatsNew(lastSeen, currentVersion)
           if (shouldShow) {
             whatsNewStore.version = currentVersion
           }

--- a/asyar-launcher/src/services/application/applicationService.test.ts
+++ b/asyar-launcher/src/services/application/applicationService.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('../log/logService', () => ({
+  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
 vi.mock('../settings/settingsService.svelte', () => ({
   settingsService: {
     currentSettings: {
@@ -29,7 +32,7 @@ describe('ApplicationService', () => {
 
       const result = await service.getFrontmostApplication();
 
-      expect(invoke).toHaveBeenCalledWith('get_frontmost_application');
+      expect(invoke).toHaveBeenCalledWith('get_frontmost_application', undefined);
       expect(result).toEqual(mockApp);
     });
   });
@@ -81,14 +84,14 @@ describe('ApplicationService', () => {
       });
     });
 
-    it('propagates Rust errors to the caller', async () => {
+    it('resolves without throwing when the Rust call fails', async () => {
       vi.mocked(invoke).mockRejectedValueOnce(
         'Permission denied: cannot uninstall system-protected application',
       );
 
       await expect(
         service.uninstallApplication('/System/Applications/Calendar.app'),
-      ).rejects.toMatch(/system-protected/);
+      ).resolves.toBeUndefined();
     });
   });
 
@@ -116,14 +119,14 @@ describe('ApplicationService', () => {
       expect(result).toEqual(scan);
     });
 
-    it('propagates Rust errors (e.g. platform unsupported)', async () => {
+    it('resolves to null when the Rust call fails (e.g. platform unsupported)', async () => {
       vi.mocked(invoke).mockRejectedValueOnce(
         'Platform error: scan_uninstall_targets is only supported on macOS',
       );
 
       await expect(
         service.scanUninstallTargets('/Applications/Foo.app'),
-      ).rejects.toMatch(/only supported on macOS/);
+      ).resolves.toBeNull();
     });
   });
 

--- a/asyar-launcher/src/services/application/applicationService.ts
+++ b/asyar-launcher/src/services/application/applicationService.ts
@@ -1,28 +1,15 @@
-import { invoke } from '@tauri-apps/api/core';
 import { settingsService } from '../settings/settingsService.svelte';
 import type { FrontmostApplication } from 'asyar-sdk/contracts';
+import {
+  getFrontmostApplication,
+  appIsRunning,
+  uninstallApplication,
+  scanUninstallTargets,
+  type UninstallScanResult,
+} from '../../lib/ipc/applicationCommands';
+import { syncApplicationIndex, listApplications } from '../../lib/ipc/commands';
 
-/**
- * One row of Library-scope data matched to an installed application by the
- * macOS uninstall scanner. Mirrors the Rust `AppDataPath` struct.
- */
-export interface AppDataPath {
-  path: string;
-  sizeBytes: number;
-  category: string;
-}
-
-/**
- * Result of a macOS uninstall scan — the `.app` path + size plus every
- * `~/Library/*` entry associated with the bundle id. Rendered in the
- * confirm sheet so the user sees exactly what will be trashed.
- */
-export interface UninstallScanResult {
-  appPath: string;
-  appSizeBytes: number;
-  dataPaths: AppDataPath[];
-  totalBytes: number;
-}
+export type { AppDataPath, UninstallScanResult } from '../../lib/ipc/applicationCommands';
 
 /**
  * Host-side service that fulfils the query half of `ApplicationService`
@@ -32,18 +19,18 @@ export interface UninstallScanResult {
  * `appEvents:*` namespace, not through this service.
  */
 export class ApplicationService {
-  async getFrontmostApplication(): Promise<FrontmostApplication> {
-    return await invoke<FrontmostApplication>('get_frontmost_application');
+  async getFrontmostApplication(): Promise<FrontmostApplication | null> {
+    return getFrontmostApplication();
   }
 
   async syncApplicationIndex(extraPaths?: string[]): Promise<{ added: number; removed: number; total: number }> {
     const paths = extraPaths ?? settingsService.currentSettings.search.additionalScanPaths ?? [];
-    return await invoke('sync_application_index', { extraPaths: paths });
+    return (await syncApplicationIndex(paths)) ?? { added: 0, removed: 0, total: 0 };
   }
 
   async listApplications(extraPaths?: string[]): Promise<any[]> {
     const paths = extraPaths ?? settingsService.currentSettings.search.additionalScanPaths ?? [];
-    return await invoke('list_applications', { extraPaths: paths });
+    return (await listApplications(paths)) ?? [];
   }
 
   /**
@@ -56,7 +43,7 @@ export class ApplicationService {
    * defense-in-depth check as a core-context call.
    */
   async isRunning(bundleId: string): Promise<boolean> {
-    return await invoke<boolean>('app_is_running', { bundleId });
+    return (await appIsRunning(bundleId)) ?? false;
   }
 
   /**
@@ -78,7 +65,7 @@ export class ApplicationService {
    * `applications-changed` on its own — no manual sync needed.
    */
   async uninstallApplication(path: string, dataPaths: string[] = []): Promise<void> {
-    await invoke<void>('uninstall_application', { path, dataPaths });
+    await uninstallApplication(path, dataPaths);
   }
 
   /**
@@ -91,8 +78,8 @@ export class ApplicationService {
    * passing their `path` list to `uninstallApplication`. The scan is
    * advisory — Rust re-validates each path before trashing.
    */
-  async scanUninstallTargets(path: string): Promise<UninstallScanResult> {
-    return await invoke<UninstallScanResult>('scan_uninstall_targets', { path });
+  async scanUninstallTargets(path: string): Promise<UninstallScanResult | null> {
+    return scanUninstallTargets(path);
   }
 }
 

--- a/asyar-launcher/src/services/application/applicationsService.ts
+++ b/asyar-launcher/src/services/application/applicationsService.ts
@@ -40,6 +40,9 @@ class ApplicationsService implements IApplicationsService {
     const extraPaths =
       override?.additionalScanPaths ?? search.additionalScanPaths ?? [];
     const result = await commands.syncApplicationIndex(extraPaths);
+    if (result === null) {
+      throw new Error('sync_application_index failed');
+    }
     logService.info(`App sync: ${result.added} added, ${result.removed} removed, ${result.total} total`);
   }
 

--- a/asyar-launcher/src/services/application/scanPathsSync.svelte.ts
+++ b/asyar-launcher/src/services/application/scanPathsSync.svelte.ts
@@ -1,6 +1,5 @@
-import { invoke } from '@tauri-apps/api/core';
 import { settingsService } from '../settings/settingsService.svelte';
-import { logService } from '../log/logService';
+import { setApplicationScanPaths } from '../../lib/ipc/applicationCommands';
 
 /**
  * Keeps the Rust `IndexWatcher`'s user-configured scan paths in sync with
@@ -45,11 +44,7 @@ function pathsEqual(a: string[], b: string[]): boolean {
 }
 
 async function pushPaths(paths: string[]): Promise<void> {
-  try {
-    await invoke('set_application_scan_paths', { paths });
-  } catch (err) {
-    logService.warn(`set_application_scan_paths failed: ${err}`);
-  }
+  await setApplicationScanPaths(paths);
 }
 
 export function initScanPathsSync(): () => void {

--- a/asyar-launcher/src/services/applicationIndex/applicationIndexService.ts
+++ b/asyar-launcher/src/services/applicationIndex/applicationIndexService.ts
@@ -1,4 +1,7 @@
-import { invoke } from '@tauri-apps/api/core';
+import {
+  applicationIndexSubscribe,
+  applicationIndexUnsubscribe,
+} from '../../lib/ipc/applicationCommands';
 
 /**
  * Host-side thin wrapper over the Rust `application_index_*` Tauri
@@ -18,20 +21,14 @@ export const applicationIndexService = {
   async subscribe(
     extensionId: string | null,
     eventTypes: string[],
-  ): Promise<string> {
-    return invoke<string>('application_index_subscribe', {
-      extensionId,
-      eventTypes,
-    });
+  ): Promise<string | null> {
+    return applicationIndexSubscribe(extensionId, eventTypes);
   },
 
   async unsubscribe(
     extensionId: string | null,
     subscriptionId: string,
   ): Promise<void> {
-    return invoke<void>('application_index_unsubscribe', {
-      extensionId,
-      subscriptionId,
-    });
+    await applicationIndexUnsubscribe(extensionId, subscriptionId);
   },
 };

--- a/asyar-launcher/src/services/auth/authService.svelte.ts
+++ b/asyar-launcher/src/services/auth/authService.svelte.ts
@@ -90,7 +90,11 @@ class AuthService {
       this.isLoading = true;
       this.loginError = null;
 
-      const { sessionCode, authUrl } = await commands.authInitiate(provider);
+      const initResult = await commands.authInitiate(provider);
+      if (!initResult) {
+        throw new Error('Server did not respond');
+      }
+      const { sessionCode, authUrl } = initResult;
 
       // Open the browser
       await openUrl(authUrl);
@@ -154,6 +158,9 @@ class AuthService {
   async refreshEntitlements(): Promise<void> {
     if (!this.isLoggedIn) return;
     const fresh = await commands.authRefreshEntitlements();
+    if (fresh === null) {
+      throw new Error('Failed to refresh entitlements');
+    }
     this.entitlements = fresh;
   }
 
@@ -191,19 +198,17 @@ class AuthService {
   /** Poll backend until status = complete or expired. Used as fallback when deep link fires. */
   private _startFallbackPolling(sessionCode: string): void {
     this.pollTimer = setInterval(async () => {
-      try {
-        const result = await commands.authPoll(sessionCode);
-        if (result.status === 'complete' || result.status === 'expired') {
-          this.cancelLoginPolling();
-          if (result.status === 'complete') {
-            await this._applyPollResult(result);
-          } else {
-            this.loginError = 'Login session expired. Please try again.';
-            this.isAwaitingOAuth = false;
-          }
+      const result = await commands.authPoll(sessionCode);
+      // null = transient poll failure (already diagnosed by invokeSafe) — try again next tick.
+      if (result === null) return;
+      if (result.status === 'complete' || result.status === 'expired') {
+        this.cancelLoginPolling();
+        if (result.status === 'complete') {
+          await this._applyPollResult(result);
+        } else {
+          this.loginError = 'Login session expired. Please try again.';
+          this.isAwaitingOAuth = false;
         }
-      } catch (err) {
-        logService.warn(`Auth: fallback poll error: ${err}`);
       }
     }, POLL_INTERVAL_MS);
   }
@@ -212,11 +217,11 @@ class AuthService {
   private async _completePoll(sessionCode: string): Promise<void> {
     // The deep link signals completion — do one direct poll for the payload
     const result = await commands.authPoll(sessionCode);
-    if (result.status !== 'complete') {
+    if (result === null || result.status !== 'complete') {
       // Try once more (network race)
       await new Promise(r => setTimeout(r, 500));
       const retry = await commands.authPoll(sessionCode);
-      if (retry.status !== 'complete') {
+      if (retry === null || retry.status !== 'complete') {
         throw new Error('OAuth completed but session data not ready');
       }
       await this._applyPollResult(retry);

--- a/asyar-launcher/src/services/browser/browserService.test.ts
+++ b/asyar-launcher/src/services/browser/browserService.test.ts
@@ -19,7 +19,7 @@ describe('browserService', () => {
     ];
     invokeMock.mockResolvedValue(fake);
     const result = await browserService.listAvailableBrowsers();
-    expect(invokeMock).toHaveBeenCalledWith('browser_list_available_browsers');
+    expect(invokeMock).toHaveBeenCalledWith('browser_list_available_browsers', undefined);
     expect(result).toEqual(fake);
   });
 
@@ -101,7 +101,7 @@ describe('browserService — live bridge', () => {
   it('listPairedBrowsers calls the command', async () => {
     invokeMock.mockResolvedValue([]);
     await browserService.listPairedBrowsers();
-    expect(invokeMock).toHaveBeenCalledWith('browser_list_paired_browsers');
+    expect(invokeMock).toHaveBeenCalledWith('browser_list_paired_browsers', undefined);
   });
 
   it('getCurrentPage forwards browser', async () => {
@@ -140,7 +140,7 @@ describe('browserService — command-bar additions', () => {
   it('getMostRecentActiveBrowser calls browser_get_most_recent_active_browser', async () => {
     invokeMock.mockResolvedValue(null);
     await browserService.getMostRecentActiveBrowser();
-    expect(invokeMock).toHaveBeenCalledWith('browser_get_most_recent_active_browser');
+    expect(invokeMock).toHaveBeenCalledWith('browser_get_most_recent_active_browser', undefined);
   });
 });
 

--- a/asyar-launcher/src/services/browser/browserService.ts
+++ b/asyar-launcher/src/services/browser/browserService.ts
@@ -1,4 +1,23 @@
-import { invoke } from '@tauri-apps/api/core';
+import {
+  browserListAvailableBrowsers,
+  browserIsCompanionInstalled,
+  browserListBookmarks,
+  browserSearchHistory,
+  browserListTabs,
+  browserGetActiveTab,
+  browserActivateTab,
+  browserCloseTab,
+  browserOpenUrl,
+  browserListPairedBrowsers,
+  browserGetCurrentPage,
+  browserQueryPage,
+  browserActOnPage,
+  browserSearchWeb,
+  browserGetMostRecentActiveBrowser,
+  browserSubscribeTabsChanged,
+  browserUnsubscribeEvents,
+  browserSubscribePageChanged,
+} from '../../lib/ipc/browserCommands';
 import type {
   Bookmark,
   BrowserFamily,
@@ -16,96 +35,86 @@ import type {
 
 export class BrowserService {
   async listAvailableBrowsers(): Promise<BrowserId[]> {
-    return invoke<BrowserId[]>('browser_list_available_browsers');
+    return (await browserListAvailableBrowsers()) ?? [];
   }
 
   async isCompanionInstalled(family: BrowserFamily): Promise<boolean> {
-    return invoke<boolean>('browser_is_companion_installed', { family });
+    return (await browserIsCompanionInstalled(family)) ?? false;
   }
 
   async listBookmarks(filter?: ListBookmarksFilter): Promise<Bookmark[]> {
-    return invoke<Bookmark[]>('browser_list_bookmarks', {
-      browser: filter?.browser,
-      query: filter?.query,
-    });
+    return (await browserListBookmarks(filter)) ?? [];
   }
 
   async searchHistory(
     query: string,
     opts?: SearchHistoryOptions,
   ): Promise<HistoryEntry[]> {
-    return invoke<HistoryEntry[]>('browser_search_history', {
-      query,
-      limit: opts?.limit,
-      sinceMs: opts?.sinceMs,
-    });
+    return (await browserSearchHistory(query, opts)) ?? [];
   }
 
   async listTabs(filter?: { browser?: BrowserId; query?: string }): Promise<Tab[]> {
-    return invoke<Tab[]>('browser_list_tabs', {
-      browser: filter?.browser,
-      query: filter?.query,
-    });
+    return (await browserListTabs(filter)) ?? [];
   }
 
   async getActiveTab(browser?: BrowserId): Promise<Tab | null> {
-    return invoke<Tab | null>('browser_get_active_tab', { browser });
+    return browserGetActiveTab(browser);
   }
 
   async activateTab(tabId: string): Promise<void> {
-    return invoke<void>('browser_activate_tab', { tabId });
+    return browserActivateTab(tabId);
   }
 
   async closeTab(tabId: string): Promise<void> {
-    return invoke<void>('browser_close_tab', { tabId });
+    return browserCloseTab(tabId);
   }
 
   async openUrl(url: string, target?: OpenUrlTarget): Promise<void> {
-    return invoke<void>('browser_open_url', { url, target });
+    return browserOpenUrl(url, target);
   }
 
   async listPairedBrowsers(): Promise<BrowserKey[]> {
-    return invoke<BrowserKey[]>('browser_list_paired_browsers');
+    return (await browserListPairedBrowsers()) ?? [];
   }
 
   async getCurrentPage(browser?: BrowserId): Promise<PageSnapshot | null> {
-    return invoke<PageSnapshot | null>('browser_get_current_page', { browser });
+    return browserGetCurrentPage(browser);
   }
 
   async queryPage(tabId: string, selector: string, attrs?: string[]): Promise<PageMatch[]> {
-    return invoke<PageMatch[]>('browser_query_page', { tabId, selector, attrs });
+    return (await browserQueryPage(tabId, selector, attrs)) ?? [];
   }
 
   async actOnPage(tabId: string, action: PageAction): Promise<void> {
-    return invoke<void>('browser_act_on_page', { tabId, action });
+    return browserActOnPage(tabId, action);
   }
 
   // — Plan A (command-bar additions) —
 
   async searchWeb(text: string, browser?: BrowserId): Promise<void> {
-    return invoke<void>('browser_search_web', { text, browser });
+    return browserSearchWeb(text, browser);
   }
 
   async getMostRecentActiveBrowser(): Promise<BrowserKey | null> {
-    return invoke<BrowserKey | null>('browser_get_most_recent_active_browser');
+    return browserGetMostRecentActiveBrowser();
   }
 
   // — Per-kind subscribe methods. Each hard-codes `eventTypes` so the wire payload
   // cannot side-channel a different kind. See permissionGate.ts for the per-kind gates.
   async subscribeTabsChanged(): Promise<string> {
-    return invoke<string>('browser_events_subscribe', { eventTypes: ['tabs.changed'] });
+    return (await browserSubscribeTabsChanged()) ?? '';
   }
 
   async unsubscribeTabsChanged(subscriptionId: string): Promise<void> {
-    return invoke<void>('browser_events_unsubscribe', { subscriptionId });
+    return browserUnsubscribeEvents(subscriptionId);
   }
 
   async subscribePageChanged(): Promise<string> {
-    return invoke<string>('browser_events_subscribe', { eventTypes: ['page.changed'] });
+    return (await browserSubscribePageChanged()) ?? '';
   }
 
   async unsubscribePageChanged(subscriptionId: string): Promise<void> {
-    return invoke<void>('browser_events_unsubscribe', { subscriptionId });
+    return browserUnsubscribeEvents(subscriptionId);
   }
 }
 

--- a/asyar-launcher/src/services/clipboard/clipboardHistoryService.test.ts
+++ b/asyar-launcher/src/services/clipboard/clipboardHistoryService.test.ts
@@ -752,7 +752,7 @@ describe('handleClipboardChange', () => {
     expect(call.sourceApp).toBeUndefined();
 
     const { logService } = await import('../log/logService');
-    expect(logService.debug).toHaveBeenCalledWith(expect.stringContaining('Failed to capture source app'));
+    expect(logService.error).toHaveBeenCalledWith(expect.stringContaining('get_frontmost_application'));
   });
 });
 
@@ -840,7 +840,7 @@ describe('pasteItem', () => {
     expect(hideWindowSpy).not.toHaveBeenCalled()
 
     // Jumps the user straight to the right System Settings pane.
-    expect(invoke).toHaveBeenCalledWith('open_accessibility_preferences')
+    expect(invoke).toHaveBeenCalledWith('open_accessibility_preferences', undefined)
 
     // Surfaces a guiding diagnostic mentioning Accessibility.
     expect(diagnosticsService.report).toHaveBeenCalledWith(

--- a/asyar-launcher/src/services/clipboard/clipboardHistoryService.ts
+++ b/asyar-launcher/src/services/clipboard/clipboardHistoryService.ts
@@ -8,9 +8,10 @@ import {
 import { copyFile, remove, mkdir } from "@tauri-apps/plugin-fs";
 import { appDataDir } from "@tauri-apps/api/path";
 import { platform } from "@tauri-apps/plugin-os";
-import { invoke } from '@tauri-apps/api/core';
 import * as commands from "../../lib/ipc/commands";
 import type { ClipboardDeleteResult, ClipboardClearResult } from "../../lib/ipc/commands";
+import { getFrontmostApplication } from "../../lib/ipc/applicationCommands";
+import { clipboardStripHtml, clipboardStripRtf } from "../../lib/ipc/clipboardCommands";
 import { v4 as uuidv4 } from "uuid";
 import { diagnosticsService } from "../diagnostics/diagnosticsService.svelte";
 import { clipboardHistoryStore } from "./stores/clipboardHistoryStore.svelte";
@@ -24,7 +25,6 @@ import {
   type ClipboardHistoryItem,
   type IClipboardHistoryService,
   type ClipboardSourceApp,
-  type FrontmostApplication,
 } from "asyar-sdk/contracts";
 
 /**
@@ -151,19 +151,14 @@ export class ClipboardHistoryService implements IClipboardHistoryService {
   }
 
   private async captureSourceApp(): Promise<ClipboardSourceApp | undefined> {
-    try {
-      const frontmost = await invoke<FrontmostApplication>('get_frontmost_application');
-      if (!frontmost?.name) return undefined;
-      return {
-        name: frontmost.name,
-        bundleId: frontmost.bundleId ?? undefined,
-        path: frontmost.path ?? undefined,
-        windowTitle: frontmost.windowTitle ?? undefined,
-      };
-    } catch (error) {
-      logService.debug(`Failed to capture source app: ${error}`);
-      return undefined;
-    }
+    const frontmost = await getFrontmostApplication();
+    if (!frontmost?.name) return undefined;
+    return {
+      name: frontmost.name,
+      bundleId: frontmost.bundleId ?? undefined,
+      path: frontmost.path ?? undefined,
+      windowTitle: frontmost.windowTitle ?? undefined,
+    };
   }
 
   /**
@@ -485,7 +480,7 @@ export class ClipboardHistoryService implements IClipboardHistoryService {
    * exposed to Tier 2 extensions via the SDK's `clipboard` proxy.
    */
   public async stripHtml(html: string): Promise<string> {
-    return invoke<string>('clipboard_strip_html', { content: html });
+    return clipboardStripHtml(html);
   }
 
   /**
@@ -494,7 +489,7 @@ export class ClipboardHistoryService implements IClipboardHistoryService {
    * Tier 2 extensions via the SDK's `clipboard` proxy.
    */
   public async stripRtf(rtf: string): Promise<string> {
-    return invoke<string>('clipboard_strip_rtf', { content: rtf });
+    return clipboardStripRtf(rtf);
   }
 
   /**

--- a/asyar-launcher/src/services/clipboard/stores/clipboardHistoryStore.svelte.ts
+++ b/asyar-launcher/src/services/clipboard/stores/clipboardHistoryStore.svelte.ts
@@ -1,5 +1,4 @@
 import { logService } from "../../log/logService";
-import { diagnosticsService } from "../../diagnostics/diagnosticsService.svelte";
 import type { ClipboardHistoryItem } from "asyar-sdk/contracts";
 import {
   clipboardListInitial,
@@ -22,16 +21,6 @@ export type ClipboardStoreChangeEvent =
   | { type: 'delete'; itemId: string };
 
 type ListItem = StoredClipboardListItem;
-
-function reportFailure(kind: string, err: unknown): void {
-  void diagnosticsService.report({
-    source: 'frontend',
-    kind,
-    severity: 'error',
-    retryable: false,
-    developerDetail: String(err),
-  });
-}
 
 export class ClipboardHistoryStoreClass {
   favorites = $state<ListItem[]>([]);
@@ -65,14 +54,11 @@ export class ClipboardHistoryStoreClass {
   }
 
   async loadInitial(limit = 100): Promise<void> {
-    try {
-      const page = await clipboardListInitial(limit);
-      this.favorites = page.favorites;
-      this.recent = page.recent;
-      this.nextOlderCursor = page.nextCursor;
-    } catch (err) {
-      reportFailure('clipboard/load-failed', err);
-    }
+    const page = await clipboardListInitial(limit);
+    if (page === null) return;
+    this.favorites = page.favorites;
+    this.recent = page.recent;
+    this.nextOlderCursor = page.nextCursor;
   }
 
   // Guards against concurrent loadOlder calls. Without this, fast scrolling
@@ -87,10 +73,9 @@ export class ClipboardHistoryStoreClass {
     try {
       const cursor = this.nextOlderCursor;
       const page = await clipboardListOlder(cursor, limit);
+      if (page === null) return;
       this.recent = [...this.recent, ...page.items];
       this.nextOlderCursor = page.nextCursor;
-    } catch (err) {
-      reportFailure('clipboard/load-older-failed', err);
     } finally {
       this.#loadingOlder = false;
     }
@@ -107,15 +92,12 @@ export class ClipboardHistoryStoreClass {
 
   async search(query: string, limit = 200): Promise<void> {
     const mySeq = ++this.#searchSeq;
-    try {
-      const res = await clipboardSearch(query, limit);
-      // Drop response if a newer search has been issued in the meantime.
-      if (mySeq !== this.#searchSeq) return;
-      this.searchResults = res.items;
-      this.indexState = res.indexState;
-    } catch (err) {
-      reportFailure('clipboard/search-failed', err);
-    }
+    const res = await clipboardSearch(query, limit);
+    if (res === null) return;
+    // Drop response if a newer search has been issued in the meantime.
+    if (mySeq !== this.#searchSeq) return;
+    this.searchResults = res.items;
+    this.indexState = res.indexState;
   }
 
   clearSearch(): void {
@@ -127,106 +109,87 @@ export class ClipboardHistoryStoreClass {
   }
 
   async fetchFullItem(id: string): Promise<StoredClipboardItem | null> {
-    try {
-      return await clipboardGetItem(id);
-    } catch (err) {
-      reportFailure('clipboard/get-item-failed', err);
-      return null;
-    }
+    return await clipboardGetItem(id);
   }
 
   async addHistoryItem(item: ClipboardHistoryItem): Promise<void> {
-    try {
-      const stored = item as unknown as StoredClipboardItem;
-      const res = await clipboardRecordCapture(stored);
-      if (res.evictedIds.length > 0) {
-        const evicted = new Set(res.evictedIds);
-        this.recent = this.recent.filter((i) => !evicted.has(i.id));
-        this.favorites = this.favorites.filter((i) => !evicted.has(i.id));
-      }
-      const newRow: ListItem = {
-        id: stored.id,
-        type: stored.type,
-        preview: stored.preview,
-        createdAt: stored.createdAt,
-        favorite: stored.favorite,
-        metadata: stored.metadata,
-        sourceApp: stored.sourceApp,
-        redactedKinds: stored.redactedKinds,
-      };
-      if (newRow.favorite) {
-        this.favorites = [newRow, ...this.favorites.filter((i) => i.id !== newRow.id)];
-      } else {
-        this.recent = [newRow, ...this.recent.filter((i) => i.id !== newRow.id)];
-      }
-      this.#notify({ type: 'upsert', itemId: stored.id });
-    } catch (err) {
-      reportFailure('clipboard/capture-failed', err);
+    const stored = item as unknown as StoredClipboardItem;
+    const res = await clipboardRecordCapture(stored);
+    if (res === null) return;
+    if (res.evictedIds.length > 0) {
+      const evicted = new Set(res.evictedIds);
+      this.recent = this.recent.filter((i) => !evicted.has(i.id));
+      this.favorites = this.favorites.filter((i) => !evicted.has(i.id));
     }
+    const newRow: ListItem = {
+      id: stored.id,
+      type: stored.type,
+      preview: stored.preview,
+      createdAt: stored.createdAt,
+      favorite: stored.favorite,
+      metadata: stored.metadata,
+      sourceApp: stored.sourceApp,
+      redactedKinds: stored.redactedKinds,
+    };
+    if (newRow.favorite) {
+      this.favorites = [newRow, ...this.favorites.filter((i) => i.id !== newRow.id)];
+    } else {
+      this.recent = [newRow, ...this.recent.filter((i) => i.id !== newRow.id)];
+    }
+    this.#notify({ type: 'upsert', itemId: stored.id });
   }
 
   async toggleFavorite(id: string): Promise<void> {
-    try {
-      const newFavorite = await clipboardToggleFavorite(id);
+    const newFavorite = await clipboardToggleFavorite(id);
+    if (newFavorite === null) return;
 
-      // Find the row anywhere in the loaded windows so we can move it.
-      const source =
-        this.recent.find((i) => i.id === id) ??
-        this.favorites.find((i) => i.id === id) ??
-        this.searchResults?.find((i) => i.id === id);
+    // Find the row anywhere in the loaded windows so we can move it.
+    const source =
+      this.recent.find((i) => i.id === id) ??
+      this.favorites.find((i) => i.id === id) ??
+      this.searchResults?.find((i) => i.id === id);
 
-      if (source) {
-        const updated = { ...source, favorite: newFavorite };
-        if (newFavorite) {
-          this.recent = this.recent.filter((i) => i.id !== id);
-          this.favorites = [updated, ...this.favorites.filter((i) => i.id !== id)];
-        } else {
-          this.favorites = this.favorites.filter((i) => i.id !== id);
-          this.recent = [updated, ...this.recent.filter((i) => i.id !== id)];
-        }
+    if (source) {
+      const updated = { ...source, favorite: newFavorite };
+      if (newFavorite) {
+        this.recent = this.recent.filter((i) => i.id !== id);
+        this.favorites = [updated, ...this.favorites.filter((i) => i.id !== id)];
+      } else {
+        this.favorites = this.favorites.filter((i) => i.id !== id);
+        this.recent = [updated, ...this.recent.filter((i) => i.id !== id)];
       }
-
-      if (this.searchResults) {
-        this.searchResults = this.searchResults.map((i) =>
-          i.id === id ? { ...i, favorite: newFavorite } : i
-        );
-      }
-      this.#notify({ type: 'upsert', itemId: id });
-    } catch (err) {
-      reportFailure('clipboard/favorite-failed', err);
     }
+
+    if (this.searchResults) {
+      this.searchResults = this.searchResults.map((i) =>
+        i.id === id ? { ...i, favorite: newFavorite } : i
+      );
+    }
+    this.#notify({ type: 'upsert', itemId: id });
   }
 
   async deleteHistoryItem(id: string): Promise<ClipboardDeleteResult> {
-    try {
-      const res = await clipboardDeleteItem(id);
-      this.favorites = this.favorites.filter((i) => i.id !== id);
-      this.recent = this.recent.filter((i) => i.id !== id);
-      if (this.searchResults) {
-        this.searchResults = this.searchResults.filter((i) => i.id !== id);
-      }
-      this.#notify({ type: 'delete', itemId: id });
-      return res;
-    } catch (err) {
-      reportFailure('clipboard/delete-failed', err);
-      return { imageContentPath: undefined };
+    const res = await clipboardDeleteItem(id);
+    if (res === null) return { imageContentPath: undefined };
+    this.favorites = this.favorites.filter((i) => i.id !== id);
+    this.recent = this.recent.filter((i) => i.id !== id);
+    if (this.searchResults) {
+      this.searchResults = this.searchResults.filter((i) => i.id !== id);
     }
+    this.#notify({ type: 'delete', itemId: id });
+    return res;
   }
 
   async clearHistory(): Promise<ClipboardClearResult> {
-    try {
-      const res = await clipboardClearNonFavorites();
-      const removed = new Set(res.removedIds);
-      this.recent = this.recent.filter((i) => !removed.has(i.id));
-      if (this.searchResults) {
-        this.searchResults = this.searchResults.filter((i) => !removed.has(i.id));
-      }
-      res.removedIds.forEach((rid) => this.#notify({ type: 'delete', itemId: rid }));
-      return res;
-    } catch (err) {
-      reportFailure('clipboard/clear-failed', err);
-      return { removedIds: [], removedImagePaths: [] };
+    const res = await clipboardClearNonFavorites();
+    if (res === null) return { removedIds: [], removedImagePaths: [] };
+    const removed = new Set(res.removedIds);
+    this.recent = this.recent.filter((i) => !removed.has(i.id));
+    if (this.searchResults) {
+      this.searchResults = this.searchResults.filter((i) => !removed.has(i.id));
     }
+    res.removedIds.forEach((rid) => this.#notify({ type: 'delete', itemId: rid }));
+    return res;
   }
 }
 

--- a/asyar-launcher/src/services/dev/inspectorStore.svelte.ts
+++ b/asyar-launcher/src/services/dev/inspectorStore.svelte.ts
@@ -9,11 +9,12 @@
 // runtime snapshot (per `extensionId:role` key), and — added in later
 // steps — state values, subscriptions, event/RPC/IPC ring buffers.
 
-import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { logService } from '../log/logService';
 import extensionManager from '../extension/extensionManager.svelte';
 import { developerSettingsService } from '../settings/developerSettingsService.svelte';
+import { getExtensionRuntimeSnapshot } from '../../lib/ipc/iframeLifecycleCommands';
+import { forceRemountWorker as forceRemountWorkerCommand, stateGetAll, stateGetSubscriptions } from '../../lib/ipc/devCommands';
 
 /** Runtime-aware dev check — returns true during development OR when the user
  *  has opted into developer mode in production. */
@@ -51,13 +52,6 @@ export interface SubscriptionSummary {
   role: ContextRoleWire;
   installedAt: number;
   listenerCount: number;
-}
-
-interface SnapshotRow {
-  extension_id: string;
-  role: ContextRoleWire;
-  state: string;
-  mailbox_len: number;
 }
 
 const RUNTIME_POLL_MS = 1000;
@@ -290,82 +284,72 @@ class InspectorStore {
 
   async refreshRuntimeSnapshot(): Promise<void> {
     if (!isDevActive()) return;
-    try {
-      const rows = await invoke<SnapshotRow[]>('get_extension_runtime_snapshot');
-      const next: Record<string, RuntimeEntry> = {};
-      const now = Date.now();
-      for (const row of rows) {
-        const key = keyOf(row.extension_id, row.role);
-        const prev = this.runtimeMap[key];
-        next[key] = {
-          extensionId: row.extension_id,
-          role: row.role,
-          state: coerceState(row.state),
-          mailboxLen: row.mailbox_len,
-          mountToken: prev?.mountToken,
-          strikes: prev?.strikes,
-          updatedAt: now,
-        };
-      }
-      this.runtimeMap = next;
-    } catch (err) {
-      logService.debug(`[dev-inspector] snapshot invoke failed: ${err}`);
+    const rows = await getExtensionRuntimeSnapshot();
+    if (rows === null) {
+      logService.debug('[dev-inspector] snapshot invoke failed');
+      return;
     }
+    const next: Record<string, RuntimeEntry> = {};
+    const now = Date.now();
+    for (const row of rows) {
+      const key = keyOf(row.extensionId, row.role as ContextRoleWire);
+      const prev = this.runtimeMap[key];
+      next[key] = {
+        extensionId: row.extensionId,
+        role: row.role as ContextRoleWire,
+        state: coerceState(row.state),
+        mailboxLen: row.mailboxLen,
+        mountToken: prev?.mountToken,
+        strikes: prev?.strikes,
+        updatedAt: now,
+      };
+    }
+    this.runtimeMap = next;
   }
 
   async forceRemountWorker(extensionId: string): Promise<void> {
     if (!isDevActive()) return;
-    try {
-      const manifest = extensionManager.getManifestById(extensionId) as
-        | { background?: { main?: string } }
-        | undefined;
-      const hasBackgroundMain = !!manifest?.background?.main;
-      await invoke('force_remount_worker', {
-        extensionId,
-        hasBackgroundMain,
-      });
-    } catch (err) {
-      logService.debug(`[dev-inspector] force_remount_worker failed: ${err}`);
-    }
+    const manifest = extensionManager.getManifestById(extensionId) as
+      | { background?: { main?: string } }
+      | undefined;
+    const hasBackgroundMain = !!manifest?.background?.main;
+    const ok = await forceRemountWorkerCommand(extensionId, hasBackgroundMain);
+    if (!ok) logService.debug('[dev-inspector] force_remount_worker failed');
   }
 
   async refreshState(extensionId: string): Promise<void> {
     if (!isDevActive()) return;
-    try {
-      const rows = await invoke<
-        Array<{ key: string; value: unknown; updatedAt: number }>
-      >('state_get_all', { extensionId });
-      this.stateByExt = {
-        ...this.stateByExt,
-        [extensionId]: rows.map((r) => ({
-          key: r.key,
-          value: r.value,
-          updatedAt: r.updatedAt,
-        })),
-      };
-    } catch (err) {
-      logService.debug(`[dev-inspector] state_get_all failed: ${err}`);
+    const rows = await stateGetAll(extensionId);
+    if (rows === null) {
+      logService.debug('[dev-inspector] state_get_all failed');
+      return;
     }
+    this.stateByExt = {
+      ...this.stateByExt,
+      [extensionId]: rows.map((r) => ({
+        key: r.key,
+        value: r.value,
+        updatedAt: r.updatedAt,
+      })),
+    };
   }
 
   async refreshSubscriptions(extensionId: string): Promise<void> {
     if (!isDevActive()) return;
-    try {
-      const rows = await invoke<
-        Array<{ key: string; role: ContextRoleWire; installedAt: number; listenerCount: number }>
-      >('state_get_subscriptions', { extensionId });
-      this.subsByExt = {
-        ...this.subsByExt,
-        [extensionId]: rows.map((r) => ({
-          key: r.key,
-          role: r.role,
-          installedAt: r.installedAt,
-          listenerCount: r.listenerCount,
-        })),
-      };
-    } catch (err) {
-      logService.debug(`[dev-inspector] state_get_subscriptions failed: ${err}`);
+    const rows = await stateGetSubscriptions(extensionId);
+    if (rows === null) {
+      logService.debug('[dev-inspector] state_get_subscriptions failed');
+      return;
     }
+    this.subsByExt = {
+      ...this.subsByExt,
+      [extensionId]: rows.map((r) => ({
+        key: r.key,
+        role: r.role as ContextRoleWire,
+        installedAt: r.installedAt,
+        listenerCount: r.listenerCount,
+      })),
+    };
   }
 
   /**

--- a/asyar-launcher/src/services/dev/inspectorStore.test.ts
+++ b/asyar-launcher/src/services/dev/inspectorStore.test.ts
@@ -66,8 +66,8 @@ describe('inspectorStore', () => {
   it('refreshRuntimeSnapshot merges Rust rows into runtimeMap', async () => {
     const { invoke } = await import('@tauri-apps/api/core');
     vi.mocked(invoke).mockResolvedValueOnce([
-      { extension_id: 'ext.a', role: 'worker', state: 'ready', mailbox_len: 2 },
-      { extension_id: 'ext.a', role: 'view', state: 'dormant', mailbox_len: 0 },
+      { extensionId: 'ext.a', role: 'worker', state: 'ready', mailboxLen: 2 },
+      { extensionId: 'ext.a', role: 'view', state: 'dormant', mailboxLen: 0 },
     ]);
     const { inspectorStore } = await import('./inspectorStore.svelte');
     await inspectorStore.refreshRuntimeSnapshot();
@@ -86,7 +86,7 @@ describe('inspectorStore', () => {
   it('refreshRuntimeSnapshot coerces unknown state strings to "unknown"', async () => {
     const { invoke } = await import('@tauri-apps/api/core');
     vi.mocked(invoke).mockResolvedValueOnce([
-      { extension_id: 'ext.a', role: 'worker', state: 'weird-state', mailbox_len: 0 },
+      { extensionId: 'ext.a', role: 'worker', state: 'weird-state', mailboxLen: 0 },
     ]);
     const { inspectorStore } = await import('./inspectorStore.svelte');
     await inspectorStore.refreshRuntimeSnapshot();
@@ -96,8 +96,8 @@ describe('inspectorStore', () => {
   it('entriesForSelected filters to the selected extension id', async () => {
     const { invoke } = await import('@tauri-apps/api/core');
     vi.mocked(invoke).mockResolvedValueOnce([
-      { extension_id: 'ext.a', role: 'worker', state: 'ready', mailbox_len: 0 },
-      { extension_id: 'ext.b', role: 'worker', state: 'ready', mailbox_len: 0 },
+      { extensionId: 'ext.a', role: 'worker', state: 'ready', mailboxLen: 0 },
+      { extensionId: 'ext.b', role: 'worker', state: 'ready', mailboxLen: 0 },
     ]);
     const { inspectorStore } = await import('./inspectorStore.svelte');
     await inspectorStore.refreshRuntimeSnapshot();
@@ -113,10 +113,10 @@ describe('inspectorStore', () => {
     const { invoke } = await import('@tauri-apps/api/core');
     vi.mocked(invoke)
       .mockResolvedValueOnce([
-        { extension_id: 'ext.a', role: 'worker', state: 'mounting', mailbox_len: 0 },
+        { extensionId: 'ext.a', role: 'worker', state: 'mounting', mailboxLen: 0 },
       ])
       .mockResolvedValueOnce([
-        { extension_id: 'ext.a', role: 'worker', state: 'ready', mailbox_len: 0 },
+        { extensionId: 'ext.a', role: 'worker', state: 'ready', mailboxLen: 0 },
       ]);
     const { inspectorStore } = await import('./inspectorStore.svelte');
     await inspectorStore.refreshRuntimeSnapshot();

--- a/asyar-launcher/src/services/extension/ExtensionIpcRouter.ts
+++ b/asyar-launcher/src/services/extension/ExtensionIpcRouter.ts
@@ -1,6 +1,14 @@
 import { logService } from "../log/logService";
-import { invoke } from '@tauri-apps/api/core';
 import * as commands from "../../lib/ipc/commands";
+import {
+  contributeShortcodes,
+  revokeShortcodes,
+  listLearnedShortcodes,
+  promoteLearnedToSnippet,
+  forgetLearnedShortcode,
+  clearLearnedShortcodes,
+  setInlineEmojiFallbackEnabled,
+} from '../../lib/ipc/shortcodeCommands';
 import { extensionIframeManager } from './extensionIframeManager.svelte';
 import { extensionPreferencesService } from './extensionPreferencesService.svelte';
 import { streamDispatcher } from './streamDispatcher.svelte';
@@ -25,6 +33,15 @@ const EXTENSION_INVOKE_DISPATCH: Record<string, (args: any) => Promise<any>> = {
 
 // Kept for documentation — actual dispatch uses EXTENSION_INVOKE_DISPATCH
 export const ALLOWED_EXTENSION_INVOKE_COMMANDS = new Set(Object.keys(EXTENSION_INVOKE_DISPATCH));
+
+/**
+ * Every EXTENSION_INVOKE_DISPATCH handler delegates to an invokeSafe-backed
+ * commands.ts wrapper, which returns null on failure instead of throwing —
+ * and has already reported a diagnostic for that failure itself. Thrown to
+ * signal "build the asyar:response error envelope" without making the outer
+ * catch block in setup() report a second, redundant diagnostic.
+ */
+class HandledDispatchError extends Error {}
 
 /**
  * Services whose first parameter is the calling extension's ID.
@@ -147,10 +164,12 @@ export class ExtensionIpcRouter {
         }
 
         // --- Permission Gate ---
+        // Fail closed: a failed permission check (null) must deny, not crash
+        // or silently let the call through.
         const permissionResult = await commands.checkExtensionPermission(extensionId, type);
-        if (!permissionResult.allowed) {
-          logService.warn(`[PermissionGate] BLOCKED: ${permissionResult.reason}`);
-          const permError = `Permission denied: "${permissionResult.requiredPermission}" is required but not declared in manifest.json`;
+        if (!permissionResult?.allowed) {
+          logService.warn(`[PermissionGate] BLOCKED: ${permissionResult?.reason ?? 'permission check failed'}`);
+          const permError = `Permission denied: "${permissionResult?.requiredPermission ?? type}" is required but not declared in manifest.json`;
           (event.source as Window)?.postMessage({
             type: 'asyar:response',
             messageId,
@@ -256,14 +275,16 @@ export class ExtensionIpcRouter {
           messageId,
           error: catchError
         }, '*');
-        void diagnosticsService.report({
-          source: 'extension',
-          kind: classifyProxyError(type, catchError),
-          severity: 'warning',
-          retryable: false,
-          context: { method: type, error: catchError },
-          extensionId: extensionId ?? 'unknown',
-        });
+        if (!(error instanceof HandledDispatchError)) {
+          void diagnosticsService.report({
+            source: 'extension',
+            kind: classifyProxyError(type, catchError),
+            severity: 'warning',
+            retryable: false,
+            context: { method: type, error: catchError },
+            extensionId: extensionId ?? 'unknown',
+          });
+        }
       }
     });
 
@@ -329,39 +350,53 @@ export class ExtensionIpcRouter {
         }
         throw new Error(`Command "${payload?.cmd}" is not available to extensions`);
       }
-      return await handler(payload?.args);
+      const result = await handler(payload?.args);
+      if (result === null) {
+        throw new HandledDispatchError(`Command "${payload?.cmd}" failed`);
+      }
+      return result;
     }
 
     if (type === 'asyar:api:snippets:registerShortcodes') {
       const { map } = payload as { map: Record<string, string> };
-      return invoke('contribute_shortcodes', { extensionId, map });
+      const ok = await contributeShortcodes(extensionId, map);
+      if (!ok) throw new HandledDispatchError('contribute_shortcodes failed');
+      return undefined;
     }
 
     if (type === 'asyar:api:snippets:unregisterShortcodes') {
-      return invoke('revoke_shortcodes', { extensionId });
+      const ok = await revokeShortcodes(extensionId);
+      if (!ok) throw new HandledDispatchError('revoke_shortcodes failed');
+      return undefined;
     }
 
     if (type === 'asyar:api:snippets:listLearnedShortcodes') {
-      return invoke('list_learned_shortcodes');
+      const result = await listLearnedShortcodes();
+      if (result === null) throw new HandledDispatchError('list_learned_shortcodes failed');
+      return result;
     }
 
     if (type === 'asyar:api:snippets:promoteLearnedShortcode') {
       const { shortcode } = payload as { shortcode: string };
-      return invoke('promote_learned_to_snippet', { shortcode });
+      const ok = await promoteLearnedToSnippet(shortcode);
+      if (!ok) throw new HandledDispatchError('promote_learned_to_snippet failed');
+      return undefined;
     }
 
     if (type === 'asyar:api:snippets:forgetLearnedShortcode') {
       const { shortcode } = payload as { shortcode: string };
-      return invoke('forget_learned_shortcode', { shortcode });
+      return forgetLearnedShortcode(shortcode);
     }
 
     if (type === 'asyar:api:snippets:clearLearnedShortcodes') {
-      return invoke('clear_learned_shortcodes');
+      return clearLearnedShortcodes();
     }
 
     if (type === 'asyar:api:snippets:setInlineFallbackEnabled') {
       const { enabled } = payload as { enabled: boolean };
-      return invoke('set_inline_emoji_fallback_enabled', { enabled });
+      const ok = await setInlineEmojiFallbackEnabled(enabled);
+      if (!ok) throw new HandledDispatchError('set_inline_emoji_fallback_enabled failed');
+      return undefined;
     }
 
     const ns = serviceName as Namespace;

--- a/asyar-launcher/src/services/extension/ExtensionLoader.ts
+++ b/asyar-launcher/src/services/extension/ExtensionLoader.ts
@@ -256,7 +256,7 @@ export class ExtensionLoader {
                   if (onboardingDecl?.command && !isOnboardingCmd) {
                     let onboarded = false;
                     try {
-                      onboarded = await commands.isExtensionOnboarded(manifest.id);
+                      onboarded = (await commands.isExtensionOnboarded(manifest.id)) ?? false;
                     } catch (err) {
                       logService.warn(
                         `[onboarding] is_extension_onboarded failed for ${manifest.id}: ${err}`,
@@ -432,6 +432,9 @@ export class ExtensionLoader {
         }));
 
       const result = await commands.syncCommandIndex(inputs);
+      if (result === null) {
+        throw new Error('sync_command_index failed');
+      }
       logService.info(
         `Command Sync complete: ${result.added} added, ${result.removed} removed, ${result.total} total commands indexed.`
       );

--- a/asyar-launcher/src/services/extension/buildServiceRegistry.ts
+++ b/asyar-launcher/src/services/extension/buildServiceRegistry.ts
@@ -1,5 +1,5 @@
-import { invoke } from '@tauri-apps/api/core';
 import { defineServiceRegistry, type ServiceRegistry } from './defineServiceRegistry';
+import { rankItemsCommand } from '../../lib/ipc/searchAccessoryCommands';
 import type { IExtensionManager, RankableItem } from 'asyar-sdk/contracts';
 import type { ExtendedManifest } from '../../types/ExtendedManifest';
 import { logService } from '../log/logService';
@@ -38,6 +38,7 @@ import { diagnosticsService } from '../diagnostics/diagnosticsService.svelte';
 import type { Diagnostic } from 'asyar-sdk/contracts';
 import { runService } from '../run/runService.svelte';
 import { agentsToolsRegisterTier2, agentsToolsList } from '../../lib/ipc/commands';
+import { completeExtensionOnboarding } from '../../lib/ipc/extensionLifecycleCommands';
 import type { ManifestTool } from 'asyar-sdk/contracts';
 
 export function buildServiceRegistry(deps: {
@@ -101,8 +102,8 @@ export function buildServiceRegistry(deps: {
     // Same Rust ranker the launcher's own search uses (search_engine::ranker).
     // Stateless passthrough — no permission required (see permissions.rs).
     search: {
-      rank: (query: string, items: RankableItem[]) =>
-        invoke<string[]>('rank_items', { query, items }),
+      rank: async (query: string, items: RankableItem[]) =>
+        (await rankItemsCommand(query, items)) ?? [],
     },
     feedback: feedbackService,
     // The IPC dispatcher spreads payload values via `Object.values` (see
@@ -159,8 +160,7 @@ export function buildServiceRegistry(deps: {
     },
     onboarding: {
       complete: async (extensionId: string) => {
-        const { invoke } = await import('@tauri-apps/api/core');
-        await invoke('complete_extension_onboarding', { extensionId });
+        await completeExtensionOnboarding(extensionId);
       },
     },
   });

--- a/asyar-launcher/src/services/extension/extensionDispatcher.svelte.ts
+++ b/asyar-launcher/src/services/extension/extensionDispatcher.svelte.ts
@@ -35,12 +35,10 @@ export async function dispatch(req: DispatchRequest): Promise<void> {
     `[dispatcher] → ${req.extensionId}/${req.kind} source=${req.source} payload=${JSON.stringify(req.payload)}`,
   );
   const role: 'view' | 'worker' = req.commandMode === 'background' ? 'worker' : 'view';
-  let outcome;
-  try {
-    outcome = await dispatchToExtension(req.extensionId, message, role);
-  } catch (err) {
+  const outcome = await dispatchToExtension(req.extensionId, message, role);
+  if (outcome === null) {
     logService.error(
-      `[dispatcher] ${req.extensionId}/${req.kind} (${req.source}) dispatch failed: ${err}`,
+      `[dispatcher] ${req.extensionId}/${req.kind} (${req.source}) dispatch failed`,
     );
     return;
   }

--- a/asyar-launcher/src/services/extension/extensionPreferencesService.svelte.ts
+++ b/asyar-launcher/src/services/extension/extensionPreferencesService.svelte.ts
@@ -52,7 +52,7 @@ class ExtensionPreferencesService {
       return { extension: {}, commands: {} };
     }
 
-    const stored = await extensionPreferencesGetAll(extensionId);
+    const stored = (await extensionPreferencesGetAll(extensionId)) ?? [];
 
     const bundle: PreferenceBundle = {
       extension: {},

--- a/asyar-launcher/src/services/extension/extensionReadinessListener.ts
+++ b/asyar-launcher/src/services/extension/extensionReadinessListener.ts
@@ -1,7 +1,4 @@
-import {
-  iframeReadyAck,
-  type IpcPendingMessage,
-} from '../../lib/ipc/iframeLifecycleCommands';
+import { iframeReadyAck } from '../../lib/ipc/iframeLifecycleCommands';
 import { post } from './extensionDelivery';
 import { logService } from '../log/logService';
 import { extensionPendingState } from './extensionPendingState.svelte';
@@ -56,11 +53,9 @@ class ExtensionReadinessListener {
     }
     const role: 'view' | 'worker' = payloadRole;
 
-    let drained: IpcPendingMessage[];
-    try {
-      drained = await iframeReadyAck(extensionId, mountToken, role);
-    } catch (err) {
-      logService.warn(`[readiness] ack failed for ${extensionId}: ${err}`);
+    const drained = await iframeReadyAck(extensionId, mountToken, role);
+    if (drained === null) {
+      logService.warn(`[readiness] ack failed for ${extensionId}`);
       return;
     }
     for (const m of drained) post(iframe, m);

--- a/asyar-launcher/src/services/extension/extensionStateManager.svelte.ts
+++ b/asyar-launcher/src/services/extension/extensionStateManager.svelte.ts
@@ -61,7 +61,7 @@ export class ExtensionStateManager {
       const records = await discoverExtensions();
       const allExtensionsData: Array<any> = [];
 
-      for (const record of records) {
+      for (const record of records ?? []) {
         const manifest = record.manifest;
         allExtensionsData.push({
           title: manifest.name,

--- a/asyar-launcher/src/services/extension/extensionUpdateService.svelte.ts
+++ b/asyar-launcher/src/services/extension/extensionUpdateService.svelte.ts
@@ -73,6 +73,10 @@ class ExtensionUpdateService {
 
     try {
       const results = await commands.updateAllExtensions(safeUpdates);
+      if (results === null) {
+        logService.error('Auto-update batch call failed');
+        return;
+      }
 
       // Remove successful updates from the available list
       const failedIds = new Set(
@@ -112,6 +116,10 @@ class ExtensionUpdateService {
     this.isChecking = true;
     try {
       const updates = await commands.checkExtensionUpdates(envService.storeApiBaseUrl);
+      if (updates === null) {
+        logService.error('Failed to check for extension updates');
+        return [];
+      }
       this.availableUpdates = updates;
       this.lastCheckTime = Date.now();
       if (updates.length > 0) {
@@ -160,6 +168,10 @@ class ExtensionUpdateService {
     this.isUpdatingAll = true;
     try {
       const results = await commands.updateAllExtensions([...this.availableUpdates]);
+      if (results === null) {
+        logService.error('Failed to update all extensions');
+        return;
+      }
       const failedIds = new Set(
         results.filter(([, r]) => r.Err).map(([id]) => id)
       );

--- a/asyar-launcher/src/services/extensionLoaderService.ts
+++ b/asyar-launcher/src/services/extensionLoaderService.ts
@@ -32,7 +32,10 @@ class ExtensionLoaderService {
     try {
       // 1. Get all extension records from Rust (manifests + state + paths)
       const records = await discoverExtensionsIpc();
-      
+      if (records === null) {
+        return extensionsMap;
+      }
+
       // 2. Load built-in JS modules (Vite globs — must stay in TypeScript)
       const builtInFeatureModules = import.meta.glob(['/src/built-in-features/*/index.ts', '/src/built-in-features/*/index.svelte.ts'], { eager: true }) as Record<string, any>;
 
@@ -107,7 +110,10 @@ class ExtensionLoaderService {
     try {
       // 1. Get extension from Rust (checks all sources)
       const record = await getExtensionIpc(extensionId);
-      
+      if (record === null) {
+        return null;
+      }
+
       if (!record.enabled) {
         logService.warn(`Attempted to load disabled extension: ${extensionId}`);
         return null;

--- a/asyar-launcher/src/services/extensionState/extensionStateService.ts
+++ b/asyar-launcher/src/services/extensionState/extensionStateService.ts
@@ -1,4 +1,12 @@
-import { invoke } from '@tauri-apps/api/core';
+import {
+  stateGet,
+  stateSet,
+  stateSubscribe,
+  stateUnsubscribe,
+  stateRpcRequest,
+  stateRpcAbort,
+  stateRpcReply,
+} from '../../lib/ipc/extensionLifecycleCommands';
 import type { IpcDispatchOutcome } from '../../lib/ipc/iframeLifecycleCommands';
 import { post } from '../extension/extensionDelivery';
 import { logService } from '../log/logService';
@@ -21,8 +29,8 @@ import { logService } from '../log/logService';
  * harness listens for; the drain happens on the ready-ack path. This
  * helper centralises both sides of that contract.
  */
-function handleWorkerRpcOutcome(extensionId: string, outcome: IpcDispatchOutcome): void {
-  if (outcome.kind !== 'readyDeliverNow') return;
+function handleWorkerRpcOutcome(extensionId: string, outcome: IpcDispatchOutcome | null): void {
+  if (outcome === null || outcome.kind !== 'readyDeliverNow') return;
   const iframe = document.querySelector(
     `iframe[data-extension-id="${extensionId}"][data-role="worker"]`,
   ) as HTMLIFrameElement | null;
@@ -37,15 +45,15 @@ function handleWorkerRpcOutcome(extensionId: string, outcome: IpcDispatchOutcome
 
 export const extensionStateService = {
   async get(extensionId: string, key: string): Promise<unknown> {
-    return invoke<unknown>('state_get', { extensionId, key });
+    return stateGet(extensionId, key);
   },
 
   async set(extensionId: string, key: string, value: unknown): Promise<void> {
-    return invoke<void>('state_set', { extensionId, key, value });
+    return stateSet(extensionId, key, value);
   },
 
-  async subscribe(extensionId: string, key: string, role: 'worker' | 'view'): Promise<number> {
-    return invoke<number>('state_subscribe', { extensionId, key, role });
+  async subscribe(extensionId: string, key: string, role: 'worker' | 'view'): Promise<number | null> {
+    return stateSubscribe(extensionId, key, role);
   },
 
   async unsubscribe(extensionId: string, subscriptionId: number): Promise<void> {
@@ -55,7 +63,7 @@ export const extensionStateService = {
     // state methods (matches the `storage`/`cache` convention even where
     // Rust would be fine with less).
     void extensionId;
-    return invoke<void>('state_unsubscribe', { subscriptionId });
+    return stateUnsubscribe(subscriptionId);
   },
 
   async rpcRequest(
@@ -64,20 +72,12 @@ export const extensionStateService = {
     correlationId: string,
     payload: unknown,
   ): Promise<void> {
-    const outcome = await invoke<IpcDispatchOutcome>('state_rpc_request', {
-      extensionId,
-      id,
-      correlationId,
-      payload,
-    });
+    const outcome = await stateRpcRequest(extensionId, id, correlationId, payload);
     handleWorkerRpcOutcome(extensionId, outcome);
   },
 
   async rpcAbort(extensionId: string, correlationId: string): Promise<void> {
-    const outcome = await invoke<IpcDispatchOutcome>('state_rpc_abort', {
-      extensionId,
-      correlationId,
-    });
+    const outcome = await stateRpcAbort(extensionId, correlationId);
     handleWorkerRpcOutcome(extensionId, outcome);
   },
 
@@ -87,11 +87,6 @@ export const extensionStateService = {
     result?: unknown,
     error?: string,
   ): Promise<void> {
-    return invoke<void>('state_rpc_reply', {
-      extensionId,
-      correlationId,
-      result: result ?? null,
-      error: error ?? null,
-    });
+    return stateRpcReply(extensionId, correlationId, result, error);
   },
 };

--- a/asyar-launcher/src/services/feedback/feedbackSubmitService.test.ts
+++ b/asyar-launcher/src/services/feedback/feedbackSubmitService.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('../log/logService', () => ({
+  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
 
 import { feedbackSubmitService } from './feedbackSubmitService';
 import { invoke } from '@tauri-apps/api/core';
@@ -28,8 +31,8 @@ describe('feedbackSubmitService', () => {
     });
   });
 
-  it('propagates invoke rejection', async () => {
+  it('throws when submit_feedback fails', async () => {
     vi.mocked(invoke).mockRejectedValueOnce(new Error('network'));
-    await expect(feedbackSubmitService.submit({ type: 'crash' })).rejects.toThrow('network');
+    await expect(feedbackSubmitService.submit({ type: 'crash' })).rejects.toThrow();
   });
 });

--- a/asyar-launcher/src/services/feedback/feedbackSubmitService.ts
+++ b/asyar-launcher/src/services/feedback/feedbackSubmitService.ts
@@ -3,7 +3,8 @@ import { submitFeedback, type FeedbackInput } from '../../lib/ipc/commands';
 export class FeedbackSubmitService {
   /** Thin dispatch — all assembly and network logic lives in Rust. */
   async submit(input: FeedbackInput): Promise<void> {
-    return submitFeedback(input);
+    const ok = await submitFeedback(input);
+    if (!ok) throw new Error('submit_feedback failed');
   }
 }
 

--- a/asyar-launcher/src/services/fsWatcher/fsWatcherService.ts
+++ b/asyar-launcher/src/services/fsWatcher/fsWatcherService.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { fsWatchCreate, fsWatchDispose } from '../../lib/ipc/systemCommands';
 
 /**
  * Host-side thin wrapper over the Rust `fs_watch_*` Tauri commands.
@@ -27,21 +27,14 @@ export class FsWatcherService implements IFsWatcherIpc {
     paths: string[],
     opts?: { recursive?: boolean; debounceMs?: number } | null,
   ): Promise<string> {
-    return invoke<string>('fs_watch_create', {
-      extensionId,
-      paths,
-      opts: opts ?? null,
-    });
+    return (await fsWatchCreate(extensionId, paths, opts ?? null)) ?? '';
   }
 
   async dispose(
     extensionId: string | null,
     handleId: string,
   ): Promise<void> {
-    return invoke<void>('fs_watch_dispose', {
-      extensionId,
-      handleId,
-    });
+    await fsWatchDispose(extensionId, handleId);
   }
 }
 

--- a/asyar-launcher/src/services/network/networkService.ts
+++ b/asyar-launcher/src/services/network/networkService.ts
@@ -6,7 +6,7 @@ export class NetworkService {
     url: string,
     options?: { method?: string; headers?: Record<string, string>; body?: string; timeout?: number },
   ): Promise<{ status: number; statusText: string; headers: Record<string, string>; body: string; ok: boolean }> {
-    return fetchUrl({
+    const result = await fetchUrl({
       url,
       method: options?.method ?? 'GET',
       headers: options?.headers,
@@ -14,6 +14,8 @@ export class NetworkService {
       timeoutMs: options?.timeout ?? 20000,
       callerExtensionId,
     })
+    if (result === null) throw new Error('fetch_url failed')
+    return result
   }
 }
 

--- a/asyar-launcher/src/services/notification/notificationService.ts
+++ b/asyar-launcher/src/services/notification/notificationService.ts
@@ -31,12 +31,14 @@ export class NotificationService {
 
   async send(callerExtensionId: string, options: NotificationOptions): Promise<string> {
     const normalisedActions = options.actions?.map(normaliseAction);
-    return commands.sendNotification({
+    const result = await commands.sendNotification({
       title: options.title,
       body: options.body,
       actions: normalisedActions,
       callerExtensionId,
     });
+    if (result === null) throw new Error('send_notification failed');
+    return result;
   }
 
   async dismiss(callerExtensionId: string, notificationId: string): Promise<void> {

--- a/asyar-launcher/src/services/oauth/extensionOAuthService.svelte.ts
+++ b/asyar-launcher/src/services/oauth/extensionOAuthService.svelte.ts
@@ -49,9 +49,13 @@ export class ExtensionOAuthService {
     }
 
     // 2. Start PKCE flow in Rust (generates verifier/challenge + state, builds URL)
-    const { state, authUrl } = await commands.oauthStartFlow(
+    const startResult = await commands.oauthStartFlow(
       extensionId, providerId, clientId, authorizationUrl, tokenUrl, scopes, flowId,
     );
+    if (!startResult) {
+      throw new Error('Failed to start OAuth flow');
+    }
+    const { state, authUrl } = startResult;
 
     // 3. Track state → {extensionId, flowId} for error routing in _handleCallback
     this._pendingFlows.set(state, { extensionId, flowId });
@@ -89,6 +93,9 @@ export class ExtensionOAuthService {
 
     try {
       const result = await commands.oauthExchangeCode(state, code);
+      if (result === null) {
+        throw new Error('oauth_exchange_code failed');
+      }
       // Clean up local tracking now that exchange succeeded
       this._pendingFlows.delete(state);
       this._postToIframe(result.extensionId, result.flowId, { token: result.token });

--- a/asyar-launcher/src/services/onboarding/onboardingService.svelte.test.ts
+++ b/asyar-launcher/src/services/onboarding/onboardingService.svelte.test.ts
@@ -30,7 +30,7 @@ describe('onboardingService', () => {
   it('loads initial state from Rust', async () => {
     vi.mocked(invoke).mockResolvedValueOnce(initialState)
     await onboardingService.load()
-    expect(invoke).toHaveBeenCalledWith('get_onboarding_state')
+    expect(invoke).toHaveBeenCalledWith('get_onboarding_state', undefined)
     expect(onboardingService.state).toEqual(initialState)
   })
 
@@ -44,7 +44,7 @@ describe('onboardingService', () => {
       })
     await onboardingService.load()
     await onboardingService.advance()
-    expect(invoke).toHaveBeenCalledWith('advance_onboarding_step')
+    expect(invoke).toHaveBeenCalledWith('advance_onboarding_step', undefined)
     expect(onboardingService.state?.current).toBe('grantAccessibility')
   })
 
@@ -54,20 +54,20 @@ describe('onboardingService', () => {
       .mockResolvedValueOnce({ ...initialState, current: 'grantAccessibility', position: 2 })
     await onboardingService.load()
     await onboardingService.goBack()
-    expect(invoke).toHaveBeenCalledWith('go_back_onboarding_step')
+    expect(invoke).toHaveBeenCalledWith('go_back_onboarding_step', undefined)
     expect(onboardingService.state?.current).toBe('grantAccessibility')
   })
 
   it('completes calls Rust', async () => {
     vi.mocked(invoke).mockResolvedValueOnce(undefined)
     await onboardingService.complete()
-    expect(invoke).toHaveBeenCalledWith('complete_onboarding')
+    expect(invoke).toHaveBeenCalledWith('complete_onboarding', undefined)
   })
 
   it('dismiss calls Rust', async () => {
     vi.mocked(invoke).mockResolvedValueOnce(undefined)
     await onboardingService.dismiss()
-    expect(invoke).toHaveBeenCalledWith('dismiss_onboarding')
+    expect(invoke).toHaveBeenCalledWith('dismiss_onboarding', undefined)
   })
 
   it('reports diagnostics on load failure', async () => {
@@ -114,14 +114,14 @@ describe('AI onboarding', () => {
   it('loadAi sets aiCompleted from the IPC reply', async () => {
     mockInvoke.mockResolvedValueOnce(true)
     await onboardingService.loadAi()
-    expect(mockInvoke).toHaveBeenCalledWith('is_ai_onboarding_completed')
+    expect(mockInvoke).toHaveBeenCalledWith('is_ai_onboarding_completed', undefined)
     expect(onboardingService.aiCompleted).toBe(true)
   })
 
   it('completeAi calls the IPC and flips aiCompleted to true', async () => {
     mockInvoke.mockResolvedValueOnce(undefined)
     await onboardingService.completeAi()
-    expect(mockInvoke).toHaveBeenCalledWith('complete_ai_onboarding')
+    expect(mockInvoke).toHaveBeenCalledWith('complete_ai_onboarding', undefined)
     expect(onboardingService.aiCompleted).toBe(true)
   })
 })

--- a/asyar-launcher/src/services/onboarding/onboardingService.svelte.ts
+++ b/asyar-launcher/src/services/onboarding/onboardingService.svelte.ts
@@ -83,7 +83,11 @@ class OnboardingServiceClass {
 
   async loadAi(): Promise<void> {
     try {
-      this.aiCompleted = await isAiOnboardingCompleted()
+      const result = await isAiOnboardingCompleted()
+      if (result === null) {
+        throw new Error('is_ai_onboarding_completed failed')
+      }
+      this.aiCompleted = result
     } catch (err) {
       logService.warn(`Failed to load AI onboarding state: ${err}`)
       diagnosticsService.report({

--- a/asyar-launcher/src/services/power/powerService.ts
+++ b/asyar-launcher/src/services/power/powerService.ts
@@ -1,5 +1,5 @@
-import { invoke } from '@tauri-apps/api/core';
 import type { KeepAwakeOptions, ActiveInhibitor } from 'asyar-sdk/contracts';
+import { powerKeepAwake, powerRelease, powerList } from '../../lib/ipc/systemCommands';
 
 /**
  * Host-side thin wrapper over the Rust `power_*` Tauri commands.
@@ -10,12 +10,12 @@ import type { KeepAwakeOptions, ActiveInhibitor } from 'asyar-sdk/contracts';
  */
 export const powerService = {
   async keepAwake(extensionId: string | null, options: KeepAwakeOptions): Promise<string> {
-    return invoke<string>('power_keep_awake', { extensionId, options });
+    return (await powerKeepAwake(extensionId, options)) ?? '';
   },
   async release(extensionId: string | null, token: string): Promise<void> {
-    return invoke<void>('power_release', { extensionId, token });
+    await powerRelease(extensionId, token);
   },
   async list(extensionId: string | null): Promise<ActiveInhibitor[]> {
-    return invoke<ActiveInhibitor[]>('power_list', { extensionId });
+    return (await powerList(extensionId)) ?? [];
   },
 };

--- a/asyar-launcher/src/services/process/processService.ts
+++ b/asyar-launcher/src/services/process/processService.ts
@@ -1,5 +1,5 @@
-import { invoke } from '@tauri-apps/api/core';
 import type { AppGroup, KillResult, ProcessSortBy } from 'asyar-sdk/contracts';
+import { processListCommand, processKillCommand } from '../../lib/ipc/systemCommands';
 
 /**
  * Host-side thin wrapper over the Rust `process_*` Tauri commands.
@@ -19,7 +19,7 @@ export const processService = {
     query: string | undefined,
     sortBy: ProcessSortBy,
   ): Promise<AppGroup[]> {
-    return invoke<AppGroup[]>('process_list', { extensionId, query, sortBy });
+    return (await processListCommand(extensionId, query, sortBy)) ?? [];
   },
   async kill(
     extensionId: string | null,
@@ -27,6 +27,11 @@ export const processService = {
     force: boolean,
     confirmedProtected: boolean,
   ): Promise<KillResult> {
-    return invoke<KillResult>('process_kill', { extensionId, pids, force, confirmedProtected });
+    const result = await processKillCommand(extensionId, pids, force, confirmedProtected);
+    if (result !== null) return result;
+    return {
+      killed: [],
+      failed: pids.map((pid) => ({ pid, error: 'process_kill failed' })),
+    };
   },
 };

--- a/asyar-launcher/src/services/profile/providers/clipboardSyncProvider.ts
+++ b/asyar-launcher/src/services/profile/providers/clipboardSyncProvider.ts
@@ -26,6 +26,9 @@ async function collectAllItems(): Promise<StoredClipboardItem[]> {
   let cursor: ClipboardCursor | undefined;
   do {
     const page = await clipboardExportForSync(cursor, SYNC_PAGE_SIZE);
+    if (page === null) {
+      throw new Error('clipboard_export_for_sync failed');
+    }
     all.push(...page.items);
     cursor = page.nextCursor;
   } while (cursor);
@@ -83,6 +86,9 @@ export class ClipboardSyncProvider implements ISyncProvider {
 
   async preview(incoming: SyncProviderData): Promise<ImportPreview> {
     const summary = await clipboardCount();
+    if (summary === null) {
+      throw new Error('clipboard_count failed');
+    }
     const localCount = summary.total;
     const incomingItems = incoming.data as ClipboardHistoryItem[];
     const incomingIds = new Set(incomingItems.map((i) => i.id));
@@ -127,6 +133,9 @@ export class ClipboardSyncProvider implements ISyncProvider {
 
   async getLocalSummary(): Promise<DataSummary> {
     const c = await clipboardCount();
+    if (c === null) {
+      throw new Error('clipboard_count failed');
+    }
     return { itemCount: c.total, label: `${c.total} clipboard item(s)` };
   }
 

--- a/asyar-launcher/src/services/profile/providers/extensionPreferencesSyncProvider.ts
+++ b/asyar-launcher/src/services/profile/providers/extensionPreferencesSyncProvider.ts
@@ -39,6 +39,7 @@ export class ExtensionPreferencesSyncProvider implements ISyncProvider {
 
   async exportForSync(): Promise<SyncProviderData> {
     const data = await extensionPreferencesExportAll();
+    if (data === null) throw new Error('extension_preferences_export_all failed');
     return {
       providerId: this.id,
       version: 1,
@@ -50,6 +51,7 @@ export class ExtensionPreferencesSyncProvider implements ISyncProvider {
   async preview(incoming: SyncProviderData): Promise<ImportPreview> {
     const incomingData = (incoming.data as PreferencesExport) ?? { rows: [] };
     const local = await extensionPreferencesExportAll();
+    if (local === null) throw new Error('extension_preferences_export_all failed');
     // Build a set of "extensionId|commandId|key" keys for quick lookup.
     const key = (r: { extensionId: string; commandId: string | null; key: string }) =>
       `${r.extensionId}|${r.commandId ?? ''}|${r.key}`;
@@ -90,6 +92,7 @@ export class ExtensionPreferencesSyncProvider implements ISyncProvider {
       payload,
       strategy as 'replace' | 'merge'
     );
+    if (result === null) throw new Error('extension_preferences_import_all failed');
     return {
       success: true,
       itemsAdded: result.itemsAdded,
@@ -101,6 +104,7 @@ export class ExtensionPreferencesSyncProvider implements ISyncProvider {
 
   async getLocalSummary(): Promise<DataSummary> {
     const data = await extensionPreferencesExportAll();
+    if (data === null) throw new Error('extension_preferences_export_all failed');
     const count = data.rows.length;
     return {
       itemCount: count,
@@ -115,6 +119,7 @@ export class ExtensionPreferencesSyncProvider implements ISyncProvider {
 
   async exportItems(): Promise<SyncItem[]> {
     const data = await extensionPreferencesExportAll();
+    if (data === null) throw new Error('extension_preferences_export_all failed');
     return [{ id: this.id, categoryId: this.id, content: data }];
   }
 

--- a/asyar-launcher/src/services/search/SearchService.test.ts
+++ b/asyar-launcher/src/services/search/SearchService.test.ts
@@ -171,7 +171,7 @@ describe('resetIndex', () => {
   it('calls invoke("reset_search_index")', async () => {
     vi.mocked(invoke).mockResolvedValueOnce(undefined)
     await getInstance().resetIndex()
-    expect(invoke).toHaveBeenCalledWith('reset_search_index')
+    expect(invoke).toHaveBeenCalledWith('reset_search_index', undefined)
   })
 
   it('swallows errors without throwing', async () => {

--- a/asyar-launcher/src/services/search/SearchService.ts
+++ b/asyar-launcher/src/services/search/SearchService.ts
@@ -6,23 +6,22 @@ import * as commands from "../../lib/ipc/commands";
 
 export class SearchService {
   async performSearch(query: string): Promise<SearchResult[]> {
-    try {
-      const results = (await commands.searchItems(query)) as SearchResult[];
-      logService.debug(`Search results for "${query}": ${results}`);
-      return results;
-    } catch (error) {
-      logService.error(`Search failed: ${error}`);
+    const results = await commands.searchItems(query, { silent: true });
+    if (results === null) {
+      logService.error('Search failed');
       void diagnosticsService.report({
         source: 'frontend',
         kind: 'search/perform-failed',
         severity: 'error',
         retryable: false,
-        developerDetail: String(error),
+        developerDetail: 'search_items failed',
         // Length only — the raw query may contain pasted secrets.
         context: { queryLength: String(query.length) },
       });
       return [];
     }
+    logService.debug(`Search results for "${query}": ${results}`);
+    return results as SearchResult[];
   }
 
   /**
@@ -30,19 +29,18 @@ export class SearchService {
    * Handles updates automatically (Rust's index_item deletes then adds).
    */
   async indexItem(item: SearchableItem): Promise<void> {
-    try {
-      logService.debug(
-        `Indexing item category: ${item.category}, name: ${item.name}`
-      );
-      await commands.indexItem(item);
-    } catch (error) {
-      logService.error(`Failed indexing item ${item.name}: ${error}`);
+    logService.debug(
+      `Indexing item category: ${item.category}, name: ${item.name}`
+    );
+    const ok = await commands.indexItem(item);
+    if (!ok) {
+      logService.error(`Failed indexing item ${item.name}`);
       void diagnosticsService.report({
         source: 'frontend',
         kind: 'search/index-failed',
         severity: 'warning',
         retryable: false,
-        developerDetail: String(error),
+        developerDetail: 'index_item failed',
         context: { name: item.name, category: String(item.category) },
       });
     }
@@ -102,6 +100,12 @@ export class SearchService {
         }...`
       );
       const allIndexedIds = await commands.getIndexedObjectIds();
+      if (allIndexedIds === null) {
+        // commands.getIndexedObjectIds already reports its own diagnostic
+        // via invokeSafe (also relied on by ExtensionIpcRouter's dispatch
+        // table) — don't report a second time here.
+        return new Set<string>();
+      }
       if (!prefix) {
         return allIndexedIds;
       }
@@ -130,20 +134,20 @@ export class SearchService {
   }
 
   async resetIndex(): Promise<void> {
-    try {
-      logService.info("Requesting search index reset...");
-      await commands.resetSearchIndex();
-      logService.info("Search index reset successful.");
-    } catch (error) {
-      logService.error(`Failed to reset search index: ${error}`);
+    logService.info("Requesting search index reset...");
+    const ok = await commands.resetSearchIndex();
+    if (!ok) {
+      logService.error('Failed to reset search index');
       void diagnosticsService.report({
         source: 'frontend',
         kind: 'search/reset-failed',
         severity: 'error',
         retryable: false,
-        developerDetail: String(error),
+        developerDetail: 'reset_search_index failed',
       });
+      return;
     }
+    logService.info("Search index reset successful.");
   }
 
   /**
@@ -151,16 +155,15 @@ export class SearchService {
    * Currently used before hiding the launcher to persist usage counts.
    */
   async saveIndex(): Promise<void> {
-    try {
-      await commands.saveSearchIndex();
-    } catch (error) {
-      logService.error(`Failed to save search index: ${error}`);
+    const ok = await commands.saveSearchIndex();
+    if (!ok) {
+      logService.error('Failed to save search index');
       void diagnosticsService.report({
         source: 'frontend',
         kind: 'search/save-failed',
         severity: 'warning',
         retryable: false,
-        developerDetail: String(error),
+        developerDetail: 'save_search_index failed',
       });
     }
   }

--- a/asyar-launcher/src/services/search/commandArgumentsService.svelte.ts
+++ b/asyar-launcher/src/services/search/commandArgumentsService.svelte.ts
@@ -143,7 +143,7 @@ export class CommandArgumentsService {
     const persistenceKey = persistenceCommandKey(meta.commandId, meta.isDynamic === true);
     let persisted: Record<string, string> = {};
     try {
-      persisted = await commandArgDefaultsGet(meta.extensionId, persistenceKey);
+      persisted = (await commandArgDefaultsGet(meta.extensionId, persistenceKey)) ?? {};
     } catch (err) {
       logService.warn(
         `[CommandArgumentsService] Failed to load defaults for ${meta.extensionId}/${persistenceKey}: ${err}`

--- a/asyar-launcher/src/services/search/searchBarAccessoryService.svelte.ts
+++ b/asyar-launcher/src/services/search/searchBarAccessoryService.svelte.ts
@@ -1,8 +1,7 @@
-import { invoke } from '@tauri-apps/api/core';
 import type { SearchBarAccessoryDropdownOption } from 'asyar-sdk/contracts';
 import { logService } from '../log/logService';
-import { diagnosticsService } from '../diagnostics/diagnosticsService.svelte';
 import { extensionIframeManager } from '../extension/extensionIframeManager.svelte';
+import { searchbarAccessoryGet, searchbarAccessorySet } from '../../lib/ipc/searchAccessoryCommands';
 
 export interface SearchBarAccessoryActiveState {
   extensionId: string;
@@ -55,24 +54,11 @@ export class SearchBarAccessoryServiceClass {
       throw new Error('searchBarAccessory.declare: options cannot be empty');
     }
 
-    let persisted: string | null = null;
-    try {
-      const got = await invoke<string | null>('searchbar_accessory_get', {
-        extensionId: input.extensionId,
-        commandId: input.commandId,
-      });
-      persisted = got ?? null;
-    } catch (e) {
-      logService.warn(`[SearchBarAccessory] get failed: ${e}`);
-      void diagnosticsService.report({
-        source: 'frontend',
-        kind: 'searchBarAccessory/persistence-read-failed',
-        severity: 'warning',
-        retryable: false,
-        developerDetail: String(e),
-        context: { extensionId: input.extensionId, commandId: input.commandId },
-      });
-    }
+    // Failure and "nothing persisted yet" both resolve to null here — both
+    // fall through to the same default-seed logic below, matching the
+    // original try/catch's behavior (a real failure still gets diagnosed
+    // via invokeSafe's default reporting; the seed selection just proceeds).
+    const persisted = await searchbarAccessoryGet(input.extensionId, input.commandId);
 
     const optionValues = new Set(input.options.map((o) => o.value));
     let seed: string;
@@ -114,11 +100,8 @@ export class SearchBarAccessoryServiceClass {
       );
     }
 
-    await invoke('searchbar_accessory_set', {
-      extensionId,
-      commandId,
-      value,
-    });
+    const persisted = await searchbarAccessorySet(extensionId, commandId, value);
+    if (!persisted) return;
     this.active = { ...this.active, value };
     this.broadcast(extensionId, commandId, value, /*toView=*/ true);
   }
@@ -176,11 +159,8 @@ export class SearchBarAccessoryServiceClass {
     // consistent and prevents `declare()` after a failed `set` from
     // silently rolling back the user's intent.
     if (valueChanged) {
-      await invoke('searchbar_accessory_set', {
-        extensionId,
-        commandId,
-        value: nextValue,
-      });
+      const persisted = await searchbarAccessorySet(extensionId, commandId, nextValue);
+      if (!persisted) return;
     }
 
     this.active = {

--- a/asyar-launcher/src/services/search/searchBarAccessoryService.test.ts
+++ b/asyar-launcher/src/services/search/searchBarAccessoryService.test.ts
@@ -55,7 +55,7 @@ describe('searchBarAccessoryService', () => {
       default: 'all',
     });
     expect(diagnosticsService.report).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: 'searchBarAccessory/persistence-read-failed', severity: 'warning' }),
+      expect.objectContaining({ severity: 'error' }),
     );
     expect(searchBarAccessoryService.active?.value).toBe('all');
   });

--- a/asyar-launcher/src/services/search/searchOrchestrator.svelte.ts
+++ b/asyar-launcher/src/services/search/searchOrchestrator.svelte.ts
@@ -97,6 +97,9 @@ class SearchOrchestratorClass {
       });
 
       const resp = await commands.mergedSearch(query, externalResults, 10);
+      if (resp === null) {
+        throw new Error('merged_search failed');
+      }
       const combinedResults: SearchResult[] = resp.results as SearchResult[];
       const aliasMatch = resp.aliasMatch ?? null;
 

--- a/asyar-launcher/src/services/selection/selectionService.test.ts
+++ b/asyar-launcher/src/services/selection/selectionService.test.ts
@@ -26,7 +26,7 @@ describe('SelectionService', () => {
 
       const result = await service.getSelectedText();
 
-      expect(invoke).toHaveBeenCalledWith('get_selected_text');
+      expect(invoke).toHaveBeenCalledWith('get_selected_text', undefined);
       expect(result).toBe('Hello World');
     });
 
@@ -47,7 +47,7 @@ describe('SelectionService', () => {
 
       const result = await service.getSelectedFinderItems();
 
-      expect(invoke).toHaveBeenCalledWith('get_selected_finder_items');
+      expect(invoke).toHaveBeenCalledWith('get_selected_finder_items', undefined);
       expect(result).toEqual(items);
     });
 

--- a/asyar-launcher/src/services/selection/selectionService.ts
+++ b/asyar-launcher/src/services/selection/selectionService.ts
@@ -1,6 +1,6 @@
-import { invoke } from '@tauri-apps/api/core';
 import type { ISelectionService, SelectionError, SelectionErrorCode } from 'asyar-sdk/contracts';
 import { logService } from '../log/logService';
+import { getSelectedTextRaw, getSelectedFinderItemsRaw } from '../../lib/ipc/selectionCommands';
 
 export class SelectionService implements ISelectionService {
   /**
@@ -10,7 +10,7 @@ export class SelectionService implements ISelectionService {
   async getSelectedText(): Promise<string | null> {
     try {
       console.log('[SelectionService] Invoking get_selected_text...');
-      const result = await invoke<string | null>('get_selected_text');
+      const result = await getSelectedTextRaw();
       return result;
     } catch (error: any) {
       this.throwSelectionError(error);
@@ -25,7 +25,7 @@ export class SelectionService implements ISelectionService {
   async getSelectedFinderItems(): Promise<string[]> {
     try {
       console.log('[SelectionService] Invoking get_selected_finder_items...');
-      const result = await invoke<string[]>('get_selected_finder_items');
+      const result = await getSelectedFinderItemsRaw();
       return result || [];
     } catch (error: any) {
       this.throwSelectionError(error);

--- a/asyar-launcher/src/services/shell/shellConsentService.svelte.ts
+++ b/asyar-launcher/src/services/shell/shellConsentService.svelte.ts
@@ -1,5 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
-import { logService } from '../log/logService';
+import { shellCheckTrust, shellGrantTrust } from '../../lib/ipc/shellCommands';
 
 interface ConsentRequest {
   extensionId: string;
@@ -23,17 +22,10 @@ class ShellConsentService {
     program: string,
     resolvedPath: string
   ): Promise<boolean> {
-    // 1. Check trust store first (hot path, no UI)
-    try {
-      const isTrusted = await invoke<boolean>('shell_check_trust', {
-        extensionId,
-        binaryPath: resolvedPath
-      });
-      
-      if (isTrusted) return true;
-    } catch (e) {
-      logService.error('[ShellConsentService] Failed to check trust:', e);
-    }
+    // 1. Check trust store first (hot path, no UI). A failed check falls
+    // through to the dialog below rather than blocking the request.
+    const isTrusted = await shellCheckTrust(extensionId, resolvedPath);
+    if (isTrusted) return true;
 
     // 2. Deduplicate concurrent requests for the same (extension, binary) pair
     const key = `${extensionId}:${resolvedPath}`;
@@ -65,13 +57,8 @@ class ShellConsentService {
     if (!this.activeRequest) return;
     
     const { extensionId, resolvedPath, resolve } = this.activeRequest;
-    try {
-      await invoke('shell_grant_trust', { extensionId, binaryPath: resolvedPath });
-      resolve(true);
-    } catch (e) {
-      logService.error('[ShellConsentService] Failed to grant trust:', e);
-      resolve(false);
-    }
+    const ok = await shellGrantTrust(extensionId, resolvedPath);
+    resolve(ok);
   }
 
   /**

--- a/asyar-launcher/src/services/shell/shellService.svelte.ts
+++ b/asyar-launcher/src/services/shell/shellService.svelte.ts
@@ -1,10 +1,16 @@
-import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { streamDispatcher } from '../extension/streamDispatcher.svelte';
 import { shellConsentService } from './shellConsentService.svelte';
 import { logService } from '../log/logService';
 import { runService, type LocalRunHandle } from '../run/runService.svelte';
-import { invokeSafe } from '../../lib/ipc/invokeSafe';
+import {
+  shellResolvePath,
+  shellKill,
+  shellSpawn,
+  shellList,
+  shellAttach,
+  type ShellDescriptor,
+} from '../../lib/ipc/shellCommands';
 
 interface ShellChunkPayload {
   spawnId: string;
@@ -22,13 +28,7 @@ interface ShellErrorPayload {
   message: string;
 }
 
-export interface ShellDescriptor {
-  spawnId: string;
-  program: string;
-  args: string[];
-  pid: number;
-  startedAt: number;
-}
+export type { ShellDescriptor };
 
 class ShellService {
   // Installed once so spawn() and attach() share a single chunk/done/error
@@ -80,7 +80,10 @@ class ShellService {
      */
     label?: string,
   ): Promise<{ streaming: true }> {
-    const resolvedPath = await invoke<string>('shell_resolve_path', { program });
+    const resolvedPath = await shellResolvePath(program);
+    if (resolvedPath === null) {
+      throw { code: 'PATH_RESOLUTION_FAILED', message: `Failed to resolve path for ${program}` };
+    }
 
     const allowed = await shellConsentService.requestConsent(extensionId, program, resolvedPath);
     if (!allowed) {
@@ -91,9 +94,7 @@ class ShellService {
 
     const handle = streamDispatcher.create(extensionId, spawnId, originRole);
     handle.onAbort(() => {
-      invoke('shell_kill', { spawnId }).catch((err) => {
-        logService.error(`[ShellService] Failed to kill process on abort: ${err}`);
-      });
+      void shellKill(spawnId);
     });
 
     const resolvedLabel =
@@ -114,7 +115,7 @@ class ShellService {
 
     if (runHandle) {
       unsubscribeCancel = runHandle.onCancel(() => {
-        void invokeSafe('shell_kill', { spawnId });
+        void shellKill(spawnId);
       });
     }
 
@@ -146,25 +147,14 @@ class ShellService {
       unsubscribeCancel?.();
     });
 
-    invoke('shell_spawn', {
-      extensionId,
-      spawnId,
-      program: resolvedPath,
-      args,
-    }).catch((err) => {
-      const message =
-        err instanceof Error
-          ? err.message
-          : typeof err === 'string'
-            ? err
-            : err && typeof err === 'object' && 'message' in err
-              ? String((err as { message: unknown }).message)
-              : JSON.stringify(err);
+    void shellSpawn(extensionId, spawnId, resolvedPath, args).then((ok) => {
+      if (ok) return;
+      const message = `Failed to spawn ${resolvedPath}`;
       streamDispatcher.forward(spawnId, 'error', {
         error: { code: 'SPAWN_FAILED', message },
       });
       // The asyar:shell:error Tauri event is only emitted by the Rust runtime
-      // for runs that actually started; a synchronous shell_spawn rejection
+      // for runs that actually started; a synchronous shell_spawn failure
       // (consent miss, missing binary, etc.) bypasses that path. Fail the
       // runHandle directly here so the Run transitions out of "running" and
       // tear down the per-spawn listeners we registered above.
@@ -179,7 +169,7 @@ class ShellService {
   }
 
   async list(extensionId: string): Promise<ShellDescriptor[]> {
-    return invoke<ShellDescriptor[]>('shell_list', { extensionId });
+    return (await shellList(extensionId)) ?? [];
   }
 
   async attach(
@@ -195,13 +185,15 @@ class ShellService {
     if (!streamDispatcher.has(spawnId)) {
       const handle = streamDispatcher.create(extensionId, spawnId, originRole);
       handle.onAbort(() => {
-        invoke('shell_kill', { spawnId }).catch((err) => {
-          logService.error(`[ShellService] Failed to kill process on abort: ${err}`);
-        });
+        void shellKill(spawnId);
       });
     }
 
-    return invoke<ShellDescriptor>('shell_attach', { extensionId, spawnId });
+    const descriptor = await shellAttach(extensionId, spawnId);
+    if (descriptor === null) {
+      throw { code: 'ATTACH_FAILED', message: `Failed to attach to spawn ${spawnId}` };
+    }
+    return descriptor;
   }
 }
 

--- a/asyar-launcher/src/services/statusBar/statusBarService.svelte.ts
+++ b/asyar-launcher/src/services/statusBar/statusBarService.svelte.ts
@@ -1,22 +1,13 @@
-import { invoke } from '@tauri-apps/api/core';
 import { logService } from '../log/logService';
+import {
+  trayRegisterItem,
+  trayUpdateItem,
+  trayUnregisterItem,
+  trayRemoveAllForExtension,
+  type StatusBarItem,
+} from '../../lib/ipc/statusBarCommands';
 
-/**
- * Launcher-side image of the SDK's `IStatusBarItem` plus the
- * `extensionId` the proxy injects before IPC. Mirrors the Rust
- * `StatusBarItem` so we can forward verbatim to the tray manager.
- */
-export interface StatusBarItem {
-  id: string;
-  extensionId: string;
-  icon?: string;
-  iconPath?: string;
-  text: string;
-  checked?: boolean;
-  submenu?: StatusBarItem[];
-  enabled?: boolean;
-  separator?: boolean;
-}
+export type { StatusBarItem };
 
 /**
  * Thin dispatcher between the extension's IPC call and the Rust tray
@@ -34,7 +25,8 @@ class StatusBarServiceClass {
     logService.debug(
       `[StatusBar] registerItem ext='${item.extensionId}' id='${item.id}'`,
     );
-    await invoke('tray_register_item', { item });
+    const ok = await trayRegisterItem(item);
+    if (!ok) throw new Error('tray_register_item failed');
   }
 
   async updateItem(
@@ -52,15 +44,18 @@ class StatusBarServiceClass {
       ...updates,
     };
     logService.debug(`[StatusBar] updateItem ext='${extensionId}' id='${id}'`);
-    await invoke('tray_update_item', { item });
+    const ok = await trayUpdateItem(item);
+    if (!ok) throw new Error('tray_update_item failed');
   }
 
   async unregisterItem(extensionId: string, id: string): Promise<void> {
-    await invoke('tray_unregister_item', { extensionId, id });
+    const ok = await trayUnregisterItem(extensionId, id);
+    if (!ok) throw new Error('tray_unregister_item failed');
   }
 
   async clearItemsForExtension(extensionId: string): Promise<void> {
-    await invoke('tray_remove_all_for_extension', { extensionId });
+    const ok = await trayRemoveAllForExtension(extensionId);
+    if (!ok) throw new Error('tray_remove_all_for_extension failed');
   }
 }
 

--- a/asyar-launcher/src/services/statusBar/statusBarService.test.ts
+++ b/asyar-launcher/src/services/statusBar/statusBarService.test.ts
@@ -50,7 +50,7 @@ describe('registerItem', () => {
 
   it('rejects the caller when the Rust command fails', async () => {
     vi.mocked(invoke).mockRejectedValueOnce(new Error('validation: top-level must provide icon'))
-    await expect(statusBarService.registerItem(topItem())).rejects.toThrow(/validation/)
+    await expect(statusBarService.registerItem(topItem())).rejects.toThrow(/tray_register_item/)
   })
 })
 

--- a/asyar-launcher/src/services/storage/extensionCacheService.ts
+++ b/asyar-launcher/src/services/storage/extensionCacheService.ts
@@ -23,14 +23,18 @@ export const extensionCacheService = {
     value: string,
     expiresAt?: number,
   ): Promise<void> {
-    return extCacheSet(extensionId, key, value, expiresAt);
+    await extCacheSet(extensionId, key, value, expiresAt);
   },
 
   async delete(extensionId: string, key: string): Promise<boolean> {
-    return extCacheDelete(extensionId, key);
+    const result = await extCacheDelete(extensionId, key);
+    if (result === null) throw new Error('ext_cache_delete failed');
+    return result;
   },
 
   async clear(extensionId: string): Promise<number> {
-    return extCacheClear(extensionId);
+    const result = await extCacheClear(extensionId);
+    if (result === null) throw new Error('ext_cache_clear failed');
+    return result;
   },
 };

--- a/asyar-launcher/src/services/storage/extensionStorageService.ts
+++ b/asyar-launcher/src/services/storage/extensionStorageService.ts
@@ -18,15 +18,18 @@ export const extensionStorageService = {
   },
 
   async set(extensionId: string, key: string, value: string): Promise<void> {
-    return extKvSet(extensionId, key, value);
+    await extKvSet(extensionId, key, value);
   },
 
   async delete(extensionId: string, key: string): Promise<boolean> {
-    return extKvDelete(extensionId, key);
+    const result = await extKvDelete(extensionId, key);
+    if (result === null) throw new Error('ext_kv_delete failed');
+    return result;
   },
 
   async getAll(extensionId: string): Promise<Record<string, string>> {
     const entries = await extKvGetAll(extensionId);
+    if (entries === null) throw new Error('ext_kv_get_all failed');
     const result: Record<string, string> = {};
     for (const entry of entries) {
       result[entry.key] = entry.value;
@@ -35,6 +38,8 @@ export const extensionStorageService = {
   },
 
   async clear(extensionId: string): Promise<number> {
-    return extKvClear(extensionId);
+    const result = await extKvClear(extensionId);
+    if (result === null) throw new Error('ext_kv_clear failed');
+    return result;
   },
 };

--- a/asyar-launcher/src/services/sync/syncEncryptionService.svelte.ts
+++ b/asyar-launcher/src/services/sync/syncEncryptionService.svelte.ts
@@ -49,6 +49,9 @@ export class SyncEncryptionService implements ISyncEncryptionService {
 
   async refreshStatus(): Promise<void> {
     const s = await syncE2eeGetStatus();
+    if (s === null) {
+      throw new Error('sync_e2ee_get_status failed');
+    }
     this.enabled = s.enabled;
     this.locked = s.locked;
     this.keyVersion = s.keyVersion;
@@ -66,11 +69,9 @@ export class SyncEncryptionService implements ISyncEncryptionService {
   // move that classification down here rather than fragmenting it across
   // dialog components.
   async enrol(passphrase: string): Promise<string> {
-    try {
-      const result = await syncE2eeEnrol(passphrase);
-      await this.refreshStatus();
-      return result.recoveryPhrase;
-    } catch (err) {
+    const result = await syncE2eeEnrol(passphrase);
+    if (result === null) {
+      const err = new Error('sync_e2ee_enrol failed');
       logService.warn(`e2ee enrol failed: ${String(err)}`);
       await diagnosticsService.report({
         source: 'frontend',
@@ -81,13 +82,14 @@ export class SyncEncryptionService implements ISyncEncryptionService {
       });
       throw err;
     }
+    await this.refreshStatus();
+    return result.recoveryPhrase;
   }
 
   async unlock(passphrase: string): Promise<void> {
-    try {
-      await syncE2eeUnlock(passphrase);
-      await this.refreshStatus();
-    } catch (err) {
+    const ok = await syncE2eeUnlock(passphrase);
+    if (!ok) {
+      const err = new Error('Incorrect passphrase or unlock failed');
       logService.warn(`e2ee unlock failed: ${String(err)}`);
       await diagnosticsService.report({
         source: 'frontend',
@@ -98,10 +100,14 @@ export class SyncEncryptionService implements ISyncEncryptionService {
       });
       throw err;
     }
+    await this.refreshStatus();
   }
 
   async rotate(oldPassphrase: string, newPassphrase: string): Promise<void> {
-    await syncE2eeRotate(oldPassphrase, newPassphrase);
+    const ok = await syncE2eeRotate(oldPassphrase, newPassphrase);
+    if (!ok) {
+      throw new Error('sync_e2ee_rotate failed');
+    }
     await this.refreshStatus();
   }
 
@@ -110,17 +116,27 @@ export class SyncEncryptionService implements ISyncEncryptionService {
     newPassphrase: string,
     verifyWithPayload?: string,
   ): Promise<void> {
-    await syncE2eeRecoverWithMnemonic(phrase, newPassphrase, verifyWithPayload);
+    const ok = await syncE2eeRecoverWithMnemonic(phrase, newPassphrase, verifyWithPayload);
+    if (!ok) {
+      throw new Error('sync_e2ee_recover_with_mnemonic failed');
+    }
     await this.refreshStatus();
   }
 
   async disable(): Promise<void> {
-    await syncE2eeDisable();
+    const ok = await syncE2eeDisable();
+    if (!ok) {
+      throw new Error('sync_e2ee_disable failed');
+    }
     await this.refreshStatus();
   }
 
   async showRecoveryPhrase(passphrase: string): Promise<string> {
-    return syncE2eeShowRecoveryPhrase(passphrase);
+    const result = await syncE2eeShowRecoveryPhrase(passphrase);
+    if (result === null) {
+      throw new Error('sync_e2ee_show_recovery_phrase failed');
+    }
+    return result;
   }
 }
 

--- a/asyar-launcher/src/services/sync/syncEncryptionService.test.ts
+++ b/asyar-launcher/src/services/sync/syncEncryptionService.test.ts
@@ -72,12 +72,10 @@ describe('syncEncryptionService', () => {
     });
 
     it('emits e2ee_enrollment_failed on backend error and re-throws', async () => {
-      vi.mocked(cmd.syncE2eeEnrol).mockRejectedValueOnce(
-        new Error('network timeout'),
-      );
+      vi.mocked(cmd.syncE2eeEnrol).mockResolvedValueOnce(null);
       await expect(
         syncEncryptionService.enrol('correct horse battery staple'),
-      ).rejects.toThrow('network timeout');
+      ).rejects.toThrow();
       expect(diagnosticsService.report).toHaveBeenCalledWith(
         expect.objectContaining({
           kind: 'e2ee_enrollment_failed',
@@ -90,7 +88,7 @@ describe('syncEncryptionService', () => {
 
   describe('unlock', () => {
     it('refreshes status on success', async () => {
-      vi.mocked(cmd.syncE2eeUnlock).mockResolvedValueOnce(undefined);
+      vi.mocked(cmd.syncE2eeUnlock).mockResolvedValueOnce(true);
       vi.mocked(cmd.syncE2eeGetStatus).mockResolvedValueOnce({
         enabled: true, locked: false, keyVersion: 1,
       });
@@ -99,9 +97,7 @@ describe('syncEncryptionService', () => {
     });
 
     it('emits e2ee_passphrase_required on incorrect passphrase and re-throws', async () => {
-      vi.mocked(cmd.syncE2eeUnlock).mockRejectedValueOnce(
-        new Error('incorrect passphrase'),
-      );
+      vi.mocked(cmd.syncE2eeUnlock).mockResolvedValueOnce(false);
       await expect(syncEncryptionService.unlock('wrong')).rejects.toThrow();
       expect(diagnosticsService.report).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -115,7 +111,7 @@ describe('syncEncryptionService', () => {
 
   describe('rotate', () => {
     it('refreshes status after success', async () => {
-      vi.mocked(cmd.syncE2eeRotate).mockResolvedValueOnce(undefined);
+      vi.mocked(cmd.syncE2eeRotate).mockResolvedValueOnce(true);
       vi.mocked(cmd.syncE2eeGetStatus).mockResolvedValueOnce({
         enabled: true, locked: false, keyVersion: 1,
       });
@@ -127,7 +123,7 @@ describe('syncEncryptionService', () => {
 
   describe('recoverWithMnemonic', () => {
     it('passes verifyWithPayload through and refreshes', async () => {
-      vi.mocked(cmd.syncE2eeRecoverWithMnemonic).mockResolvedValueOnce(undefined);
+      vi.mocked(cmd.syncE2eeRecoverWithMnemonic).mockResolvedValueOnce(true);
       vi.mocked(cmd.syncE2eeGetStatus).mockResolvedValueOnce({
         enabled: true, locked: false, keyVersion: 1,
       });
@@ -142,7 +138,7 @@ describe('syncEncryptionService', () => {
 
   describe('disable', () => {
     it('refreshes status to disabled', async () => {
-      vi.mocked(cmd.syncE2eeDisable).mockResolvedValueOnce(undefined);
+      vi.mocked(cmd.syncE2eeDisable).mockResolvedValueOnce(true);
       vi.mocked(cmd.syncE2eeGetStatus).mockResolvedValueOnce({
         enabled: false, locked: false, keyVersion: null,
       });

--- a/asyar-launcher/src/services/systemEvents/systemEventsService.ts
+++ b/asyar-launcher/src/services/systemEvents/systemEventsService.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { systemEventsSubscribe, systemEventsUnsubscribe } from '../../lib/ipc/systemCommands';
 
 /**
  * Host-side thin wrapper over the Rust `system_events_*` Tauri commands.
@@ -16,10 +16,10 @@ import { invoke } from '@tauri-apps/api/core';
  */
 export const systemEventsService = {
   async subscribe(extensionId: string | null, eventTypes: string[]): Promise<string> {
-    return invoke<string>('system_events_subscribe', { extensionId, eventTypes });
+    return (await systemEventsSubscribe(extensionId, eventTypes)) ?? '';
   },
 
   async unsubscribe(extensionId: string | null, subscriptionId: string): Promise<void> {
-    return invoke<void>('system_events_unsubscribe', { extensionId, subscriptionId });
+    await systemEventsUnsubscribe(extensionId, subscriptionId);
   },
 };

--- a/asyar-launcher/src/services/theme/themeService.ts
+++ b/asyar-launcher/src/services/theme/themeService.ts
@@ -25,7 +25,10 @@ function queueNativeBarResync(): void {
 export async function applyTheme(themeId: string): Promise<void> {
   removeTheme();
 
-  const definition: ThemeDefinition = await getThemeDefinition(themeId);
+  const definition = await getThemeDefinition(themeId);
+  if (definition === null) {
+    throw new Error(`get_theme_definition failed for ${themeId}`);
+  }
 
   const allowedSet = new Set(THEME_VAR_NAMES);
   for (const [name, value] of Object.entries(definition.variables)) {

--- a/asyar-launcher/src/services/timers/timerService.test.ts
+++ b/asyar-launcher/src/services/timers/timerService.test.ts
@@ -40,13 +40,13 @@ describe('timerService.schedule', () => {
     });
   });
 
-  it('propagates Rust validation errors unchanged', async () => {
+  it('resolves to an empty string when the Rust call fails (e.g. validation error)', async () => {
     vi.mocked(invoke).mockRejectedValueOnce(
       new Error('Validation error: fire_at (100) must be strictly greater than now (2000)'),
     );
     await expect(
       timerService.schedule('my.ext', { commandId: 'bell', fireAt: 100 }),
-    ).rejects.toThrow(/fire_at/);
+    ).resolves.toBe('');
   });
 });
 

--- a/asyar-launcher/src/services/timers/timerService.ts
+++ b/asyar-launcher/src/services/timers/timerService.ts
@@ -1,6 +1,6 @@
-import { invoke } from '@tauri-apps/api/core';
 import type { ScheduleTimerOptions, TimerDescriptor } from 'asyar-sdk/contracts';
 import { logService } from '../log/logService';
+import { timerSchedule, timerCancel, timerList } from '../../lib/ipc/systemCommands';
 
 /**
  * Host-side thin wrapper over the Rust `timer_*` Tauri commands.
@@ -14,15 +14,6 @@ import { logService } from '../log/logService';
  * (via the SDK proxy) and the launcher consumers see
  * `Record<string, unknown>`; only the SQLite row carries a string.
  */
-type RawTimerRow = {
-  timerId: string;
-  extensionId: string;
-  commandId: string;
-  argsJson: string;
-  fireAt: number;
-  createdAt: number;
-};
-
 function parseArgs(json: string): Record<string, unknown> {
   try {
     const parsed = JSON.parse(json);
@@ -38,20 +29,15 @@ function parseArgs(json: string): Record<string, unknown> {
 export const timerService = {
   async schedule(extensionId: string | null, opts: ScheduleTimerOptions): Promise<string> {
     const argsJson = JSON.stringify(opts.args ?? {});
-    return invoke<string>('timer_schedule', {
-      extensionId,
-      commandId: opts.commandId,
-      argsJson,
-      fireAt: opts.fireAt,
-    });
+    return (await timerSchedule(extensionId, opts.commandId, argsJson, opts.fireAt)) ?? '';
   },
 
   async cancel(extensionId: string | null, timerId: string): Promise<void> {
-    return invoke<void>('timer_cancel', { extensionId, timerId });
+    await timerCancel(extensionId, timerId);
   },
 
   async list(extensionId: string | null): Promise<TimerDescriptor[]> {
-    const raw = await invoke<RawTimerRow[]>('timer_list', { extensionId });
+    const raw = (await timerList(extensionId)) ?? [];
     return raw.map((r) => ({
       timerId: r.timerId,
       extensionId: r.extensionId,

--- a/asyar-launcher/src/services/update/appUpdateStore.svelte.ts
+++ b/asyar-launcher/src/services/update/appUpdateStore.svelte.ts
@@ -1,6 +1,6 @@
-import { invoke } from '@tauri-apps/api/core'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 import { logService } from '../log/logService'
+import { appUpdaterGetPending } from '../../lib/ipc/updateCommands'
 
 export type AppUpdatePhase = 'idle' | 'checking' | 'downloading' | 'ready' | 'error'
 
@@ -22,14 +22,10 @@ export async function initAppUpdateStore(): Promise<void> {
   initialized = true
 
   // Restore state from Rust in case a download completed before the webview loaded
-  try {
-    const pending = await invoke<{ version: string } | null>('app_updater_get_pending')
-    if (pending) {
-      appUpdateState.phase = 'ready'
-      appUpdateState.pendingVersion = pending.version
-    }
-  } catch (e) {
-    logService.warn(`appUpdateStore: failed to get pending update — ${e}`)
+  const pending = await appUpdaterGetPending()
+  if (pending) {
+    appUpdateState.phase = 'ready'
+    appUpdateState.pendingVersion = pending.version
   }
 
   // Listen to Rust-emitted events

--- a/asyar-launcher/src/services/update/updateService.test.ts
+++ b/asyar-launcher/src/services/update/updateService.test.ts
@@ -32,7 +32,7 @@ describe('runUpdateCheck', () => {
   it('returns error kind when invoke rejects', async () => {
     vi.mocked(invoke).mockRejectedValueOnce(new Error('network down'))
     const result = await runUpdateCheck()
-    expect(result).toEqual({ kind: 'error', message: 'network down' })
+    expect(result).toEqual({ kind: 'error', message: 'app_updater_check_now failed' })
     expect(logService.error).toHaveBeenCalled()
   })
 

--- a/asyar-launcher/src/services/update/updateService.ts
+++ b/asyar-launcher/src/services/update/updateService.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core'
+import { appUpdaterCheckNow } from '../../lib/ipc/updateCommands'
 import { logService } from '../log/logService'
 
 export type UpdateChannel = 'stable' | 'beta'
@@ -25,17 +25,18 @@ export async function runUpdateCheck(): Promise<UpdateResult> {
   logService.info('updateService: checking for updates')
 
   try {
-    const version = await invoke<string | null>('app_updater_check_now')
-    if (!version) {
+    const result = await appUpdaterCheckNow()
+    if (!result.ok) {
+      const message = 'app_updater_check_now failed'
+      logService.error(`updateService: check failed — ${message}`)
+      return { kind: 'error', message }
+    }
+    if (!result.value) {
       logService.info('updateService: no update available')
       return { kind: 'up-to-date' }
     }
-    logService.info(`updateService: update ${version} downloaded`)
-    return { kind: 'installed', version }
-  } catch (e) {
-    const message = e instanceof Error ? e.message : String(e)
-    logService.error(`updateService: check failed — ${message}`)
-    return { kind: 'error', message }
+    logService.info(`updateService: update ${result.value} downloaded`)
+    return { kind: 'installed', version: result.value }
   } finally {
     inFlight = false
   }

--- a/asyar-launcher/src/services/windowManagement/windowManagementService.ts
+++ b/asyar-launcher/src/services/windowManagement/windowManagementService.ts
@@ -11,7 +11,9 @@ export interface IWindowManagementService {
 
 export class WindowManagementService implements IWindowManagementService {
   async getWindowBounds(): Promise<WindowBounds> {
-    return commands.windowGetBounds()
+    const result = await commands.windowGetBounds()
+    if (result === null) throw new Error('window_management_get_bounds failed')
+    return result
   }
 
   async setWindowBounds(update: WindowBoundsUpdate): Promise<void> {
@@ -23,7 +25,9 @@ export class WindowManagementService implements IWindowManagementService {
   }
 
   async getMonitors(): Promise<WindowBounds[]> {
-    return commands.windowGetMonitors()
+    const result = await commands.windowGetMonitors()
+    if (result === null) throw new Error('window_management_get_monitors failed')
+    return result
   }
 
   async applyPreset(presetId: string): Promise<void> {

--- a/asyar-launcher/src/utils/shortcutManager.ts
+++ b/asyar-launcher/src/utils/shortcutManager.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { updateGlobalShortcut } from "../lib/ipc/commands";
 import { logService } from "../services/log/logService";
 import { settingsService } from "../services/settings/settingsService.svelte";
 
@@ -9,13 +9,17 @@ export async function updateShortcut(
   modifier: string,
   key: string
 ): Promise<boolean> {
+  logService.info(`Updating shortcut to: ${modifier}+${key}`);
+
+  // Update the system shortcut via Rust
+  const ok = await updateGlobalShortcut(modifier, key);
+  if (!ok) {
+    logService.error(`Failed to update shortcut: update_global_shortcut failed`);
+    return false;
+  }
+
+  // Save to settings store
   try {
-    logService.info(`Updating shortcut to: ${modifier}+${key}`);
-
-    // Update the system shortcut via Rust
-    await invoke("update_global_shortcut", { modifier, key });
-
-    // Save to settings store
     const success = await settingsService.updateSettings("shortcut", {
       modifier,
       key,
@@ -25,7 +29,8 @@ export async function updateShortcut(
       logService.info("Shortcut updated successfully");
       return true;
     } else {
-      throw new Error("Failed to save shortcut settings");
+      logService.error("Failed to update shortcut: Failed to save shortcut settings");
+      return false;
     }
   } catch (error) {
     logService.error(`Failed to update shortcut: ${error}`);


### PR DESCRIPTION
Replace every raw invoke() call in src/ with invokeSafe/invokeSafeVoid wrappers so command failures are diagnosed and reported instead of throwing uncaught or being silently swallowed. Adds invokeSafeOption for Option<T>-returning fail-closed checks and invokeRaw as an escape hatch for the few callers with load-bearing throw/retry contracts