### PR TITLE
Fix file search watcher pinning CPU and holding gigabytes of memory

### DIFF
--- a/asyar-launcher/docs/architecture/file-search.md
+++ b/asyar-launcher/docs/architecture/file-search.md
@@ -22,7 +22,7 @@ All of it lives under `asyar-launcher/src-tauri/src/file_index/`:
 | `ranking.rs` | Pure scoring functions (match quality, frecency, depth, type prior) |
 | `file_id.rs` | Stable file id: FNV hash of `(dev, inode)` (Unix) / `(volume, file_index)` (Windows) — survives renames |
 | `walker.rs` | Parallel initial scan (`ignore` crate), exclusion patterns, hard entry cap, bundle-as-leaf handling |
-| `watcher.rs` | `notify-debouncer-full` live updates, same exclusion set as the walker, `FileIndexWatcherHandle` |
+| `watcher.rs` | Raw `notify` watcher + Asyar-owned coalescer (exclusion check first, flush every 500 ms), `FileIndexWatcherHandle` |
 | `snapshot.rs` | Versioned bincode snapshot — instant restart without a full rescan |
 | `learning.rs` | In-memory per-query selection/pin boosts, loaded once at startup (never queried on the keystroke path) |
 | `service.rs` | `FileIndexState` — the lifecycle/state machine tying everything together, Tauri-agnostic by design |
@@ -30,7 +30,7 @@ All of it lives under `asyar-launcher/src-tauri/src/file_index/`:
 | `commands.rs` | Thin `#[tauri::command]` wrappers — no logic beyond extract/delegate/map-error |
 
 `asyar-launcher/src-tauri/src/thumbnail/` is a separate, related subsystem
-(§6).
+(§7).
 
 Two SQLite tables back learning/pins: `storage/file_search_selections.rs`,
 `storage/file_search_pinned.rs`.
@@ -125,12 +125,50 @@ walker and `watcher.rs`'s exclusion set (the same pattern list).
 
 `walker::BUNDLE_EXTENSIONS` treats `.app`, `.framework`, `.photoslibrary`,
 `.pvm`, `.vmwarevm` directories as opaque leaves — indexed as one entry,
-never descended into, regardless of what folder they live in.
+never descended into, regardless of what folder they live in. The
+watcher's exclusion set mirrors this with `**/*.<ext>/**` globs so events
+from *inside* a bundle (Photos doing library maintenance, an app updating
+itself) can't append tail entries the walker would never emit.
+
+## 6. Watcher internals: why not `notify-debouncer-full`
+
+`watcher.rs` uses a **raw `notify` watcher** plus a small Asyar-owned
+coalescer, not `notify-debouncer-full`. The debouncer's default
+`FileIdMap` cache walks and `stat`s **every file under each watched
+root** into a `HashMap<PathBuf, FileId>` — no exclusions, symlinks
+followed — and re-walks the entire tree on every kernel "events dropped"
+flag. Watching `$HOME` that way kept a core pinned in a self-feeding
+rescan loop (the walk blocks the event thread → the kernel drops events →
+another rescan flag → another walk) and held gigabytes of path strings,
+all to power rename stitching the index never consumed.
+
+The replacement pipeline:
+
+```
+notify event callback (FSEvents/inotify thread)
+  → Coalescer.ingest: exclusion glob check FIRST — no stat, no queueing
+    for excluded paths; survivors de-dup into a HashSet
+flush thread, every 500 ms
+  → drain → resolve(path): one symlink_metadata per survivor —
+    exists ⇒ Upserted, gone ⇒ Removed (renames tombstone the old name)
+  → FileIndexState::apply_watcher_batch
+```
+
+Two valves degrade a window to a **bounded** walker rescan
+(`commands::make_on_rescan` → `spawn_rescan`, which never re-arms the
+watcher and never stacks on a running scan): the kernel's rescan flag,
+and a >50k pending-path overflow. Both replace the library's answer
+(unbounded cache walk) with ours (exclusion-aware, hard-capped scan).
+
+The other two debouncer users (`application/index_watcher.rs`,
+`fs_watcher/mod.rs`) keep `notify-debouncer-full` for its debouncing but
+pass `NoCache` explicitly — neither consumes rename stitching, and an
+extension watching a large tree must not make the host stat-walk it.
 
 A hard cap (`walker::HARD_CAP` = 1,000,000 entries) stops the walk and
 flips status to `CapReached` rather than growing unbounded.
 
-## 6. Thumbnails — a separate, related subsystem
+## 7. Thumbnails — a separate, related subsystem
 
 `asyar-launcher/src-tauri/src/thumbnail/` generates and caches file preview
 thumbnails, served the same way application icons already are:
@@ -177,7 +215,7 @@ Cache: `$APPDATA/thumbnail_cache/`, size-capped at 300 MB
 (`thumbnail::cache::CACHE_CAP_BYTES`), oldest-by-mtime eviction sweep on
 every write once over budget.
 
-## 7. IPC contract
+## 8. IPC contract
 
 | Command | Args (camelCase) | Returns |
 |---|---|---|
@@ -211,7 +249,7 @@ milestones are the synchronous `Rescanning` flip and the final
 TS wrappers: `src/lib/ipc/fileSearchCommands.ts`,
 `src/lib/ipc/thumbnailCommands.ts`.
 
-## 8. Root-search fallback row
+## 9. Root-search fallback row
 
 `search_engine/file_search_fallback.rs::append_file_search_fallback` is the
 **only** touch point on the root-search hot path — everything else about
@@ -240,7 +278,7 @@ independent reactive stores, so seeding only the internal query state
 leaves the visible search bar showing whatever the user had typed in
 root search even though results have already updated underneath it.
 
