### PR TITLE
fix(macos): disable press-and-hold accent popup for the app process

### DIFF
--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -728,6 +728,11 @@ fn register_builtin_tools(
 }
 
 fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+    // Must run before any window/webview is created — WKWebView reads this
+    // default when it builds its NSTextInputContext.
+    #[cfg(target_os = "macos")]
+    crate::platform::macos::disable_press_and_hold();
+
     tray::setup_tray(app)?;
 
     // Install a panic hook that emits a `diagnostics:report` event before

--- a/asyar-launcher/src-tauri/src/platform/macos.rs
+++ b/asyar-launcher/src-tauri/src/platform/macos.rs
@@ -814,6 +814,33 @@ pub fn install_appearance_observer<R: Runtime + 'static>(app: &AppHandle<R>) {
     }
 }
 
+/// Disables macOS's "hold key for accented characters" popup for Asyar's
+/// own process (issue #433, item 3). WKWebView shows this popup on any
+/// focused editable element when a key is held, driven by AppKit's
+/// `NSTextInputContext` — a layer below WebKit's DOM event dispatch, so
+/// the shortcut recorder's capture-phase `preventDefault()` in
+/// `useShortcutCapture.svelte.ts` never reaches it. `NSUserDefaults` is
+/// scoped to the calling process's own bundle id, so this does not affect
+/// any other app or a system-wide setting.
+pub fn disable_press_and_hold() {
+    unsafe {
+        let defaults_cls = match AnyClass::get("NSUserDefaults") {
+            Some(c) => c,
+            None => {
+                log::warn!("[disable_press_and_hold] NSUserDefaults class not found");
+                return;
+            }
+        };
+        let defaults: *mut AnyObject = msg_send![defaults_cls, standardUserDefaults];
+        if defaults.is_null() {
+            log::warn!("[disable_press_and_hold] standardUserDefaults returned null");
+            return;
+        }
+        let key = NSString::from_str("ApplePressAndHoldEnabled");
+        let _: () = msg_send![defaults, setBool: Bool::NO forKey: Retained::as_ptr(&key)];
+    }
+}
+
 pub fn register_cmdq_monitor(app_handle: AppHandle) {
     use block2::StackBlock;
     const KEY_DOWN_MASK: u64 = 1u64 << 10;


### PR DESCRIPTION
Holding a key while recording a shortcut showed macOS's native accented-character popup. WKWebView's NSTextInputContext triggers it below the DOM event dispatch, so the shortcut recorder's preventDefault() never reaches it. NSUserDefaults is scoped to Asyar's own bundle id, so this doesn't touch other apps or a system-wide setting.

Related to #433"