### PR TITLE
Don't auto-execute portal aliases with an empty query

### DIFF
--- a/asyar-launcher/src/built-in-features/portals/portalLifecycle.test.ts
+++ b/asyar-launcher/src/built-in-features/portals/portalLifecycle.test.ts
@@ -71,11 +71,44 @@ describe('removePortalFromIndex', () => {
   });
 });
 
+describe('Portal context provider metadata', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function getRegisteredProvider(portalId: string) {
+    return vi.mocked(contextModeService.registerProvider).mock.calls
+      .find(c => c[0].id === `portal_${portalId}`)![0];
+  }
+
+  it('links the provider to its command object id', async () => {
+    const portal = { id: '20', name: 'Google', url: 'https://google.com/?q={query}', icon: '🔍' };
+    await syncPortalToIndex(portal as any);
+    expect(getRegisteredProvider('20').commandObjectId).toBe('cmd_portals_20');
+  });
+
+  it('marks needsQuery true for a {query} portal', async () => {
+    const portal = { id: '21', name: 'Google', url: 'https://google.com/?q={query}', icon: '🔍' };
+    await syncPortalToIndex(portal as any);
+    expect(getRegisteredProvider('21').needsQuery).toBe(true);
+  });
+
+  it('marks needsQuery true for an {Argument} portal (query alias)', async () => {
+    const portal = { id: '22', name: 'Wiki', url: 'https://wiki.com/?q={Argument}', icon: '📖' };
+    await syncPortalToIndex(portal as any);
+    expect(getRegisteredProvider('22').needsQuery).toBe(true);
+  });
+
+  it('marks needsQuery false for a portal with no query placeholder', async () => {
+    const portal = { id: '23', name: 'GitHub', url: 'https://github.com', icon: '🐙' };
+    await syncPortalToIndex(portal as any);
+    expect(getRegisteredProvider('23').needsQuery).toBe(false);
+  });
+});
+
 describe('Portal onActivate guard', () => {
   beforeEach(() => vi.clearAllMocks());
 
   async function getOnActivate(portal: any) {
-    await syncPortalToIndex(portal);
+    await syncPortalToIndex(portal as any);
     const call = vi.mocked(contextModeService.registerProvider).mock.calls
       .find(c => c[0].id === `portal_${portal.id}`);
     return call![0].onActivate!;
@@ -117,7 +150,7 @@ describe('Portal chip pre-fill (onActivate with empty query)', () => {
   beforeEach(() => vi.clearAllMocks());
 
   async function getOnActivate(portal: any) {
-    await syncPortalToIndex(portal);
+    await syncPortalToIndex(portal as any);
     const call = vi.mocked(contextModeService.registerProvider).mock.calls
       .find(c => c[0].id === `portal_${portal.id}`);
     return call![0].onActivate!;

--- a/asyar-launcher/src/built-in-features/portals/portalLifecycle.ts
+++ b/asyar-launcher/src/built-in-features/portals/portalLifecycle.ts
@@ -54,6 +54,24 @@ export async function deletePortal(portalId: string): Promise<void> {
   await removePortalFromIndex(portalId);
 }
 
+/** Extract `{token}` placeholder names from a portal URL. */
+function getPortalTokens(portalUrl: string): string[] {
+  const TOKEN_RE = /\{([^{}]+)\}/g;
+  return [...portalUrl.matchAll(TOKEN_RE)].map(m => m[1]);
+}
+
+/**
+ * True when the portal URL contains a user-query token ({query}/{Argument}).
+ * These portals can't be resolved without the user typing something, so
+ * activating them (via Tab or an alias) must wait for input rather than
+ * firing immediately.
+ */
+function portalNeedsQuery(portalUrl: string): boolean {
+  return getPortalTokens(portalUrl).some(t =>
+    PLACEHOLDERS.some(p => p.id === 'query' && (p.token === t || p.aliases?.includes(t)))
+  );
+}
+
 /**
  * Resolve a pre-fill value for the query bar when the chip is first set (Tab).
  *
@@ -63,17 +81,10 @@ export async function deletePortal(portalId: string): Promise<void> {
  * user sees the value that will be used and can edit it before pressing Enter.
  */
 async function resolveChipPrefill(portalUrl: string): Promise<string> {
-  const TOKEN_RE = /\{([^{}]+)\}/g;
-  const tokens = [...portalUrl.matchAll(TOKEN_RE)].map(m => m[1]);
-
-  // If the URL has a user-query token the user will type their own input — no pre-fill.
-  const hasQueryToken = tokens.some(t =>
-    PLACEHOLDERS.some(p => p.id === 'query' && (p.token === t || p.aliases?.includes(t)))
-  );
-  if (hasQueryToken) return '';
+  if (portalNeedsQuery(portalUrl)) return '';
 
   // Resolve and return the first known placeholder's value.
-  for (const tokenText of tokens) {
+  for (const tokenText of getPortalTokens(portalUrl)) {
     const def = PLACEHOLDERS.find(p => p.token === tokenText || p.aliases?.includes(tokenText));
     if (def) return def.resolve({});
   }
@@ -83,6 +94,8 @@ async function resolveChipPrefill(portalUrl: string): Promise<string> {
 function registerPortalContextProvider(portal: Portal): void {
   contextModeService.registerProvider({
     id: `portal_${portal.id}`,
+    commandObjectId: `cmd_portals_${portal.id}`,
+    needsQuery: portalNeedsQuery(portal.url),
     triggers: [portal.name],
     display: {
       name: portal.name,

--- a/asyar-launcher/src/services/context/contextModeService.svelte.ts
+++ b/asyar-launcher/src/services/context/contextModeService.svelte.ts
@@ -18,6 +18,19 @@ export interface ContextModeProvider {
   type: 'url' | 'view' | 'stream';
   onActivate?: (initialQuery?: string) => void;
   onDeactivate?: () => void;
+  /**
+   * The runtime command object id this provider is registered alongside
+   * (e.g. `cmd_portals_<id>`), if any. Lets callers that only have an
+   * objectId (e.g. an alias match) find the matching context provider.
+   */
+  commandObjectId?: string;
+  /**
+   * True when activating this provider without a query does nothing but
+   * arm the chip (e.g. a portal URL with a `{query}` placeholder). Callers
+   * that would otherwise fire the command with an empty query should
+   * activate the context mode and wait for input instead.
+   */
+  needsQuery?: boolean;
 }
 
 export interface ActiveContext {
@@ -213,6 +226,14 @@ class ContextModeService {
 
   getActiveContext(): ActiveContext | null {
     return this.activeContext;
+  }
+
+  /** Find the provider registered alongside a given command object id, if any. */
+  getProviderForCommand(commandObjectId: string): ContextModeProvider | null {
+    for (const provider of this.providers.values()) {
+      if (provider.commandObjectId === commandObjectId) return provider;
+    }
+    return null;
   }
 
   isActive(): boolean {

--- a/asyar-launcher/src/services/search/searchOrchestrator.alias.test.ts
+++ b/asyar-launcher/src/services/search/searchOrchestrator.alias.test.ts
@@ -23,6 +23,8 @@ vi.mock('../context/contextModeService.svelte', () => ({
     isActive: vi.fn(() => false),
     getHint: vi.fn(() => null),
     contextHint: null,
+    getProviderForCommand: vi.fn(() => null),
+    activate: vi.fn(),
   },
 }));
 
@@ -45,15 +47,20 @@ vi.mock('../../lib/ipc/commands', () => ({
 import * as commands from '../../lib/ipc/commands';
 import { searchStores } from './stores/search.svelte';
 import { commandService } from '../extension/commandService.svelte';
+import { contextModeService } from '../context/contextModeService.svelte';
 import { searchOrchestrator, invalidateTopItemsCache } from './searchOrchestrator.svelte';
 
 const mergedSearchMock = vi.mocked(commands.mergedSearch);
 const executeCommand = vi.mocked(commandService.executeCommand);
+const getProviderForCommand = vi.mocked(contextModeService.getProviderForCommand);
+const activate = vi.mocked(contextModeService.activate);
 
 describe('searchOrchestrator alias handling', () => {
   beforeEach(async () => {
     mergedSearchMock.mockReset();
     executeCommand.mockReset();
+    getProviderForCommand.mockReset().mockReturnValue(null);
+    activate.mockReset();
     searchOrchestrator.items = [];
     invalidateTopItemsCache();
     // Clear the orchestrator's private auto-execute guard so each test starts
@@ -90,6 +97,37 @@ describe('searchOrchestrator alias handling', () => {
     });
     await searchOrchestrator.handleSearch('cl ');
     expect(executeCommand).toHaveBeenCalledWith('cmd_clip_history');
+    expect(searchStores.query).toBe('');
+  });
+
+  it('activates context mode instead of auto-executing when the aliased command needs a typed query', async () => {
+    // Regression for issue #433 follow-up: a portal alias (e.g. "g" -> Search
+    // Google) followed by a trailing space must not fire with an empty query.
+    getProviderForCommand.mockReturnValue({ id: 'portal_1', needsQuery: true } as any);
+    mergedSearchMock.mockResolvedValueOnce({
+      results: [
+        { objectId: 'cmd_portals_1', name: 'Search Google', type: 'command', score: 0.5 } as any,
+      ],
+      aliasMatch: { objectId: 'cmd_portals_1', itemType: 'command', autoExecute: true },
+    });
+    await searchOrchestrator.handleSearch('g ');
+    expect(getProviderForCommand).toHaveBeenCalledWith('cmd_portals_1');
+    expect(activate).toHaveBeenCalledWith('portal_1', '');
+    expect(executeCommand).not.toHaveBeenCalled();
+    expect(searchStores.query).toBe('');
+  });
+
+  it('still auto-executes a portal alias when the portal has no query placeholder', async () => {
+    getProviderForCommand.mockReturnValue({ id: 'portal_2', needsQuery: false } as any);
+    mergedSearchMock.mockResolvedValueOnce({
+      results: [
+        { objectId: 'cmd_portals_2', name: 'Open GitHub', type: 'command', score: 0.5 } as any,
+      ],
+      aliasMatch: { objectId: 'cmd_portals_2', itemType: 'command', autoExecute: true },
+    });
+    await searchOrchestrator.handleSearch('gh ');
+    expect(executeCommand).toHaveBeenCalledWith('cmd_portals_2');
+    expect(activate).not.toHaveBeenCalled();
     expect(searchStores.query).toBe('');
   });
 

--- a/asyar-launcher/src/services/search/searchOrchestrator.svelte.ts
+++ b/asyar-launcher/src/services/search/searchOrchestrator.svelte.ts
@@ -11,6 +11,7 @@ import { dispatch } from '../extension/extensionDispatcher.svelte';
 import { commandService } from '../extension/commandService.svelte';
 import { isBuiltInFeature } from '../extension/extensionDiscovery';
 import { actionService } from '../action/actionService.svelte';
+import { contextModeService } from '../context/contextModeService.svelte';
 
 export { invalidateTopItemsCache };
 
@@ -118,8 +119,18 @@ class SearchOrchestratorClass {
       if (aliasMatch && aliasMatch.autoExecute && aliasMatch.itemType === 'command') {
         if (this.#lastAutoExecutedQuery !== query) {
           this.#lastAutoExecutedQuery = query;
-          void commandService.executeCommand(aliasMatch.objectId);
-          searchStores.query = '';
+          // If the aliased command needs a typed query (e.g. a portal with a
+          // {query} placeholder), firing it now would resolve with an empty
+          // value. Arm its context mode instead — same as pressing Tab — so
+          // the user types the parameter before it runs (issue #433 follow-up).
+          const provider = contextModeService.getProviderForCommand(aliasMatch.objectId);
+          if (provider?.needsQuery) {
+            searchStores.query = '';
+            contextModeService.activate(provider.id, '');
+          } else {
+            void commandService.executeCommand(aliasMatch.objectId);
+            searchStores.query = '';
+          }
           this.items = [];
           this.lastCompletedQuery = '';
           if (token === this.#searchToken) searchStores.isLoading = false;


### PR DESCRIPTION
Typing an alias (e.g. "g") + space for a portal that needs a typed parameter fired it immediately with an empty query instead of waiting for input like Tab does. Route alias auto-execute through context mode when the target needs a query; leave query-less commands unaffected.

related to #433 