-## 9. Settings
+## 10. Settings
 
 ```ts
 AppSettings.fileSearch: {
@@ -256,7 +294,7 @@ AppSettings.fileSearch: {
 current settings value to Rust on init, diff-and-repush on every change.
 UI: `src/routes/settings/tabs/FileSearchTab.svelte`.
 
-## 10. Known follow-ups
+## 11. Known follow-ups
 
 - Windows/Linux native thumbnail providers for non-image types
   (`thumbnail::windows`/`thumbnail::linux` are stubs today, always

--- a/asyar-launcher/src-tauri/Cargo.toml
+++ b/asyar-launcher/src-tauri/Cargo.toml
@@ -81,7 +81,7 @@ trash = "5"
 regex = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
 notify = "8"                       # Filesystem watcher — drives auto-rescan of the app index
-notify-debouncer-full = "0.7"      # Coalesces app-install fs-event bursts into one rescan
+notify-debouncer-full = "0.7"      # Debounce for app-index/fs-watch. ALWAYS NoCache: default FileIdMap stat-walks whole watched roots
 globset = "0.4"                    # Glob pattern matching for fs:watch permission patterns
 async-trait = "0.1"
 chrono = "0.4"                     # Local-date formatting for usage rollups (YYYY-MM-DD)

--- a/asyar-launcher/src-tauri/src/application/index_watcher.rs
+++ b/asyar-launcher/src-tauri/src/application/index_watcher.rs
@@ -43,7 +43,7 @@ use crate::index_events::{IndexEvent, IndexEventsHub};
 use crate::search_engine::managed_search_state;
 use log::{debug, warn};
 use notify::RecursiveMode;
-use notify_debouncer_full::{new_debouncer, DebounceEventResult, Debouncer, RecommendedCache};
+use notify_debouncer_full::{new_debouncer_opt, DebounceEventResult, Debouncer, NoCache};
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -116,12 +116,12 @@ fn build_extras_state(initial: Vec<PathBuf>) -> (ExtrasState, ExtrasState) {
 /// Long-lived watcher handle. Drop drops the debouncer which unwatches all
 /// paths, so this must be stored in managed state for the app's lifetime.
 pub struct IndexWatcher {
-    // Holding the debouncer keeps the watcher thread alive. The concrete
-    // type is the debouncer-full recommended bundle (RecommendedWatcher +
-    // FileIdMap cache); we don't name it directly because the crate's
-    // public type alias `Debouncer<RecommendedWatcher, RecommendedCache>`
-    // is the stable surface.
-    debouncer: Mutex<Debouncer<notify::RecommendedWatcher, RecommendedCache>>,
+    // Holding the debouncer keeps the watcher thread alive. `NoCache` is
+    // deliberate: the default `FileIdMap` cache walks and stats every file
+    // under each watched root (and re-walks on kernel rescan flags) purely
+    // for rename stitching — this watcher only counts "something changed"
+    // and rescans, so the cache would be pure overhead.
+    debouncer: Mutex<Debouncer<notify::RecommendedWatcher, NoCache>>,
     // Shared with the debouncer closure so set_extra_paths writes are
     // visible to FS-event rescans.
     extras: ExtrasState,
@@ -146,7 +146,7 @@ impl IndexWatcher {
         let handler_app = app_handle.clone();
         let handler_hub = hub.clone();
 
-        let mut debouncer = new_debouncer(
+        let mut debouncer = new_debouncer_opt(
             DEBOUNCE_WINDOW,
             None,
             move |result: DebounceEventResult| match result {
@@ -164,6 +164,8 @@ impl IndexWatcher {
                     }
                 }
             },
+            NoCache::new(),
+            notify::Config::default(),
         )
         .map_err(|e| AppError::Other(format!("failed to create debouncer: {e}")))?;
 
@@ -541,7 +543,7 @@ mod tests {
 
         let (tx, rx) = mpsc::channel::<()>();
         let hub_cb = hub.clone();
-        let mut debouncer = new_debouncer(
+        let mut debouncer = new_debouncer_opt::<_, notify::RecommendedWatcher, NoCache>(
             Duration::from_millis(150),
             None,
             move |result: DebounceEventResult| {
@@ -563,6 +565,8 @@ mod tests {
                     }
                 }
             },
+            NoCache::new(),
+            notify::Config::default(),
         )
         .expect("debouncer starts");
 

--- a/asyar-launcher/src-tauri/src/file_index/commands.rs
+++ b/asyar-launcher/src-tauri/src/file_index/commands.rs
@@ -16,7 +16,9 @@ use super::query::QueryOptions;
 use super::ranking::now_seconds;
 use super::service::FileIndexState;
 use super::snapshot::SNAPSHOT_FILE_NAME;
-use super::types::{FileHit, FileIndexConfig, FileSearchResponse, FileType, HitSource, IndexStatus};
+use super::types::{
+    FileHit, FileIndexConfig, FileSearchResponse, FileType, HitSource, IndexStateKind, IndexStatus,
+};
 use super::walker::HARD_CAP;
 use super::watcher::{self, FileIndexWatcherHandle};
 
@@ -68,6 +70,35 @@ fn snapshot_path(app: &AppHandle) -> Option<PathBuf> {
         .map(|d| d.join(SNAPSHOT_FILE_NAME))
 }
 
+/// Full walker scan + snapshot persist, both off the async thread. Returns
+/// the roots and excludes it scanned so `spawn_rebuild` can re-arm the
+/// watcher over the same set. Callers check `config().enabled` first.
+async fn run_scan_and_snapshot(
+    app: &AppHandle,
+    state: &Arc<FileIndexState>,
+) -> (Vec<PathBuf>, Vec<String>) {
+    let cfg = state.config();
+    let roots = resolve_roots(app, &cfg);
+    let excludes = cfg.exclude_patterns.clone();
+    let now = now_seconds();
+
+    let scan_state = state.clone();
+    let scan_roots = roots.clone();
+    let scan_excludes = excludes.clone();
+    let _ = tauri::async_runtime::spawn_blocking(move || {
+        scan_state.run_full_scan(scan_roots, scan_excludes, HARD_CAP, now)
+    })
+    .await;
+
+    if let Some(path) = snapshot_path(app) {
+        let save_state = state.clone();
+        let _ = tauri::async_runtime::spawn_blocking(move || save_state.save_snapshot(&path))
+            .await;
+    }
+
+    (roots, excludes)
+}
+
 /// Runs a full rescan off the calling task, saves a snapshot, re-arms the
 /// watcher over the new roots, and emits the resulting status. Spawned
 /// so the triggering command (`file_index_rebuild` /
@@ -82,35 +113,57 @@ fn snapshot_path(app: &AppHandle) -> Option<PathBuf> {
 /// possibly many seconds later.
 fn spawn_rebuild(app: AppHandle, state: Arc<FileIndexState>) {
     tauri::async_runtime::spawn(async move {
-        let cfg = state.config();
-        if !cfg.enabled {
+        if !state.config().enabled {
             return;
         }
-        let roots = resolve_roots(&app, &cfg);
-        let excludes = cfg.exclude_patterns.clone();
-        let now = now_seconds();
-
-        let scan_state = state.clone();
-        let scan_roots = roots.clone();
-        let scan_excludes = excludes.clone();
-        let _ = tauri::async_runtime::spawn_blocking(move || {
-            scan_state.run_full_scan(scan_roots, scan_excludes, HARD_CAP, now)
-        })
-        .await;
-
-        if let Some(path) = snapshot_path(&app) {
-            let save_state = state.clone();
-            let _ = tauri::async_runtime::spawn_blocking(move || save_state.save_snapshot(&path))
-                .await;
-        }
+        let (roots, excludes) = run_scan_and_snapshot(&app, &state).await;
 
         if let Some(handle) = app.try_state::<Arc<FileIndexWatcherHandle>>() {
             let exclusions = watcher::build_exclusion_set(&excludes);
-            handle.rearm(roots, exclusions, state.clone());
+            let on_rescan = make_on_rescan(app.clone(), state.clone());
+            handle.rearm(roots, exclusions, state.clone(), on_rescan);
         }
 
         let _ = app.emit("asyar:file-index-status", state.status());
     });
+}
+
+/// Rescan without re-arming: the watcher stays on its current roots. Used
+/// to answer the watcher's degraded-window signal, where the roots didn't
+/// change — only the index's freshness is in doubt.
+fn spawn_rescan(app: AppHandle, state: Arc<FileIndexState>) {
+    tauri::async_runtime::spawn(async move {
+        if !state.config().enabled {
+            return;
+        }
+        run_scan_and_snapshot(&app, &state).await;
+        let _ = app.emit("asyar:file-index-status", state.status());
+    });
+}
+
+/// `true` when a watcher rescan signal should start a scan now. `Building`
+/// and `Rescanning` mean one is already running (stacking a second wastes
+/// a full walk); `Disabled` means never.
+fn should_start_rescan(state: IndexStateKind) -> bool {
+    matches!(state, IndexStateKind::Ready | IndexStateKind::CapReached)
+}
+
+/// Handler for the watcher's rescan signal (kernel dropped events, or the
+/// coalescer's overflow valve tripped): the index may have missed changes,
+/// so answer with the same bounded, exclusion-aware scan a manual rebuild
+/// runs — never the watcher-library's unbounded cache walk this replaced.
+pub(crate) fn make_on_rescan(
+    app: AppHandle,
+    state: Arc<FileIndexState>,
+) -> impl Fn() + Send + 'static {
+    move || {
+        if !should_start_rescan(state.status().state) {
+            return;
+        }
+        state.mark_rescanning();
+        let _ = app.emit("asyar:file-index-status", state.status());
+        spawn_rescan(app.clone(), state.clone());
+    }
 }
 
 #[tauri::command]
@@ -146,7 +199,12 @@ pub async fn file_index_set_config(
         spawn_rebuild(app, state.inner().clone());
     } else if !config.enabled {
         if let Some(handle) = app.try_state::<Arc<FileIndexWatcherHandle>>() {
-            handle.rearm(Vec::new(), watcher::build_exclusion_set(&[]), state.inner().clone());
+            handle.rearm(
+                Vec::new(),
+                watcher::build_exclusion_set(&[]),
+                state.inner().clone(),
+                || {},
+            );
         }
     }
     Ok(())
@@ -445,6 +503,21 @@ mod tests {
         drop(conn);
         let id = file_id::from_hex(&file_id_hex).unwrap();
         assert_eq!(state.learning_boost("report", id, NOW), 0.0);
+    }
+
+    #[test]
+    fn rescan_signal_only_fires_from_stable_states() {
+        assert!(should_start_rescan(IndexStateKind::Ready));
+        assert!(should_start_rescan(IndexStateKind::CapReached));
+        assert!(
+            !should_start_rescan(IndexStateKind::Building),
+            "startup scan already running"
+        );
+        assert!(
+            !should_start_rescan(IndexStateKind::Rescanning),
+            "never stack a second scan on a running one"
+        );
+        assert!(!should_start_rescan(IndexStateKind::Disabled));
     }
 
     #[tokio::test]

--- a/asyar-launcher/src-tauri/src/file_index/walker.rs
+++ b/asyar-launcher/src-tauri/src/file_index/walker.rs
@@ -55,8 +55,9 @@ pub const DEFAULT_IGNORE_PATTERNS: &[&str] = &[
 
 /// Directory extensions treated as opaque leaf "bundles" — indexed as one
 /// entry, never descended into (app bundles, frameworks, photo libraries,
-/// VM disk images).
-const BUNDLE_EXTENSIONS: &[&str] = &[
+/// VM disk images). The watcher's exclusion set mirrors this so events
+/// from inside a bundle can't append entries the walker would never emit.
+pub(crate) const BUNDLE_EXTENSIONS: &[&str] = &[
     "app",
     "framework",
     "photoslibrary",

--- a/asyar-launcher/src-tauri/src/file_index/watcher.rs
+++ b/asyar-launcher/src-tauri/src/file_index/watcher.rs
@@ -1,21 +1,31 @@
-//! fs-event ingest. Watches configured roots and forwards batches of typed
-//! `IndexUpdate`s (see `index.rs`) as files appear/change/disappear.
-//! `notify-debouncer-full` coalesces bursts (npm install, large rsync) into
-//! one callback per quiescent window.
+//! fs-event ingest for the file index: a raw `notify` watcher plus an
+//! Asyar-owned coalescer.
 //!
-//! Unlike the old attempt, every event path is checked against the same
-//! exclusion set the walker used *before* it's stat'ed or translated — a
-//! build/install storm inside `node_modules` or `target` must not wake the
-//! index (or spend a syscall) just because it's nested under a watched
-//! root.
+//! Deliberately NOT `notify-debouncer-full`. Its default `FileIdMap` cache
+//! stats every file under each watched root into a `HashMap<PathBuf,
+//! FileId>` — no exclusions, symlinks followed — and re-walks the whole
+//! tree on every kernel "events dropped" flag. Watching `$HOME` that way
+//! kept one core pinned in an endless stat-walk loop and held gigabytes of
+//! path strings, all to power rename stitching the index never consumed.
+//!
+//! Here the exclusion set is the FIRST thing an event meets, on the event
+//! callback thread, before any stat or queueing: excluded churn (browser
+//! caches, `node_modules`, VM disks) costs one glob check and nothing
+//! else. Survivors are de-duplicated per coalesce window and resolved
+//! against the live filesystem at flush time. The kernel's rescan flag
+//! (and a pending-set overflow valve) degrade to `on_rescan` — the caller
+//! answers with the bounded, exclusion-aware walker scan, never an
+//! unbounded walk.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, RecvTimeoutError};
 use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
 use std::time::Duration;
 
