### PR TITLE
Set CREATE_NO_WINDOW on extension shell spawns (Windows)

### DIFF
--- a/asyar-launcher/src-tauri/src/shell/mod.rs
+++ b/asyar-launcher/src-tauri/src/shell/mod.rs
@@ -277,6 +277,17 @@ pub fn spawn(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
+    // CREATE_NO_WINDOW — keep a console-subsystem child (e.g. powershell.exe)
+    // from briefly flashing a black console window when an extension spawns it,
+    // matching the launcher's own PowerShell calls (application/service.rs, #411).
+    // Stdio is piped, so suppressing the console doesn't affect output capture.
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        child_process.creation_flags(CREATE_NO_WINDOW);
+    }
+
     let mut child = Command::from(child_process).spawn()?;
 
     let pid = child
@@ -374,7 +385,16 @@ pub fn kill(shell_registry: &ShellProcessRegistry, spawn_id: &str) -> Result<(),
 
 pub async fn resolve_path(program: &str) -> Result<String, AppError> {
     let cmd = if cfg!(windows) { "where" } else { "which" };
-    let output = Command::new(cmd).arg(program).output().await?;
+    let mut command = Command::new(cmd);
+
+    // `where` is a console-subsystem binary too — suppress its window flash.
+    #[cfg(target_os = "windows")]
+    {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let output = command.arg(program).output().await?;
 
     if output.status.success() {
         let path = String::from_utf8_lossy(&output.stdout).trim().to_string();


### PR DESCRIPTION
### Problem

Extension `shell:spawn` children are spawned without `creation_flags`, so every console-subsystem child (e.g. `powershell.exe`) briefly flashes a black console window. The `where` lookup in `shell::resolve_path` has the same issue.

The launcher's **own** PowerShell calls already suppress this — `application/service.rs` sets `CREATE_NO_WINDOW` on the UWP scan specifically to avoid the flash (#411) — but the extension-facing spawn paths in `shell/mod.rs` never got the same treatment.

Hit in practice by a Steam-games launcher extension that must use `shell:spawn` both to read Steam's library files and to open `steam://run/<appid>` (see #448 / #449 for why no non-shell path exists today): every background reindex and every game launch flashes a console window.

### Fix

Apply the same `CREATE_NO_WINDOW` flag (`0x0800_0000`) to both spawn sites in `shell/mod.rs`, `#[cfg(target_os = "windows")]`-gated, mirroring the existing pattern in `application/service.rs`:

- `spawn()` — set on the `std::process::Command` before conversion to tokio
- `resolve_path()` — set via tokio's inherent `creation_flags`

Stdio is piped in both sites, so suppressing the console does not affect output capture, and GUI-subsystem children are unaffected by the flag.

### Verification

- **Behavioral (Windows 11):** built the launcher from this branch and drove it with the Steam-games extension — PowerShell-based reindex and `steam://` game launch both run with **no console window flash**; output capture, exit codes, and the run tracker behave unchanged. Same actions on the unpatched launcher flash a console window each time.
- `cargo test` (Linux): 2472 passed; 1 pre-existing failure (`fs_watcher::registry_tests::rejects_when_global_total_paths_would_exceed_limit`) that reproduces identically on clean `main` under WSL's default `fs.inotify.max_user_instances=128` — unrelated to this change.
- `cargo clippy --all-targets -- -D warnings`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