-use globset::{Glob, GlobSet, GlobSetBuilder};
-use notify::EventKind;
-use notify_debouncer_full::{new_debouncer, DebounceEventResult, Debouncer, RecommendedCache};
+use globset::{Glob, GlobBuilder, GlobSet, GlobSetBuilder};
+use notify::{EventKind, RecursiveMode, Watcher};
 
 use super::index::{IndexUpdate, ScannedEntry};
 use super::ranking::now_seconds;
@@ -24,6 +34,12 @@ use super::types::EntryKind;
 use super::walker::DEFAULT_IGNORE_PATTERNS;
 
 const COALESCE_WINDOW: Duration = Duration::from_millis(500);
+
+/// Overflow valve: if one coalesce window accumulates more distinct
+/// non-excluded paths than this, stop collecting and degrade to a single
+/// bounded rescan — cheaper than resolving each path and appending an
+/// unbounded live tail to the index.
+const PENDING_OVERFLOW: usize = 50_000;
 
 /// Builds the exclusion matcher from the same default patterns the walker
 /// uses, plus user-configured extras. A pattern matches anywhere in the
@@ -38,6 +54,17 @@ pub fn build_exclusion_set(custom_patterns: &[String]) -> GlobSet {
             builder.add(g);
         }
     }
+    // Bundle *internals* only — the bundle directory itself stays watchable
+    // because the walker indexes it as a leaf entry. Case-insensitive to
+    // match the walker's extension comparison.
+    for ext in super::walker::BUNDLE_EXTENSIONS {
+        if let Ok(g) = GlobBuilder::new(&format!("**/*.{ext}/**"))
+            .case_insensitive(true)
+            .build()
+        {
+            builder.add(g);
+        }
+    }
     builder
         .build()
         .unwrap_or_else(|_| GlobSetBuilder::new().build().expect("empty GlobSet always builds"))
@@ -47,81 +74,195 @@ pub fn is_excluded(set: &GlobSet, path: &Path) -> bool {
     set.is_match(path)
 }
 
-/// Build a debouncer that watches `roots` and calls `on_updates` with each
-/// non-empty, non-excluded batch. The returned `Debouncer` must be kept
-/// alive — dropping it stops watching.
-pub fn start_watcher<F>(
+/// What one flush window produced: the surviving distinct paths, and
+/// whether the window degraded to "just rescan everything (bounded)".
+#[derive(Default)]
+pub struct Drained {
+    pub paths: Vec<PathBuf>,
+    pub rescan: bool,
+}
+
+/// Pure coalescing core, kept thread-free so the policy is unit-testable:
+/// exclusion check first (never a syscall), de-dup within the window, and
+/// two degrade-to-rescan valves (kernel rescan flag, pending overflow).
+pub struct Coalescer {
+    exclusions: GlobSet,
+    pending: HashSet<PathBuf>,
+    rescan: bool,
+    overflow_cap: usize,
+}
+
+impl Coalescer {
+    pub fn new(exclusions: GlobSet) -> Self {
+        Self::with_overflow_cap(exclusions, PENDING_OVERFLOW)
+    }
+
+    fn with_overflow_cap(exclusions: GlobSet, overflow_cap: usize) -> Self {
+        Self {
+            exclusions,
+            pending: HashSet::new(),
+            rescan: false,
+            overflow_cap,
+        }
+    }
+
+    /// Ingests one raw watcher event. Runs on the event callback thread,
+    /// so the only work allowed here is the glob check and a set insert.
+    pub fn ingest(&mut self, event: &notify::Event) {
+        if self.rescan {
+            // A full scan supersedes anything else this window.
+            return;
+        }
+        if event.need_rescan() {
+            self.flip_to_rescan();
+            return;
+        }
+        if !matches!(
+            event.kind,
+            EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+        ) {
+            return;
+        }
+        for path in &event.paths {
+            if self.exclusions.is_match(path) {
+                continue;
+            }
+            if self.pending.len() >= self.overflow_cap {
+                self.flip_to_rescan();
+                return;
+            }
+            self.pending.insert(path.clone());
+        }
+    }
+
+    /// Takes everything accumulated this window and resets the slate.
+    pub fn drain(&mut self) -> Drained {
+        Drained {
+            paths: self.pending.drain().collect(),
+            rescan: std::mem::take(&mut self.rescan),
+        }
+    }
+
+    /// Replaces (not clears) the set so a storm's capacity is released.
+    fn flip_to_rescan(&mut self) {
+        self.rescan = true;
+        self.pending = HashSet::new();
+    }
+}
+
+/// Resolves one surviving path against the live filesystem at flush time.
+/// The path's current state — not the event kind — decides the update, so
+/// create/modify/remove races within a window and rename-from paths
+/// (whose old name no longer exists) all land on the truth: a rename now
+/// tombstones the old entry instead of leaving it stale until rescan.
+pub fn resolve(path: &Path) -> IndexUpdate {
+    let Ok(meta) = std::fs::symlink_metadata(path) else {
+        return IndexUpdate::Removed(path.to_path_buf());
+    };
+    let name = path
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let kind = if meta.file_type().is_symlink() {
+        EntryKind::Symlink
+    } else if meta.is_dir() {
+        EntryKind::Dir
+    } else {
+        EntryKind::File
+    };
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as u32)
+        .unwrap_or(0);
+    IndexUpdate::Upserted(ScannedEntry {
+        path: path.to_path_buf(),
+        kind,
+        mtime,
+        hidden: name.starts_with('.'),
+        placeholder: false,
+    })
+}
+
+/// Live watch over `roots`. Dropping stops the OS watch and joins the
+/// flush thread (bounded by one `COALESCE_WINDOW`).
+pub struct FileIndexWatcher {
+    /// Keeps the OS watch alive; dropped after the flusher joined.
+    _watcher: notify::RecommendedWatcher,
+    stop_tx: mpsc::Sender<()>,
+    flusher: Option<JoinHandle<()>>,
+}
+
+impl Drop for FileIndexWatcher {
+    fn drop(&mut self) {
+        let _ = self.stop_tx.send(());
+        if let Some(h) = self.flusher.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+/// Arms a raw watcher over `roots` and a flush thread that hands each
+/// non-empty resolved batch to `on_updates`; a degraded window fires
+/// `on_rescan` instead.
+pub fn start_watcher<F, R>(
     roots: &[PathBuf],
     exclusions: GlobSet,
     mut on_updates: F,
-) -> notify::Result<Debouncer<notify::RecommendedWatcher, RecommendedCache>>
+    on_rescan: R,
+) -> notify::Result<FileIndexWatcher>
 where
     F: FnMut(Vec<IndexUpdate>) + Send + 'static,
+    R: Fn() + Send + 'static,
 {
-    let mut debouncer = new_debouncer(COALESCE_WINDOW, None, move |res: DebounceEventResult| {
-        let Ok(events) = res else { return };
-        let mut updates = Vec::new();
-        for ev in events {
-            for path in &ev.paths {
-                if is_excluded(&exclusions, path) {
-                    continue;
-                }
-                if let Some(u) = translate(&ev.kind, path) {
-                    updates.push(u);
-                }
-            }
-        }
-        if !updates.is_empty() {
-            on_updates(updates);
+    let coalescer = Arc::new(Mutex::new(Coalescer::new(exclusions)));
+    let ingest_side = Arc::clone(&coalescer);
+    let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+        let Ok(event) = res else { return };
+        if let Ok(mut c) = ingest_side.lock() {
+            c.ingest(&event);
         }
     })?;
     for root in roots {
-        debouncer.watch(root, notify::RecursiveMode::Recursive)?;
+        watcher.watch(root, RecursiveMode::Recursive)?;
     }
-    Ok(debouncer)
+
+    let (stop_tx, stop_rx) = mpsc::channel::<()>();
+    let flusher = std::thread::Builder::new()
+        .name("file-index-flush".into())
+        .spawn(move || {
+            // Timeout = one coalesce window elapsed → flush; a stop signal
+            // (or the sender dropping) ends the thread.
+            while let Err(RecvTimeoutError::Timeout) = stop_rx.recv_timeout(COALESCE_WINDOW) {
+                let drained = match coalescer.lock() {
+                    Ok(mut c) => c.drain(),
+                    Err(_) => Drained::default(),
+                };
+                if drained.rescan {
+                    on_rescan();
+                }
+                if drained.paths.is_empty() {
+                    continue;
+                }
+                on_updates(drained.paths.iter().map(|p| resolve(p)).collect());
+            }
+        })
+        .map_err(|e| notify::Error::generic(&e.to_string()))?;
+
+    Ok(FileIndexWatcher {
+        _watcher: watcher,
+        stop_tx,
+        flusher: Some(flusher),
+    })
 }
 
-fn translate(kind: &EventKind, path: &Path) -> Option<IndexUpdate> {
-    match kind {
-        EventKind::Create(_) | EventKind::Modify(_) => {
-            let meta = std::fs::metadata(path).ok()?;
-            let name = path
-                .file_name()
-                .map(|s| s.to_string_lossy().into_owned())
-                .unwrap_or_default();
-            let hidden = name.starts_with('.');
-            let entry_kind = if meta.is_dir() {
-                EntryKind::Dir
-            } else {
-                EntryKind::File
-            };
-            let mtime = meta
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs() as u32)
-                .unwrap_or(0);
-            Some(IndexUpdate::Upserted(ScannedEntry {
-                path: path.to_path_buf(),
-                kind: entry_kind,
-                mtime,
-                hidden,
-                placeholder: false,
-            }))
-        }
-        EventKind::Remove(_) => Some(IndexUpdate::Removed(path.to_path_buf())),
-        _ => None,
-    }
-}
-
-/// Long-lived managed handle owning the debouncer. `rearm` fully replaces
-/// the watch set — simpler than the applications watcher's incremental
-/// diffing, which is worth it there because default+extra scan paths
-/// change independently; file-index roots only ever change as one atomic
-/// settings edit, so a full unwatch-then-rewatch is the right amount of
+/// Long-lived managed handle owning the live watcher. `rearm` fully
+/// replaces the watch set — file-index roots only ever change as one
+/// atomic settings edit, so unwatch-then-rewatch is the right amount of
 /// complexity.
 pub struct FileIndexWatcherHandle {
-    debouncer: Mutex<Option<Debouncer<notify::RecommendedWatcher, RecommendedCache>>>,
+    watcher: Mutex<Option<FileIndexWatcher>>,
 }
 
 impl Default for FileIndexWatcherHandle {
@@ -133,23 +274,34 @@ impl Default for FileIndexWatcherHandle {
 impl FileIndexWatcherHandle {
     pub fn new() -> Self {
         Self {
-            debouncer: Mutex::new(None),
+            watcher: Mutex::new(None),
         }
     }
 
-    /// Drops any existing debouncer (stopping all prior watches) and, if
+    /// Drops any existing watcher (stopping all prior watches) and, if
     /// `roots` is non-empty, arms a fresh one that applies batches directly
-    /// to `state`.
-    pub fn rearm(&self, roots: Vec<PathBuf>, exclusions: GlobSet, state: Arc<FileIndexState>) {
-        let mut guard = self.debouncer.lock().expect("debouncer lock");
+    /// to `state` and answers degraded windows via `on_rescan`.
+    pub fn rearm<R>(
+        &self,
+        roots: Vec<PathBuf>,
+        exclusions: GlobSet,
+        state: Arc<FileIndexState>,
+        on_rescan: R,
+    ) where
+        R: Fn() + Send + 'static,
+    {
+        let mut guard = self.watcher.lock().expect("watcher lock");
         *guard = None;
         if roots.is_empty() {
             return;
         }
-        match start_watcher(&roots, exclusions, move |updates| {
-            state.apply_watcher_batch(updates, now_seconds());
-        }) {
-            Ok(d) => *guard = Some(d),
+        match start_watcher(
+            &roots,
+            exclusions,
+            move |updates| state.apply_watcher_batch(updates, now_seconds()),
+            on_rescan,
+        ) {
+            Ok(w) => *guard = Some(w),
             Err(e) => log::warn!("[file_index_watcher] rearm failed: {e}"),
         }
     }
@@ -158,43 +310,16 @@ impl FileIndexWatcherHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::file_index::types::FileIndexConfig;
+    use notify::event::{AccessKind, AccessMode, CreateKind, Flag, ModifyKind, RemoveKind};
     use std::fs;
 
-    #[test]
-    fn translate_create_yields_upserted_scanned_entry() {
-        let id = std::process::id();
-        let p = std::env::temp_dir().join(format!("fi_watcher_test_{id}.txt"));
-        fs::write(&p, "x").unwrap();
-        let u = translate(&EventKind::Create(notify::event::CreateKind::File), &p).unwrap();
-        match u {
-            IndexUpdate::Upserted(e) => {
-                assert_eq!(e.path, p);
-                assert!(matches!(e.kind, EntryKind::File));
-            }
-            _ => panic!("wrong variant"),
-        }
-        let _ = fs::remove_file(&p);
+    fn ev(kind: EventKind, path: &Path) -> notify::Event {
+        notify::Event::new(kind).add_path(path.to_path_buf())
     }
 
-    #[test]
-    fn translate_remove_yields_removed_path() {
-        let p = Path::new("/tmp/nonexistent_fi_watcher.txt");
-        let u = translate(&EventKind::Remove(notify::event::RemoveKind::File), p).unwrap();
-        match u {
-            IndexUpdate::Removed(removed) => assert_eq!(removed, p),
-            _ => panic!("wrong variant"),
-        }
-    }
-
-    #[test]
-    fn translate_unrelated_event_yields_none() {
-        let u = translate(
-            &EventKind::Access(notify::event::AccessKind::Open(
-                notify::event::AccessMode::Read,
-            )),
-            Path::new("/tmp/anything.txt"),
-        );
-        assert!(u.is_none());
+    fn create_ev(path: &Path) -> notify::Event {
+        ev(EventKind::Create(CreateKind::File), path)
     }
 
     #[test]
@@ -205,6 +330,38 @@ mod tests {
         assert!(is_excluded(&set, Path::new("/home/u/Library/Caches/x")));
         assert!(is_excluded(&set, Path::new("/home/u/proj/my-custom-skip/x.txt")));
         assert!(!is_excluded(&set, Path::new("/home/u/proj/src/main.rs")));
+    }
+
+    #[test]
+    fn exclusion_set_drops_bundle_internals_but_keeps_the_bundle_leaf_itself() {
+        let set = build_exclusion_set(&[]);
+        // The walker indexes bundles as opaque leaves and never descends
+        // into them — watcher events from inside a bundle must not be able
+        // to append entries the scan policy excludes.
+        assert!(is_excluded(
+            &set,
+            Path::new("/Users/u/Applications/Foo.app/Contents/Info.plist")
+        ));
+        assert!(is_excluded(
+            &set,
+            Path::new("/Users/u/Pictures/Photos Library.photoslibrary/database/Photos.sqlite")
+        ));
+        assert!(is_excluded(
+            &set,
+            Path::new("/Users/u/dev/Some.framework/Versions/A/Some")
+        ));
+        // Extension casing must not matter (walker compares case-insensitively).
+        assert!(is_excluded(
+            &set,
+            Path::new("/Users/u/Applications/Odd.APP/Contents/x")
+        ));
+        // The bundle itself is a real indexed leaf — events on it (e.g. an
+        // app update bumping the bundle mtime) must still pass through.
+        assert!(!is_excluded(&set, Path::new("/Users/u/Applications/Foo.app")));
+        assert!(!is_excluded(
+            &set,
+            Path::new("/Users/u/Pictures/Photos Library.photoslibrary")
+        ));
     }
 
     #[test]
@@ -221,6 +378,126 @@ mod tests {
     }
 
     #[test]
+    fn coalescer_drops_excluded_paths_at_ingest() {
+        let mut c = Coalescer::new(build_exclusion_set(&[]));
+        c.ingest(&create_ev(Path::new("/home/u/proj/node_modules/react/index.js")));
+        c.ingest(&create_ev(Path::new("/home/u/Library/Caches/noise.db")));
+        let d = c.drain();
+        assert!(d.paths.is_empty(), "excluded paths must never survive ingest");
+        assert!(!d.rescan);
+    }
+
+    #[test]
+    fn coalescer_dedupes_repeated_events_for_one_path() {
+        let mut c = Coalescer::new(build_exclusion_set(&[]));
+        let p = Path::new("/home/u/notes.txt");
+        c.ingest(&create_ev(p));
+        c.ingest(&ev(EventKind::Modify(ModifyKind::Any), p));
+        c.ingest(&ev(EventKind::Remove(RemoveKind::File), p));
+        let d = c.drain();
+        assert_eq!(d.paths, vec![PathBuf::from("/home/u/notes.txt")]);
+        assert!(!d.rescan);
+    }
+
+    #[test]
+    fn coalescer_ignores_access_events() {
+        let mut c = Coalescer::new(build_exclusion_set(&[]));
+        c.ingest(&ev(
+            EventKind::Access(AccessKind::Open(AccessMode::Read)),
+            Path::new("/home/u/opened.txt"),
+        ));
+        let d = c.drain();
+        assert!(d.paths.is_empty());
+        assert!(!d.rescan);
+    }
+
+    #[test]
+    fn coalescer_drain_resets_the_slate() {
+        let mut c = Coalescer::new(build_exclusion_set(&[]));
+        c.ingest(&create_ev(Path::new("/home/u/a.txt")));
+        let first = c.drain();
+        assert_eq!(first.paths.len(), 1);
+        let second = c.drain();
+        assert!(second.paths.is_empty());
+        assert!(!second.rescan);
+    }
+
+    #[test]
+    fn coalescer_rescan_flag_supersedes_pending_paths() {
+        let mut c = Coalescer::new(build_exclusion_set(&[]));
+        c.ingest(&create_ev(Path::new("/home/u/a.txt")));
+        c.ingest(&notify::Event::new(EventKind::Other).set_flag(Flag::Rescan));
+        // Anything after the flag is pointless — the full scan supersedes it.
+        c.ingest(&create_ev(Path::new("/home/u/b.txt")));
+        let d = c.drain();
+        assert!(d.rescan);
+        assert!(d.paths.is_empty(), "a rescan window emits no per-path work");
+        // Slate is clean afterwards.
+        let d2 = c.drain();
+        assert!(!d2.rescan);
+        assert!(d2.paths.is_empty());
+    }
+
+    #[test]
+    fn coalescer_overflow_converts_to_rescan() {
+        let mut c = Coalescer::with_overflow_cap(build_exclusion_set(&[]), 3);
+        for i in 0..5 {
+            c.ingest(&create_ev(&PathBuf::from(format!("/home/u/f{i}.txt"))));
+        }
+        let d = c.drain();
+        assert!(d.rescan, "overflow must degrade to one bounded rescan");
+        assert!(d.paths.is_empty());
+    }
+
+    #[test]
+    fn resolve_existing_file_yields_upserted_with_metadata() {
+        let id = std::process::id();
+        let p = std::env::temp_dir().join(format!("fi_watcher_resolve_{id}.txt"));
+        fs::write(&p, "x").unwrap();
+        match resolve(&p) {
+            IndexUpdate::Upserted(e) => {
+                assert_eq!(e.path, p);
+                assert!(matches!(e.kind, EntryKind::File));
+                assert!(e.mtime > 0);
+                assert!(!e.hidden);
+            }
+            IndexUpdate::Removed(_) => panic!("existing file must upsert"),
+        }
+        let _ = fs::remove_file(&p);
+    }
+
+    #[test]
+    fn resolve_missing_path_yields_removed() {
+        let p = Path::new("/tmp/definitely_missing_fi_watcher.txt");
+        match resolve(p) {
+            IndexUpdate::Removed(removed) => assert_eq!(removed, p),
+            IndexUpdate::Upserted(_) => panic!("missing path must remove"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_symlink_keeps_symlink_kind_without_following() {
+        let id = std::process::id();
+        let dir = std::env::temp_dir().join(format!("fi_watcher_symlink_{id}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let target = dir.join("target-dir");
+        fs::create_dir_all(&target).unwrap();
+        let link = dir.join("link");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        match resolve(&link) {
+            IndexUpdate::Upserted(e) => assert!(
+                matches!(e.kind, EntryKind::Symlink),
+                "symlink must keep Symlink kind (walker parity), got {:?}",
+                e.kind
+            ),
+            IndexUpdate::Removed(_) => panic!("symlink exists"),
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn excluded_path_events_are_dropped_before_reaching_callback() {
         let id = std::process::id();
         let root = std::env::temp_dir().join(format!("fi_watcher_e2e_{id}"));
@@ -230,10 +507,17 @@ mod tests {
         let exclusions = build_exclusion_set(&[]);
         let received: Arc<Mutex<Vec<IndexUpdate>>> = Arc::new(Mutex::new(Vec::new()));
         let received_cb = received.clone();
+        let rescans = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let rescans_cb = rescans.clone();
 
-        let mut debouncer = start_watcher(std::slice::from_ref(&root), exclusions, move |updates| {
-            received_cb.lock().unwrap().extend(updates);
-        })
+        let watcher = start_watcher(
+            std::slice::from_ref(&root),
+            exclusions,
+            move |updates| received_cb.lock().unwrap().extend(updates),
+            move || {
+                rescans_cb.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            },
+        )
         .expect("watcher starts");
 
         // Excluded: must never surface.
@@ -241,10 +525,9 @@ mod tests {
         // Not excluded: must surface.
         fs::write(root.join("keep.txt"), "hi").unwrap();
 
-        // Give the debouncer's coalesce window (500ms) time to fire, then
-        // stop watching so the callback thread quiesces.
-        std::thread::sleep(Duration::from_millis(900));
-        let _ = debouncer.unwatch(&root);
+        // Give the coalesce window (500ms) time to flush.
+        std::thread::sleep(Duration::from_millis(1200));
+        drop(watcher);
 
         let updates = received.lock().unwrap();
         let has_excluded = updates.iter().any(|u| match u {
@@ -257,7 +540,53 @@ mod tests {
         });
         assert!(!has_excluded, "node_modules event must be dropped, got {updates:?}");
         assert!(has_kept, "non-excluded event must surface, got {updates:?}");
+        assert_eq!(rescans.load(std::sync::atomic::Ordering::SeqCst), 0);
 
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn rename_tombstones_old_path_and_upserts_new_path() {
+        let id = std::process::id();
+        let root = std::env::temp_dir().join(format!("fi_watcher_rename_{id}"));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let old = root.join("old-name.txt");
+        fs::write(&old, "x").unwrap();
+
+        let received: Arc<Mutex<Vec<IndexUpdate>>> = Arc::new(Mutex::new(Vec::new()));
+        let received_cb = received.clone();
+        let watcher = start_watcher(
+            std::slice::from_ref(&root),
+            build_exclusion_set(&[]),
+            move |updates| received_cb.lock().unwrap().extend(updates),
+            || {},
+        )
+        .expect("watcher starts");
+
+        let new = root.join("new-name.txt");
+        fs::rename(&old, &new).unwrap();
+
+        std::thread::sleep(Duration::from_millis(1200));
+        drop(watcher);
+
+        let updates = received.lock().unwrap();
+        let old_removed = updates.iter().any(|u| matches!(u, IndexUpdate::Removed(p) if p.ends_with("old-name.txt")));
+        let new_upserted = updates.iter().any(|u| matches!(u, IndexUpdate::Upserted(e) if e.path.ends_with("new-name.txt")));
+        assert!(
+            old_removed,
+            "rename must tombstone the old path (stat fails at flush), got {updates:?}"
+        );
+        assert!(new_upserted, "rename must upsert the new path, got {updates:?}");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn rearm_with_empty_roots_disarms() {
+        let handle = FileIndexWatcherHandle::new();
+        let state = Arc::new(FileIndexState::new(FileIndexConfig::default()));
+        handle.rearm(Vec::new(), build_exclusion_set(&[]), state, || {});
+        assert!(handle.watcher.lock().unwrap().is_none());
     }
 }

--- a/asyar-launcher/src-tauri/src/fs_watcher/mod.rs
+++ b/asyar-launcher/src-tauri/src/fs_watcher/mod.rs
@@ -10,7 +10,7 @@ pub mod matcher;
 
 use crate::error::AppError;
 use notify::RecursiveMode;
-use notify_debouncer_full::{new_debouncer, DebounceEventResult, Debouncer, RecommendedCache};
+use notify_debouncer_full::{new_debouncer_opt, DebounceEventResult, Debouncer, NoCache};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -59,8 +59,12 @@ struct WatcherEntry {
     extension_id: String,
     paths: Vec<PathBuf>,
     /// Dropping this entry stops the watcher thread. Underscore-prefixed
-    /// because we never access it directly after construction.
-    _debouncer: Debouncer<notify::RecommendedWatcher, RecommendedCache>,
+    /// because we never access it directly after construction. `NoCache`
+    /// is deliberate: the default `FileIdMap` stats every file under each
+    /// watched root purely for rename stitching, and this registry only
+    /// forwards which roots saw activity — an extension watching a large
+    /// tree must not make the host walk it.
+    _debouncer: Debouncer<notify::RecommendedWatcher, NoCache>,
 }
 
 /// Per-handle registry. Stored as managed Tauri state (`Arc<Self>`).
@@ -140,7 +144,7 @@ impl FsWatcherRegistry {
         let emit_for_cb = self.emit.clone();
         let roots_for_cb = paths.clone();
 
-        let mut debouncer = new_debouncer(debounce, None, move |result: DebounceEventResult| {
+        let mut debouncer = new_debouncer_opt(debounce, None, move |result: DebounceEventResult| {
             let events = match result {
                 Ok(e) if !e.is_empty() => e,
                 _ => return,
@@ -160,7 +164,7 @@ impl FsWatcherRegistry {
                     );
                 }
             }
-        })
+        }, NoCache::new(), notify::Config::default())
         .map_err(|e| AppError::Other(format!("failed to create debouncer: {e}")))?;
 
         for p in &paths {

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -1723,7 +1723,11 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 app_handle_for_file_index.try_state::<std::sync::Arc<file_index::watcher::FileIndexWatcherHandle>>()
             {
                 let exclusions = file_index::watcher::build_exclusion_set(&cfg.exclude_patterns);
-                handle.rearm(roots, exclusions, file_index_state.clone());
+                let on_rescan = file_index::commands::make_on_rescan(
+                    app_handle_for_file_index.clone(),
+                    file_index_state.clone(),
+                );
+                handle.rearm(roots, exclusions, file_index_state.clone(), on_rescan);
             }
 
             let _ = app_handle_for_file_index.emit("asyar:file-index-status", file_index_state.status());


### PR DESCRIPTION
Replace notify-debouncer-full in the file-index watcher with a raw notify watcher and an exclusion-first coalescer. The debouncer's default FileIdMap cache stat-walked all of $HOME (ignoring exclusions) and re-walked it on every kernel rescan flag, keeping a core busy forever. Rescan signals now trigger the bounded walker scan instead, events inside bundles (.app, .photoslibrary, ...) are excluded, renames now tombstone the old path, and the app-index and fs-watch watchers switch to an explicit NoCache.