### PR TITLE
feat(launcher): require user consent for extension permissions at install/enable

### DIFF
--- a/asyar-launcher/src-tauri/src/extensions/consent.rs
+++ b/asyar-launcher/src-tauri/src/extensions/consent.rs
@@ -11,6 +11,7 @@
 
 use crate::error::AppError;
 use crate::extensions::{ExtensionRecord, ExtensionRegistryState};
+use crate::permissions::ExtensionPermissionRegistry;
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
@@ -358,6 +359,73 @@ pub fn set_extension_consent(
     set_consent(&app_handle, &extension_id, &record)
 }
 
+/// Remove `extension_id`'s entry from `settings.extensions.consent`, if
+/// present. Pure JSON manipulation — testable without an `AppHandle`.
+/// Returns whether an entry was actually removed. Missing `extensions` or
+/// `consent` objects are a no-op (nothing to remove), matching
+/// `get_consent`'s "absent record" semantics; a *present but non-object*
+/// value at either level is corruption and errors instead of being
+/// silently clobbered, same as `child_object_mut`.
+pub fn remove_consent(
+    settings: &mut serde_json::Value,
+    extension_id: &str,
+) -> Result<bool, AppError> {
+    let root = settings_root_mut(settings)?;
+    let Some(extensions) = root.get_mut("extensions") else {
+        return Ok(false);
+    };
+    let extensions = extensions.as_object_mut().ok_or_else(|| {
+        AppError::Other("settings.dat is corrupt: 'extensions' is not a JSON object".into())
+    })?;
+    let Some(consent) = extensions.get_mut("consent") else {
+        return Ok(false);
+    };
+    let consent = consent.as_object_mut().ok_or_else(|| {
+        AppError::Other("settings.dat is corrupt: 'consent' is not a JSON object".into())
+    })?;
+    Ok(consent.remove(extension_id).is_some())
+}
+
+/// Withdraw a previously-granted consent record. Used by the Settings UI's
+/// "Revoke" action — the extension stays installed/enabled; the record's
+/// absence means the next registration attempt withholds its permissions
+/// until the user re-grants via the normal review flow.
+pub fn clear_consent(app_handle: &AppHandle, extension_id: &str) -> Result<(), AppError> {
+    let store = app_handle
+        .store("settings.dat")
+        .map_err(|e| AppError::Other(format!("Failed to open settings store: {}", e)))?;
+    let Some(mut settings) = store.get("settings") else {
+        return Ok(());
+    };
+    if remove_consent(&mut settings, extension_id)? {
+        store.set("settings", settings);
+        store
+            .save()
+            .map_err(|e| AppError::Other(format!("Failed to save settings: {}", e)))?;
+    }
+    Ok(())
+}
+
+/// Tauri command backing the Settings → Extensions "Revoke" button. Clears
+/// the consent record and immediately unregisters the extension from the
+/// live permission registry, so its gated calls fail closed right away —
+/// no restart or extension reload required.
+#[tauri::command]
+pub fn revoke_extension_consent(
+    app_handle: AppHandle,
+    extension_id: String,
+    registry: tauri::State<'_, ExtensionPermissionRegistry>,
+) -> Result<(), AppError> {
+    if extension_id.trim().is_empty() {
+        return Err(AppError::Validation(
+            "extension_id cannot be empty".to_string(),
+        ));
+    }
+    clear_consent(&app_handle, &extension_id)?;
+    registry.unregister(&extension_id);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -628,5 +696,65 @@ mod tests {
         assert!(value.get("permissionArgs").is_some());
         assert!(value.get("consentedAt").is_some());
         assert!(value.get("grandfathered").is_some());
+    }
+
+    // ---- remove_consent (backs the Settings "Revoke" action) ----
+
+    #[test]
+    fn remove_consent_removes_existing_record() {
+        let mut settings = serde_json::json!({
+            "extensions": { "consent": { "ext.a": { "permissions": ["network"] } } }
+        });
+        assert!(remove_consent(&mut settings, "ext.a").unwrap());
+        assert!(settings["extensions"]["consent"].get("ext.a").is_none());
+    }
+
+    #[test]
+    fn remove_consent_preserves_sibling_entries() {
+        let mut settings = serde_json::json!({
+            "extensions": { "consent": {
+                "ext.a": { "permissions": ["network"] },
+                "ext.b": { "permissions": ["fs:watch"] },
+            }}
+        });
+        assert!(remove_consent(&mut settings, "ext.a").unwrap());
+        assert!(settings["extensions"]["consent"].get("ext.a").is_none());
+        assert!(settings["extensions"]["consent"].get("ext.b").is_some());
+    }
+
+    #[test]
+    fn remove_consent_is_noop_when_extensions_key_missing() {
+        let mut settings = serde_json::json!({});
+        assert!(!remove_consent(&mut settings, "ext.a").unwrap());
+    }
+
+    #[test]
+    fn remove_consent_is_noop_when_consent_key_missing() {
+        let mut settings = serde_json::json!({ "extensions": {} });
+        assert!(!remove_consent(&mut settings, "ext.a").unwrap());
+    }
+
+    #[test]
+    fn remove_consent_is_noop_when_id_not_present() {
+        let mut settings = serde_json::json!({ "extensions": { "consent": {} } });
+        assert!(!remove_consent(&mut settings, "ext.a").unwrap());
+    }
+
+    #[test]
+    fn remove_consent_errors_on_corrupt_extensions() {
+        let mut settings = serde_json::json!({ "extensions": "corrupt-string" });
+        assert!(remove_consent(&mut settings, "ext.a").is_err());
+    }
+
+    #[test]
+    fn remove_consent_errors_on_corrupt_consent() {
+        let mut settings = serde_json::json!({ "extensions": { "consent": "corrupt-string" } });
+        assert!(remove_consent(&mut settings, "ext.a").is_err());
+    }
+
+    #[test]
+    fn remove_consent_errors_on_corrupt_settings_root() {
+        let mut settings = serde_json::json!("corrupt");
+        assert!(remove_consent(&mut settings, "ext.a").is_err());
     }
 }

--- a/asyar-launcher/src-tauri/src/extensions/consent.rs
+++ b/asyar-launcher/src-tauri/src/extensions/consent.rs
@@ -142,6 +142,35 @@ pub fn get_consent(
     }
 }
 
+/// Get (creating if absent) the object at `parent[key]`. Errors — rather than
+/// panicking or silently replacing — when an existing value is not a JSON
+/// object: a corrupt settings.dat should fail the consent write, not be
+/// clobbered by it. Consent stays unrecorded and the registration backstop
+/// keeps the permissions withheld, so failing here fails closed.
+fn child_object_mut<'a>(
+    parent: &'a mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<&'a mut serde_json::Map<String, serde_json::Value>, AppError> {
+    parent
+        .entry(key)
+        .or_insert_with(|| serde_json::Value::Object(Default::default()))
+        .as_object_mut()
+        .ok_or_else(|| {
+            AppError::Other(format!(
+                "settings.dat is corrupt: '{}' is not a JSON object",
+                key
+            ))
+        })
+}
+
+fn settings_root_mut(
+    settings: &mut serde_json::Value,
+) -> Result<&mut serde_json::Map<String, serde_json::Value>, AppError> {
+    settings.as_object_mut().ok_or_else(|| {
+        AppError::Other("settings.dat is corrupt: 'settings' is not a JSON object".into())
+    })
+}
+
 /// Persist a consent record under `settings.extensions.consent.<id>`.
 pub fn set_consent(
     app_handle: &AppHandle,
@@ -153,15 +182,17 @@ pub fn set_consent(
         .map_err(|e| AppError::Other(format!("Failed to open settings store: {}", e)))?;
 
     let mut settings = store.get("settings").unwrap_or(serde_json::json!({}));
-    if settings.get("extensions").is_none() {
-        settings["extensions"] = serde_json::json!({});
+    {
+        let root = settings_root_mut(&mut settings)?;
+        let extensions = child_object_mut(root, "extensions")?;
+        let consent = child_object_mut(extensions, "consent")?;
+        consent.insert(
+            extension_id.to_string(),
+            serde_json::to_value(record).map_err(|e| {
+                AppError::Other(format!("Failed to serialize consent record: {}", e))
+            })?,
+        );
     }
-    let extensions = settings.get_mut("extensions").unwrap();
-    if extensions.get("consent").is_none() {
-        extensions["consent"] = serde_json::json!({});
-    }
-    extensions["consent"][extension_id] = serde_json::to_value(record)
-        .map_err(|e| AppError::Other(format!("Failed to serialize consent record: {}", e)))?;
 
     store.set("settings", settings);
     store
@@ -217,32 +248,33 @@ pub fn run_grandfather_migration(
         return Ok(());
     }
 
-    if settings.get("extensions").is_none() {
-        settings["extensions"] = serde_json::json!({});
-    }
-    let extensions = settings.get_mut("extensions").unwrap();
-    if extensions.get("consent").is_none() {
-        extensions["consent"] = serde_json::json!({});
-    }
-
     let now = now_ms();
     let mut grandfathered = 0usize;
-    for record in records_to_grandfather(records) {
-        let id = record.manifest.id.as_str();
-        if extensions["consent"].get(id).is_some() {
-            continue;
+    {
+        let root = settings_root_mut(&mut settings)?;
+        let extensions = child_object_mut(root, "extensions")?;
+        let consent = child_object_mut(extensions, "consent")?;
+        for record in records_to_grandfather(records) {
+            let id = record.manifest.id.as_str();
+            if consent.contains_key(id) {
+                continue;
+            }
+            let consent_record = ConsentRecord {
+                permissions: record.manifest.permissions.clone().unwrap_or_default(),
+                permission_args: record.manifest.permission_args.clone().unwrap_or_default(),
+                consented_at: now,
+                grandfathered: true,
+            };
+            consent.insert(
+                id.to_string(),
+                serde_json::to_value(&consent_record).map_err(|e| {
+                    AppError::Other(format!("Failed to serialize consent record: {}", e))
+                })?,
+            );
+            grandfathered += 1;
         }
-        let consent = ConsentRecord {
-            permissions: record.manifest.permissions.clone().unwrap_or_default(),
-            permission_args: record.manifest.permission_args.clone().unwrap_or_default(),
-            consented_at: now,
-            grandfathered: true,
-        };
-        extensions["consent"][id] = serde_json::to_value(&consent)
-            .map_err(|e| AppError::Other(format!("Failed to serialize consent record: {}", e)))?;
-        grandfathered += 1;
+        extensions.insert(GRANDFATHER_FLAG.to_string(), serde_json::json!(true));
     }
-    extensions[GRANDFATHER_FLAG] = serde_json::json!(true);
 
     store.set("settings", settings);
     store
@@ -555,6 +587,33 @@ mod tests {
         let selected = records_to_grandfather(&records);
         let ids: Vec<&str> = selected.iter().map(|r| r.manifest.id.as_str()).collect();
         assert_eq!(ids, vec!["ext.keeper"]);
+    }
+
+    #[test]
+    fn child_object_mut_creates_missing_and_returns_existing() {
+        let mut value = serde_json::json!({ "existing": { "a": 1 } });
+        let root = value.as_object_mut().unwrap();
+        assert!(child_object_mut(root, "created").is_ok());
+        let existing = child_object_mut(root, "existing").unwrap();
+        assert_eq!(existing.get("a"), Some(&serde_json::json!(1)));
+    }
+
+    #[test]
+    fn child_object_mut_errors_on_non_object_instead_of_clobbering() {
+        let mut value = serde_json::json!({ "consent": "corrupt-string" });
+        let root = value.as_object_mut().unwrap();
+        assert!(child_object_mut(root, "consent").is_err());
+        // The corrupt value must survive untouched.
+        assert_eq!(
+            value.get("consent"),
+            Some(&serde_json::json!("corrupt-string"))
+        );
+    }
+
+    #[test]
+    fn settings_root_mut_errors_on_non_object_settings() {
+        let mut value = serde_json::json!("corrupt");
+        assert!(settings_root_mut(&mut value).is_err());
     }
 
     #[test]

--- a/asyar-launcher/src-tauri/src/extensions/consent.rs
+++ b/asyar-launcher/src-tauri/src/extensions/consent.rs
@@ -1,0 +1,573 @@
+//! Extension permission consent: user-approved permission sets persisted in
+//! settings.dat, checked before an extension's permissions are registered in
+//! the runtime permission registry.
+//!
+//! Consent is host-owned trust state (like shell binary trust), keyed by
+//! extension id under `settings.extensions.consent.<id>`. The frontend prompts
+//! at install/enable/update time; `register_extension_permissions` enforces at
+//! load time as the backstop — permissions never enter the registry without a
+//! covering consent record, so every gated call fails closed until the user
+//! accepts.
+
+use crate::error::AppError;
+use crate::extensions::{ExtensionRecord, ExtensionRegistryState};
+use log::{info, warn};
+use serde::{Deserialize, Serialize};
+use tauri::AppHandle;
+use tauri_plugin_store::StoreExt;
+
+/// Flag under `settings.extensions` marking that the one-shot grandfather
+/// migration has run. Its presence distinguishes "installed before the consent
+/// surface shipped" (recorded by the migration) from "fresh install that never
+/// got consent" (flag set, no record → prompted).
+const GRANDFATHER_FLAG: &str = "consentGrandfathered";
+
+/// A user-approved permission set for one extension.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsentRecord {
+    pub permissions: Vec<String>,
+    #[serde(default)]
+    pub permission_args: serde_json::Map<String, serde_json::Value>,
+    /// Epoch milliseconds.
+    pub consented_at: u64,
+    /// Recorded by the migration for extensions already installed and enabled
+    /// when the consent surface shipped, rather than by an explicit prompt.
+    #[serde(default)]
+    pub grandfathered: bool,
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Subset semantics: consent covers the declared set when every declared
+/// permission was consented, and every declared arg value is contained in the
+/// consented one. Removing a permission or an arg entry never re-prompts;
+/// adding one does. Array args compare element-wise containment; any other
+/// JSON shape requires exact equality. Arg keys without a matching declared
+/// permission are a manifest-validation concern, not a consent one.
+pub fn consent_covers(
+    consented: &ConsentRecord,
+    declared_permissions: &[String],
+    declared_args: &serde_json::Map<String, serde_json::Value>,
+) -> bool {
+    for perm in declared_permissions {
+        if !consented.permissions.iter().any(|p| p == perm) {
+            return false;
+        }
+    }
+    for (perm, declared) in declared_args {
+        if !declared_permissions.iter().any(|p| p == perm) {
+            continue;
+        }
+        let Some(consented_value) = consented.permission_args.get(perm) else {
+            return false;
+        };
+        match (declared.as_array(), consented_value.as_array()) {
+            (Some(d), Some(c)) => {
+                if d.iter().any(|item| !c.contains(item)) {
+                    return false;
+                }
+            }
+            _ => {
+                if declared != consented_value {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+#[derive(Debug, PartialEq)]
+pub enum RegistrationDecision {
+    Register,
+    WithholdNeedsConsent,
+}
+
+/// Whether an extension's declared permissions may enter the runtime registry.
+/// Built-ins bypass consent entirely; an empty declared set registers as-is
+/// (there is nothing to consent to, and keeping the extension registered keeps
+/// `check_extension_permission`'s "did not declare" error accurate).
+pub fn registration_decision(
+    is_built_in: bool,
+    declared_permissions: &[String],
+    declared_args: &serde_json::Map<String, serde_json::Value>,
+    consent: Option<&ConsentRecord>,
+) -> RegistrationDecision {
+    if is_built_in || declared_permissions.is_empty() {
+        return RegistrationDecision::Register;
+    }
+    match consent {
+        Some(record) if consent_covers(record, declared_permissions, declared_args) => {
+            RegistrationDecision::Register
+        }
+        _ => RegistrationDecision::WithholdNeedsConsent,
+    }
+}
+
+/// Read the persisted consent record. A record that fails to deserialize is
+/// treated as absent (fail closed → re-prompt) rather than an error.
+pub fn get_consent(
+    app_handle: &AppHandle,
+    extension_id: &str,
+) -> Result<Option<ConsentRecord>, AppError> {
+    let store = app_handle
+        .store("settings.dat")
+        .map_err(|e| AppError::Other(format!("Failed to open settings store: {}", e)))?;
+    let Some(settings) = store.get("settings") else {
+        return Ok(None);
+    };
+    let value = settings
+        .get("extensions")
+        .and_then(|e| e.get("consent"))
+        .and_then(|c| c.get(extension_id))
+        .cloned();
+    match value {
+        Some(v) => match serde_json::from_value::<ConsentRecord>(v) {
+            Ok(record) => Ok(Some(record)),
+            Err(e) => {
+                warn!(
+                    "Corrupt consent record for '{}' ({}); treating as unconsented",
+                    extension_id, e
+                );
+                Ok(None)
+            }
+        },
+        None => Ok(None),
+    }
+}
+
+/// Persist a consent record under `settings.extensions.consent.<id>`.
+pub fn set_consent(
+    app_handle: &AppHandle,
+    extension_id: &str,
+    record: &ConsentRecord,
+) -> Result<(), AppError> {
+    let store = app_handle
+        .store("settings.dat")
+        .map_err(|e| AppError::Other(format!("Failed to open settings store: {}", e)))?;
+
+    let mut settings = store.get("settings").unwrap_or(serde_json::json!({}));
+    if settings.get("extensions").is_none() {
+        settings["extensions"] = serde_json::json!({});
+    }
+    let extensions = settings.get_mut("extensions").unwrap();
+    if extensions.get("consent").is_none() {
+        extensions["consent"] = serde_json::json!({});
+    }
+    extensions["consent"][extension_id] = serde_json::to_value(record)
+        .map_err(|e| AppError::Other(format!("Failed to serialize consent record: {}", e)))?;
+
+    store.set("settings", settings);
+    store
+        .save()
+        .map_err(|e| AppError::Other(format!("Failed to save settings: {}", e)))
+}
+
+/// The records the one-shot migration grandfathers: non-built-in, currently
+/// enabled, with a non-empty declared permission set.
+pub fn records_to_grandfather(records: &[ExtensionRecord]) -> Vec<&ExtensionRecord> {
+    records
+        .iter()
+        .filter(|r| {
+            !r.is_built_in
+                && r.enabled
+                && r.manifest
+                    .permissions
+                    .as_ref()
+                    .map(|p| !p.is_empty())
+                    .unwrap_or(false)
+        })
+        .collect()
+}
+
+/// One-shot migration: on the first launch after the consent surface ships,
+/// record the current manifest permission set as consented for every
+/// already-enabled extension, then set the flag. Runs after enabled state has
+/// been applied to the records (see `lifecycle::discover_all`).
+///
+/// This mirrors how browsers introduced permission prompts to extension
+/// ecosystems that predated them: extensions the user already chose to
+/// install keep the access they visibly have today, and the prompt fires
+/// only for new installs and for permission growth on update. The
+/// alternative — prompting for every installed extension on first launch
+/// after upgrade — front-loads a wall of dialogs for grants the user cannot
+/// meaningfully re-evaluate in bulk, training them to click through exactly
+/// the surface this feature adds.
+pub fn run_grandfather_migration(
+    app_handle: &AppHandle,
+    records: &[ExtensionRecord],
+) -> Result<(), AppError> {
+    let store = app_handle
+        .store("settings.dat")
+        .map_err(|e| AppError::Other(format!("Failed to open settings store: {}", e)))?;
+
+    let mut settings = store.get("settings").unwrap_or(serde_json::json!({}));
+    let already_ran = settings
+        .get("extensions")
+        .and_then(|e| e.get(GRANDFATHER_FLAG))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if already_ran {
+        return Ok(());
+    }
+
+    if settings.get("extensions").is_none() {
+        settings["extensions"] = serde_json::json!({});
+    }
+    let extensions = settings.get_mut("extensions").unwrap();
+    if extensions.get("consent").is_none() {
+        extensions["consent"] = serde_json::json!({});
+    }
+
+    let now = now_ms();
+    let mut grandfathered = 0usize;
+    for record in records_to_grandfather(records) {
+        let id = record.manifest.id.as_str();
+        if extensions["consent"].get(id).is_some() {
+            continue;
+        }
+        let consent = ConsentRecord {
+            permissions: record.manifest.permissions.clone().unwrap_or_default(),
+            permission_args: record.manifest.permission_args.clone().unwrap_or_default(),
+            consented_at: now,
+            grandfathered: true,
+        };
+        extensions["consent"][id] = serde_json::to_value(&consent)
+            .map_err(|e| AppError::Other(format!("Failed to serialize consent record: {}", e)))?;
+        grandfathered += 1;
+    }
+    extensions[GRANDFATHER_FLAG] = serde_json::json!(true);
+
+    store.set("settings", settings);
+    store
+        .save()
+        .map_err(|e| AppError::Other(format!("Failed to save settings: {}", e)))?;
+
+    if grandfathered > 0 {
+        info!(
+            "Grandfathered permission consent for {} pre-existing extension(s)",
+            grandfathered
+        );
+    }
+    Ok(())
+}
+
+/// Consent status for one extension, returned to the frontend.
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ExtensionConsentStatus {
+    pub needs_consent: bool,
+    pub declared_permissions: Vec<String>,
+    pub declared_args: serde_json::Map<String, serde_json::Value>,
+    pub consented: Option<ConsentRecord>,
+}
+
+/// Resolve the declared set from the discovered manifest and report whether a
+/// covering consent record exists. Built-in or permissionless extensions never
+/// need consent.
+#[tauri::command]
+pub fn check_extension_consent(
+    app_handle: AppHandle,
+    extension_id: String,
+    extensions: tauri::State<'_, ExtensionRegistryState>,
+) -> Result<ExtensionConsentStatus, AppError> {
+    let (is_built_in, declared_permissions, declared_args) = {
+        let reg = extensions.extensions.lock().map_err(|_| AppError::Lock)?;
+        let record = reg
+            .get(&extension_id)
+            .ok_or_else(|| AppError::NotFound(format!("Extension not found: {}", extension_id)))?;
+        (
+            record.is_built_in,
+            record.manifest.permissions.clone().unwrap_or_default(),
+            record.manifest.permission_args.clone().unwrap_or_default(),
+        )
+    };
+    let consented = get_consent(&app_handle, &extension_id)?;
+    let needs_consent = registration_decision(
+        is_built_in,
+        &declared_permissions,
+        &declared_args,
+        consented.as_ref(),
+    ) == RegistrationDecision::WithholdNeedsConsent;
+    Ok(ExtensionConsentStatus {
+        needs_consent,
+        declared_permissions,
+        declared_args,
+        consented,
+    })
+}
+
+/// Record the user's acceptance of a permission set. Called by the host
+/// frontend after the consent dialog is accepted.
+#[tauri::command]
+pub fn set_extension_consent(
+    app_handle: AppHandle,
+    extension_id: String,
+    permissions: Vec<String>,
+    permission_args: Option<serde_json::Map<String, serde_json::Value>>,
+) -> Result<(), AppError> {
+    if extension_id.trim().is_empty() {
+        return Err(AppError::Validation(
+            "extension_id cannot be empty".to_string(),
+        ));
+    }
+    let record = ConsentRecord {
+        permissions,
+        permission_args: permission_args.unwrap_or_default(),
+        consented_at: now_ms(),
+        grandfathered: false,
+    };
+    set_consent(&app_handle, &extension_id, &record)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extensions::{CompatibilityStatus, ExtensionManifest};
+
+    fn record_with(permissions: &[&str], args: serde_json::Value) -> ConsentRecord {
+        ConsentRecord {
+            permissions: permissions.iter().map(|s| s.to_string()).collect(),
+            permission_args: args.as_object().cloned().unwrap_or_default(),
+            consented_at: 0,
+            grandfathered: false,
+        }
+    }
+
+    fn args(value: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+        value.as_object().cloned().unwrap_or_default()
+    }
+
+    fn perms(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn covers_identical_set() {
+        let consent = record_with(
+            &["fs:watch", "network"],
+            serde_json::json!({"fs:watch": ["~/a/**"]}),
+        );
+        assert!(consent_covers(
+            &consent,
+            &perms(&["fs:watch", "network"]),
+            &args(serde_json::json!({"fs:watch": ["~/a/**"]})),
+        ));
+    }
+
+    #[test]
+    fn added_permission_is_not_covered() {
+        let consent = record_with(&["network"], serde_json::json!({}));
+        assert!(!consent_covers(
+            &consent,
+            &perms(&["network", "clipboard:read"]),
+            &args(serde_json::json!({})),
+        ));
+    }
+
+    #[test]
+    fn removed_permission_is_still_covered() {
+        let consent = record_with(&["network", "clipboard:read"], serde_json::json!({}));
+        assert!(consent_covers(
+            &consent,
+            &perms(&["network"]),
+            &args(serde_json::json!({})),
+        ));
+    }
+
+    #[test]
+    fn added_arg_element_is_not_covered() {
+        let consent = record_with(&["fs:watch"], serde_json::json!({"fs:watch": ["~/a/**"]}));
+        assert!(!consent_covers(
+            &consent,
+            &perms(&["fs:watch"]),
+            &args(serde_json::json!({"fs:watch": ["~/a/**", "~/b/**"]})),
+        ));
+    }
+
+    #[test]
+    fn removed_arg_element_is_still_covered() {
+        let consent = record_with(
+            &["fs:watch"],
+            serde_json::json!({"fs:watch": ["~/a/**", "~/b/**"]}),
+        );
+        assert!(consent_covers(
+            &consent,
+            &perms(&["fs:watch"]),
+            &args(serde_json::json!({"fs:watch": ["~/a/**"]})),
+        ));
+    }
+
+    #[test]
+    fn missing_consented_arg_is_not_covered() {
+        let consent = record_with(&["fs:watch"], serde_json::json!({}));
+        assert!(!consent_covers(
+            &consent,
+            &perms(&["fs:watch"]),
+            &args(serde_json::json!({"fs:watch": ["~/a/**"]})),
+        ));
+    }
+
+    #[test]
+    fn non_array_arg_requires_exact_equality() {
+        let consent = record_with(&["some:perm"], serde_json::json!({"some:perm": {"max": 5}}));
+        assert!(consent_covers(
+            &consent,
+            &perms(&["some:perm"]),
+            &args(serde_json::json!({"some:perm": {"max": 5}})),
+        ));
+        assert!(!consent_covers(
+            &consent,
+            &perms(&["some:perm"]),
+            &args(serde_json::json!({"some:perm": {"max": 6}})),
+        ));
+    }
+
+    #[test]
+    fn orphan_declared_arg_without_permission_is_ignored() {
+        let consent = record_with(&["network"], serde_json::json!({}));
+        assert!(consent_covers(
+            &consent,
+            &perms(&["network"]),
+            &args(serde_json::json!({"fs:watch": ["~/a/**"]})),
+        ));
+    }
+
+    #[test]
+    fn empty_declared_set_is_always_covered() {
+        let consent = record_with(&[], serde_json::json!({}));
+        assert!(consent_covers(&consent, &[], &args(serde_json::json!({}))));
+    }
+
+    #[test]
+    fn decision_registers_built_in_without_consent() {
+        assert_eq!(
+            registration_decision(
+                true,
+                &perms(&["network"]),
+                &args(serde_json::json!({})),
+                None
+            ),
+            RegistrationDecision::Register
+        );
+    }
+
+    #[test]
+    fn decision_registers_empty_declared_set_without_consent() {
+        assert_eq!(
+            registration_decision(false, &[], &args(serde_json::json!({})), None),
+            RegistrationDecision::Register
+        );
+    }
+
+    #[test]
+    fn decision_withholds_when_consent_missing() {
+        assert_eq!(
+            registration_decision(
+                false,
+                &perms(&["network"]),
+                &args(serde_json::json!({})),
+                None
+            ),
+            RegistrationDecision::WithholdNeedsConsent
+        );
+    }
+
+    #[test]
+    fn decision_withholds_when_consent_stale() {
+        let consent = record_with(&["network"], serde_json::json!({}));
+        assert_eq!(
+            registration_decision(
+                false,
+                &perms(&["network", "shell:spawn"]),
+                &args(serde_json::json!({})),
+                Some(&consent)
+            ),
+            RegistrationDecision::WithholdNeedsConsent
+        );
+    }
+
+    #[test]
+    fn decision_registers_when_consent_covers() {
+        let consent = record_with(&["fs:watch"], serde_json::json!({"fs:watch": ["~/a/**"]}));
+        assert_eq!(
+            registration_decision(
+                false,
+                &perms(&["fs:watch"]),
+                &args(serde_json::json!({"fs:watch": ["~/a/**"]})),
+                Some(&consent)
+            ),
+            RegistrationDecision::Register
+        );
+    }
+
+    fn make_record(
+        id: &str,
+        is_built_in: bool,
+        enabled: bool,
+        permissions: Option<Vec<String>>,
+    ) -> ExtensionRecord {
+        ExtensionRecord {
+            manifest: ExtensionManifest {
+                id: id.into(),
+                name: id.into(),
+                version: "1.0.0".into(),
+                description: String::new(),
+                author: None,
+                extension_type: None,
+                background: None,
+                searchable: None,
+                icon: None,
+                commands: vec![],
+                permissions,
+                permission_args: None,
+                min_app_version: None,
+                asyar_sdk: None,
+                platforms: None,
+                preferences: None,
+                actions: None,
+                onboarding: None,
+                tools: None,
+            },
+            enabled,
+            is_built_in,
+            path: format!("/tmp/{id}"),
+            compatibility: CompatibilityStatus::Unknown,
+            first_view_component: None,
+        }
+    }
+
+    #[test]
+    fn grandfather_selection_skips_built_ins_disabled_and_permissionless() {
+        let records = vec![
+            make_record("ext.builtin", true, true, Some(vec!["network".into()])),
+            make_record("ext.disabled", false, false, Some(vec!["network".into()])),
+            make_record("ext.no-perms", false, true, None),
+            make_record("ext.empty-perms", false, true, Some(vec![])),
+            make_record("ext.keeper", false, true, Some(vec!["fs:watch".into()])),
+        ];
+        let selected = records_to_grandfather(&records);
+        let ids: Vec<&str> = selected.iter().map(|r| r.manifest.id.as_str()).collect();
+        assert_eq!(ids, vec!["ext.keeper"]);
+    }
+
+    #[test]
+    fn consent_record_serializes_camel_case() {
+        let record = ConsentRecord {
+            permissions: vec!["fs:watch".into()],
+            permission_args: args(serde_json::json!({"fs:watch": ["~/a/**"]})),
+            consented_at: 42,
+            grandfathered: true,
+        };
+        let value = serde_json::to_value(&record).unwrap();
+        assert!(value.get("permissionArgs").is_some());
+        assert!(value.get("consentedAt").is_some());
+        assert!(value.get("grandfathered").is_some());
+    }
+}

--- a/asyar-launcher/src-tauri/src/extensions/lifecycle.rs
+++ b/asyar-launcher/src-tauri/src/extensions/lifecycle.rs
@@ -74,6 +74,13 @@ pub(crate) fn uninstall(
                         }
                     }
                 }
+                if let Some(consent) = extensions.get_mut("consent") {
+                    if let Some(obj) = consent.as_object_mut() {
+                        if obj.remove(extension_id).is_some() {
+                            modified = true;
+                        }
+                    }
+                }
             }
             if modified {
                 store.set("settings", settings);
@@ -515,6 +522,15 @@ pub(crate) fn discover_all(
 
     // 4. Apply enabled/disabled state from store
     apply_extension_states(app_handle, &mut all_records)?;
+
+    // 4b. One-shot consent migration for extensions installed before the
+    // consent surface shipped. Runs after enabled state is applied so only
+    // actually-enabled extensions are grandfathered. Failure must not abort
+    // discovery — affected extensions degrade to the needs-consent path.
+    if let Err(e) = crate::extensions::consent::run_grandfather_migration(app_handle, &all_records)
+    {
+        warn!("Consent grandfather migration failed: {}", e);
+    }
 
     // 5. Order for display: built-ins first, then each group alphabetically.
     sort_extension_records(&mut all_records);

--- a/asyar-launcher/src-tauri/src/extensions/mod.rs
+++ b/asyar-launcher/src-tauri/src/extensions/mod.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Mutex;
 
+pub mod consent;
 pub mod discovery;
 pub mod extension_runtime;
 pub mod extension_state;

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -394,6 +394,7 @@ pub fn run() {
             permissions::check_extension_permission,
             extensions::consent::check_extension_consent,
             extensions::consent::set_extension_consent,
+            extensions::consent::revoke_extension_consent,
             commands::auth_initiate,
             commands::auth_poll,
             commands::auth_load_cached,

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -392,6 +392,8 @@ pub fn run() {
             commands::set_inline_emoji_fallback_enabled,
             permissions::register_extension_permissions,
             permissions::check_extension_permission,
+            extensions::consent::check_extension_consent,
+            extensions::consent::set_extension_consent,
             commands::auth_initiate,
             commands::auth_poll,
             commands::auth_load_cached,

--- a/asyar-launcher/src-tauri/src/permissions.rs
+++ b/asyar-launcher/src-tauri/src/permissions.rs
@@ -318,26 +318,79 @@ pub fn check_extension_permission(
     }
 }
 
+/// Outcome of a registration attempt, returned to the frontend loader.
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionRegistrationResult {
+    pub registered: bool,
+    pub needs_consent: bool,
+}
+
 /// Called by extensionManager.ts when an extension loads. Stores the extension's
 /// declared permission strings + their sidecar arguments so sensitive Rust
 /// commands can check them.
+///
+/// Consent backstop: the declared set only enters the registry when a covering
+/// consent record exists (see `extensions::consent`). Otherwise any stale
+/// entry is cleared and `needs_consent` is reported, so every gated call fails
+/// closed until the user accepts. The declared set is resolved from the
+/// discovered manifest when the extension is known — the caller-supplied
+/// values are only trusted when no discovery record exists.
 #[tauri::command]
 pub fn register_extension_permissions(
+    app_handle: tauri::AppHandle,
     extension_id: String,
     permissions: Vec<String>,
     permission_args: Option<serde_json::Map<String, serde_json::Value>>,
     registry: tauri::State<'_, ExtensionPermissionRegistry>,
-) -> Result<(), AppError> {
+    extensions: tauri::State<'_, crate::extensions::ExtensionRegistryState>,
+) -> Result<PermissionRegistrationResult, AppError> {
     if extension_id.trim().is_empty() {
         return Err(AppError::Validation(
             "extension_id cannot be empty".to_string(),
         ));
     }
-    let perms: HashSet<String> = permissions.into_iter().collect();
-    let args: HashMap<String, serde_json::Value> =
-        permission_args.unwrap_or_default().into_iter().collect();
-    registry.register(&extension_id, perms, args);
-    Ok(())
+
+    let (is_built_in, declared_perms, declared_args) = {
+        let reg = extensions.extensions.lock().map_err(|_| AppError::Lock)?;
+        match reg.get(&extension_id) {
+            Some(record) => (
+                record.is_built_in,
+                record.manifest.permissions.clone().unwrap_or_default(),
+                record.manifest.permission_args.clone().unwrap_or_default(),
+            ),
+            None => (false, permissions, permission_args.unwrap_or_default()),
+        }
+    };
+
+    let consent = crate::extensions::consent::get_consent(&app_handle, &extension_id)?;
+    match crate::extensions::consent::registration_decision(
+        is_built_in,
+        &declared_perms,
+        &declared_args,
+        consent.as_ref(),
+    ) {
+        crate::extensions::consent::RegistrationDecision::Register => {
+            let perms: HashSet<String> = declared_perms.into_iter().collect();
+            let args: HashMap<String, serde_json::Value> = declared_args.into_iter().collect();
+            registry.register(&extension_id, perms, args);
+            Ok(PermissionRegistrationResult {
+                registered: true,
+                needs_consent: false,
+            })
+        }
+        crate::extensions::consent::RegistrationDecision::WithholdNeedsConsent => {
+            registry.unregister(&extension_id);
+            log::warn!(
+                "Withholding permission registration for '{}': declared permissions exceed recorded consent",
+                extension_id
+            );
+            Ok(PermissionRegistrationResult {
+                registered: false,
+                needs_consent: true,
+            })
+        }
+    }
 }
 
 #[cfg(test)]

--- a/asyar-launcher/src/built-in-features/create-extension/ai-builder/finalizeBuild.test.ts
+++ b/asyar-launcher/src/built-in-features/create-extension/ai-builder/finalizeBuild.test.ts
@@ -10,6 +10,13 @@ vi.mock('asyar-sdk/contracts', () => ({
   },
 }));
 
+// Consent is exercised in permissionConsentService.test.ts; here it would
+// only drag the real logService (and its Tauri log invoke) into a node env.
+const ensureConsent = vi.fn().mockResolvedValue(true);
+vi.mock('../../../services/extension/permissionConsentService.svelte', () => ({
+  permissionConsentService: { ensureConsent },
+}));
+
 import { finalizeBuild } from './finalizeBuild';
 import { invoke } from '@tauri-apps/api/core';
 import { scanForSecret } from './secretGuard';
@@ -33,6 +40,7 @@ describe('finalizeBuild', () => {
       path: '/home/me/AsyarExtensions/com.x',
     });
     expect(reloadExtensions).toHaveBeenCalledOnce();
+    expect(ensureConsent).toHaveBeenCalledWith('com.x', 'com.x', 'install');
   });
 
   it('scans for the secret and still registers when the build is clean', async () => {
@@ -59,5 +67,6 @@ describe('finalizeBuild', () => {
     expect(result).toEqual({ leaked: true, path: '/ext/src/config.ts' });
     expect(invoke).not.toHaveBeenCalled();
     expect(reloadExtensions).not.toHaveBeenCalled();
+    expect(ensureConsent).not.toHaveBeenCalled();
   });
 });

--- a/asyar-launcher/src/built-in-features/create-extension/ai-builder/finalizeBuild.test.ts
+++ b/asyar-launcher/src/built-in-features/create-extension/ai-builder/finalizeBuild.test.ts
@@ -12,7 +12,9 @@ vi.mock('asyar-sdk/contracts', () => ({
 
 // Consent is exercised in permissionConsentService.test.ts; here it would
 // only drag the real logService (and its Tauri log invoke) into a node env.
-const ensureConsent = vi.fn().mockResolvedValue(true);
+const { ensureConsent } = vi.hoisted(() => ({
+  ensureConsent: vi.fn().mockResolvedValue(true),
+}));
 vi.mock('../../../services/extension/permissionConsentService.svelte', () => ({
   permissionConsentService: { ensureConsent },
 }));

--- a/asyar-launcher/src/built-in-features/create-extension/ai-builder/finalizeBuild.ts
+++ b/asyar-launcher/src/built-in-features/create-extension/ai-builder/finalizeBuild.ts
@@ -1,6 +1,7 @@
 import { registerDevExtension } from '../../../lib/ipc/commands';
 import { scanForSecret, type SecretScanResult } from './secretGuard';
 import { buildJobStore } from './buildJobStore.svelte';
+import { permissionConsentService } from '../../../services/extension/permissionConsentService.svelte';
 
 export async function finalizeBuild(path: string, extensionId: string): Promise<SecretScanResult> {
   const secret = buildJobStore.buildSecret;
@@ -14,5 +15,8 @@ export async function finalizeBuild(path: string, extensionId: string): Promise<
   }
   const { ExtensionManagerProxy } = await import('asyar-sdk/contracts');
   await new ExtensionManagerProxy().reloadExtensions();
+  // Dev extensions get the same consent treatment as store installs; no-op
+  // when the built manifest declares no permissions.
+  await permissionConsentService.ensureConsent(extensionId, extensionId, 'install');
   return { leaked: false };
 }

--- a/asyar-launcher/src/built-in-features/store/DetailView.svelte
+++ b/asyar-launcher/src/built-in-features/store/DetailView.svelte
@@ -18,6 +18,7 @@
   import storeExtension from './index.svelte';
   import { onMount } from 'svelte';
   import { extensionUpdateService } from '../../services/extension/extensionUpdateService.svelte';
+  import PermissionList from '../../components/settings/PermissionList.svelte';
 
   // Define structure for detailed API response
   interface ExtensionDetail {
@@ -67,6 +68,13 @@
   // Use reactive subscriptions to the store instance
   let currentSlug = $derived(store.selectedExtensionSlug);
   let extensionManager = $derived(store.extensionManager);
+
+  // The detail API doesn't include the manifest, but the store listing does —
+  // surface the declared permissions from the list item for this slug.
+  let listedManifest = $derived(
+    currentSlug ? store.allItems.find((item) => item.slug === currentSlug)?.manifest : undefined,
+  );
+  let listedPermissions = $derived(listedManifest?.permissions ?? []);
 
   $effect(() => {
     if (currentSlug) {
@@ -360,6 +368,18 @@
 
           <!-- Right Column: Meta & Versions -->
           <div class="space-y-8">
+            {#if listedPermissions.length > 0}
+              <section
+                class="bg-[var(--bg-secondary)] rounded-2xl p-6 border border-[var(--separator)]"
+              >
+                <h3 class="text-section mb-6">Permissions</h3>
+                <PermissionList
+                  permissions={listedPermissions}
+                  permissionArgs={listedManifest?.permissionArgs ?? {}}
+                />
+              </section>
+            {/if}
+
             <section
               class="bg-[var(--bg-secondary)] rounded-2xl p-6 border border-[var(--separator)]"
             >

--- a/asyar-launcher/src/built-in-features/store/DetailView.svelte
+++ b/asyar-launcher/src/built-in-features/store/DetailView.svelte
@@ -72,7 +72,7 @@
   // The detail API doesn't include the manifest, but the store listing does —
   // surface the declared permissions from the list item for this slug.
   let listedManifest = $derived(
-    currentSlug ? store.allItems.find((item) => item.slug === currentSlug)?.manifest : undefined,
+    currentSlug ? store?.allItems.find((item) => item.slug === currentSlug)?.manifest : undefined,
   );
   let listedPermissions = $derived(listedManifest?.permissions ?? []);
 

--- a/asyar-launcher/src/built-in-features/store/index.svelte.ts
+++ b/asyar-launcher/src/built-in-features/store/index.svelte.ts
@@ -16,6 +16,7 @@ import DefaultView from './DefaultView.svelte'; // Import component
 import DetailView from './DetailView.svelte'; // Import component
 import { actionService } from '../../services/action/actionService.svelte';
 import { extensionUpdateService } from '../../services/extension/extensionUpdateService.svelte';
+import { permissionConsentService } from '../../services/extension/permissionConsentService.svelte';
 import { filterCompatibleExtensions } from '../../lib/filterCompatibleExtensions';
 
 const EXTENSION_ID = 'store';
@@ -95,6 +96,28 @@ class StoreExtension implements Extension {
     const displayName = name || slug; // Use name if provided, otherwise slug
 
     const store = initializeStore();
+
+    // Permission consent gate: prompt from the store listing's manifest
+    // metadata before anything is downloaded. The packaged manifest is
+    // reconciled against this acceptance after install, so listing/package
+    // drift re-prompts rather than slipping through.
+    const listing = store?.allItems.find((item) => item.slug === slug);
+    const acceptedPermissions = listing?.manifest?.permissions ?? [];
+    const acceptedArgs = listing?.manifest?.permissionArgs ?? {};
+    if (acceptedPermissions.length > 0) {
+      const accepted = await permissionConsentService.requestConsent({
+        extensionId: extensionId.toString(),
+        extensionName: displayName,
+        reason: 'install',
+        permissions: acceptedPermissions,
+        permissionArgs: acceptedArgs,
+      });
+      if (!accepted) {
+        this.logService?.info(`Install of ${displayName} declined at permission consent`);
+        return;
+      }
+    }
+
     store?.setInstallingSlug(slug);
 
     this.logService?.info(`Install action triggered for slug: ${slug}`);
@@ -123,6 +146,17 @@ class StoreExtension implements Extension {
         throw new Error('Extension download URL is not available. Please try again.');
       }
 
+      // Persist the pre-install acceptance under the real manifest id before
+      // extensions reload, so the loader's registration finds a covering
+      // consent record instead of withholding.
+      if (acceptedPermissions.length > 0 && installInfo.extensionId) {
+        await commands.setExtensionConsent(
+          installInfo.extensionId,
+          acceptedPermissions,
+          acceptedArgs,
+        );
+      }
+
       // 2. Trigger installation via Tauri command
       this.logService?.info(
         `Invoking Tauri command 'install_extension_from_url' for ${displayName}`,
@@ -148,6 +182,17 @@ class StoreExtension implements Extension {
         await this.extensionManager?.reloadExtensions();
       } catch (err) {
         this.logService?.error(`Failed to reload extensions after install: ${err}`);
+      }
+
+      // Reconcile against the actual packaged manifest: if the package
+      // declares more than the store listing showed, this re-prompts with the
+      // real set; if the pre-install acceptance covers it, no prompt.
+      if (installInfo.extensionId) {
+        await permissionConsentService.ensureConsent(
+          installInfo.extensionId,
+          displayName,
+          'install',
+        );
       }
 
       const store = initializeStore();

--- a/asyar-launcher/src/built-in-features/store/state.svelte.ts
+++ b/asyar-launcher/src/built-in-features/store/state.svelte.ts
@@ -24,7 +24,11 @@ export interface ApiExtension {
   updated_at: string;
   last_polled_at: string | null;
   author: ExtensionAuthor;
-  manifest?: { platforms?: string[] };
+  manifest?: {
+    platforms?: string[];
+    permissions?: string[];
+    permissionArgs?: Record<string, unknown>;
+  };
 }
 
 // Search Engine handled in StoreViewStateClass

--- a/asyar-launcher/src/components/feedback/DialogHost.svelte
+++ b/asyar-launcher/src/components/feedback/DialogHost.svelte
@@ -1,7 +1,17 @@
 <script lang="ts">
   import { feedbackService } from '../../services/feedback/feedbackService.svelte';
+  import { permissionConsentService } from '../../services/extension/permissionConsentService.svelte';
   import ConfirmDialog from '../base/ConfirmDialog.svelte';
+  import PermissionConsentDialog from './PermissionConsentDialog.svelte';
 </script>
+
+{#if permissionConsentService.activeRequest}
+  <PermissionConsentDialog
+    request={permissionConsentService.activeRequest}
+    onAccept={() => permissionConsentService.onAccepted()}
+    onDecline={() => permissionConsentService.onDeclined()}
+  />
+{/if}
 
 {#if feedbackService.activeDialog}
   {@const dialog = feedbackService.activeDialog}

--- a/asyar-launcher/src/components/feedback/PermissionConsentDialog.svelte
+++ b/asyar-launcher/src/components/feedback/PermissionConsentDialog.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import Button from '../base/Button.svelte';
+  import PermissionList from '../settings/PermissionList.svelte';
+  import { fadeIn, popupScale } from '$lib/transitions';
+  import type { PermissionConsentRequest } from '../../services/extension/permissionConsentService.svelte';
+
+  let { request, onAccept, onDecline } = $props<{
+    request: PermissionConsentRequest;
+    onAccept: () => void;
+    onDecline: () => void;
+  }>();
+
+  const subtitle = $derived.by(() => {
+    switch (request.reason) {
+      case 'install':
+        return 'Installing it grants the following permissions:';
+      case 'enable':
+        return 'Enabling it grants the following permissions:';
+      case 'update':
+        return 'An update changed the permissions it requests:';
+      case 'review':
+        return 'Its requested permissions have changed and need your review:';
+    }
+  });
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      onDecline();
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      onAccept();
+    }
+  }
+
+  // Capture phase so this fires before all other keydown handlers.
+  onMount(() => {
+    window.addEventListener('keydown', handleKeydown, true);
+  });
+  onDestroy(() => {
+    window.removeEventListener('keydown', handleKeydown, true);
+  });
+</script>
+
+<div
+  class="fixed inset-0 dialog-backdrop flex items-center justify-center z-[200]"
+  onclick={(e) => e.target === e.currentTarget && onDecline()}
+  role="button"
+  tabindex="0"
+  onkeydown={(event) => (event.key === 'Enter' || event.key === ' ' ? onDecline() : null)}
+  transition:fadeIn={{ duration: 150 }}
+>
+  <div
+    class="bg-[var(--bg-primary)] rounded-lg shadow-lg w-full max-w-md overflow-hidden"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="permission-consent-title"
+    transition:popupScale={{ duration: 120 }}
+  >
+    <div class="p-6">
+      <h2
+        id="permission-consent-title"
+        class="text-xl font-semibold mb-2 text-[var(--text-primary)]"
+      >
+        {request.extensionName} requests permissions
+      </h2>
+      <p class="text-[var(--text-secondary)] text-sm mb-4">{subtitle}</p>
+
+      <div class="max-h-72 overflow-y-auto mb-6 pr-1">
+        <PermissionList permissions={request.permissions} permissionArgs={request.permissionArgs} />
+      </div>
+
+      <div class="flex justify-end gap-3">
+        <Button onclick={onDecline}>Cancel</Button>
+        <Button onclick={onAccept} class="btn-consent-primary">Allow</Button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .dialog-backdrop {
+    background: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(8px);
+  }
+
+  :global(html[data-platform='linux']) .dialog-backdrop {
+    backdrop-filter: none;
+    background: rgba(0, 0, 0, 0.6);
+  }
+
+  :global(.btn-consent-primary) {
+    background: var(--accent-primary) !important;
+    color: white !important;
+    border: none !important;
+  }
+
+  :global(.btn-consent-primary:hover) {
+    opacity: 0.9;
+  }
+</style>

--- a/asyar-launcher/src/components/feedback/PermissionConsentDialog.svelte
+++ b/asyar-launcher/src/components/feedback/PermissionConsentDialog.svelte
@@ -30,6 +30,15 @@
       event.stopImmediatePropagation();
       onDecline();
     } else if (event.key === 'Enter') {
+      // Let a keyboard-focused control's own activation win — otherwise
+      // Enter on a Tab-focused Cancel would accept the permissions.
+      const active = document.activeElement;
+      if (
+        active instanceof HTMLButtonElement ||
+        (active instanceof HTMLElement && active.getAttribute('role') === 'button')
+      ) {
+        return;
+      }
       event.preventDefault();
       event.stopImmediatePropagation();
       onAccept();

--- a/asyar-launcher/src/components/feedback/ToastHost.svelte
+++ b/asyar-launcher/src/components/feedback/ToastHost.svelte
@@ -24,14 +24,18 @@
 {#if feedbackService.activeToast}
   {@const toast = feedbackService.activeToast}
   {#if toast.onClick}
-    <button
-      class="toast-host toast-clickable"
-      transition:fadeIn={{ duration: 150 }}
-      data-style={toast.style}
-      onclick={() => feedbackService.onToastClicked()}
-    >
-      {@render toastBody(toast)}
-    </button>
+    <div class="toast-host toast-clickable" transition:fadeIn={{ duration: 150 }} data-style={toast.style}>
+      <button class="toast-action" onclick={() => feedbackService.onToastClicked()}>
+        {@render toastBody(toast)}
+      </button>
+      <button
+        class="toast-dismiss"
+        aria-label="Dismiss notification"
+        onclick={() => feedbackService.onToastDismissed()}
+      >
+        ✕
+      </button>
+    </div>
   {:else}
     <div
       class="toast-host"
@@ -70,17 +74,45 @@
     background-color: var(--bg-popup);
   }
 
-  /* Clickable variant renders as a <button>: undo UA styles, allow clicks. */
+  /* Actionable variant: body button runs the action, ✕ dismisses. */
   .toast-clickable {
     pointer-events: auto;
-    cursor: pointer;
-    font: inherit;
-    text-align: left;
-    color: inherit;
   }
 
   .toast-clickable:hover {
     border-color: var(--accent-primary);
+  }
+
+  .toast-action {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .toast-dismiss {
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    padding: 2px 5px;
+    border-radius: var(--radius-xs);
+    font-size: 11px;
+    line-height: 1;
+    color: var(--text-tertiary);
+    cursor: pointer;
+    transition: var(--transition-fast);
+  }
+
+  .toast-dismiss:hover {
+    color: var(--text-primary);
+    background: var(--bg-tertiary);
   }
 
   .toast-icon {

--- a/asyar-launcher/src/components/feedback/ToastHost.svelte
+++ b/asyar-launcher/src/components/feedback/ToastHost.svelte
@@ -26,7 +26,11 @@
 {#if feedbackService.activeToast}
   {@const toast = feedbackService.activeToast}
   {#if toast.onClick}
-    <div class="toast-host toast-clickable" transition:fadeIn={{ duration: 150 }} data-style={toast.style}>
+    <div
+      class="toast-host toast-clickable"
+      transition:fadeIn={{ duration: 150 }}
+      data-style={toast.style}
+    >
       <button class="toast-action" onclick={() => feedbackService.onToastClicked()}>
         {@render toastBody(toast)}
       </button>

--- a/asyar-launcher/src/components/feedback/ToastHost.svelte
+++ b/asyar-launcher/src/components/feedback/ToastHost.svelte
@@ -3,31 +3,46 @@
   import { fadeIn } from '$lib/transitions';
 </script>
 
+{#snippet toastBody(toast: NonNullable<typeof feedbackService.activeToast>)}
+  <span class="toast-icon" aria-hidden="true">
+    {#if toast.style === 'animated'}
+      <span class="spinner"></span>
+    {:else if toast.style === 'success'}
+      <span class="symbol">✓</span>
+    {:else if toast.style === 'failure'}
+      <span class="symbol">✕</span>
+    {/if}
+  </span>
+  <div class="toast-text">
+    <span class="toast-title">{toast.title}</span>
+    {#if toast.message}
+      <span class="toast-message">{toast.message}</span>
+    {/if}
+  </div>
+{/snippet}
+
 {#if feedbackService.activeToast}
   {@const toast = feedbackService.activeToast}
-  <div
-    class="toast-host"
-    role="status"
-    aria-live="polite"
-    transition:fadeIn={{ duration: 150 }}
-    data-style={toast.style}
-  >
-    <span class="toast-icon" aria-hidden="true">
-      {#if toast.style === 'animated'}
-        <span class="spinner"></span>
-      {:else if toast.style === 'success'}
-        <span class="symbol">✓</span>
-      {:else if toast.style === 'failure'}
-        <span class="symbol">✕</span>
-      {/if}
-    </span>
-    <div class="toast-text">
-      <span class="toast-title">{toast.title}</span>
-      {#if toast.message}
-        <span class="toast-message">{toast.message}</span>
-      {/if}
+  {#if toast.onClick}
+    <button
+      class="toast-host toast-clickable"
+      transition:fadeIn={{ duration: 150 }}
+      data-style={toast.style}
+      onclick={() => feedbackService.onToastClicked()}
+    >
+      {@render toastBody(toast)}
+    </button>
+  {:else}
+    <div
+      class="toast-host"
+      role="status"
+      aria-live="polite"
+      transition:fadeIn={{ duration: 150 }}
+      data-style={toast.style}
+    >
+      {@render toastBody(toast)}
     </div>
-  </div>
+  {/if}
 {/if}
 
 <style>
@@ -53,6 +68,19 @@
   :global(html[data-platform='linux']) .toast-host {
     backdrop-filter: none;
     background-color: var(--bg-popup);
+  }
+
+  /* Clickable variant renders as a <button>: undo UA styles, allow clicks. */
+  .toast-clickable {
+    pointer-events: auto;
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+    color: inherit;
+  }
+
+  .toast-clickable:hover {
+    border-color: var(--accent-primary);
   }
 
   .toast-icon {

--- a/asyar-launcher/src/components/feedback/ToastHost.svelte
+++ b/asyar-launcher/src/components/feedback/ToastHost.svelte
@@ -11,6 +11,8 @@
       <span class="symbol">✓</span>
     {:else if toast.style === 'failure'}
       <span class="symbol">✕</span>
+    {:else if toast.style === 'warning'}
+      <span class="symbol">!</span>
     {/if}
   </span>
   <div class="toast-text">
@@ -133,6 +135,9 @@
   .toast-host[data-style='failure'] .toast-icon {
     color: var(--accent-danger);
   }
+  .toast-host[data-style='warning'] .toast-icon {
+    color: var(--accent-warning);
+  }
 
   .toast-text {
     display: flex;
@@ -156,6 +161,9 @@
   }
   .toast-host[data-style='failure'] .toast-title {
     color: var(--accent-danger);
+  }
+  .toast-host[data-style='warning'] .toast-title {
+    color: var(--accent-warning);
   }
 
   .toast-message {

--- a/asyar-launcher/src/components/settings/ExtensionDetailPanel.svelte
+++ b/asyar-launcher/src/components/settings/ExtensionDetailPanel.svelte
@@ -2,11 +2,14 @@
   import Badge from '../base/Badge.svelte';
   import Toggle from '../base/Toggle.svelte';
   import ExtensionPreferencesForm from './ExtensionPreferencesForm.svelte';
+  import PermissionList from './PermissionList.svelte';
   import type { ExtensionItem } from '../../routes/settings/settingsHandlers.svelte';
   import type { ExtensionCommand } from 'asyar-sdk/contracts';
   import { extensionPreferencesService } from '../../services/extension/extensionPreferencesService.svelte';
+  import { permissionConsentService } from '../../services/extension/permissionConsentService.svelte';
   import { diagnosticsService } from '../../services/diagnostics/diagnosticsService.svelte';
   import { logService } from '../../services/log/logService';
+  import * as commands from '../../lib/ipc/commands';
 
   let {
     extension = null,
@@ -33,6 +36,31 @@
 
   let preferenceValues = $state<Record<string, any>>({});
   let isLoadingPrefs = $state(false);
+  let needsPermissionReview = $state(false);
+
+  // Consent status is re-derived per selection via IPC: the settings window
+  // is a separate webview, so it cannot see the main window's in-memory
+  // needs-review state — but the Rust registry it queries is global.
+  $effect(() => {
+    const ext = extension;
+    needsPermissionReview = false;
+    if (ext?.id && !ext.isBuiltIn && (ext.permissions?.length ?? 0) > 0) {
+      commands.checkExtensionConsent(ext.id).then((status) => {
+        if (extension?.id === ext.id) {
+          needsPermissionReview = status?.needsConsent ?? false;
+        }
+      });
+    }
+  });
+
+  async function reviewPermissions() {
+    const ext = extension;
+    if (!ext?.id) return;
+    const accepted = await permissionConsentService.ensureConsent(ext.id, ext.title, 'review');
+    if (accepted && extension?.id === ext.id) {
+      needsPermissionReview = false;
+    }
+  }
 
   // Load preferences when selection changes OR when preferencesVersion bumps.
   // Reading `preferencesVersion` inside the effect makes it a reactive
@@ -184,7 +212,25 @@
       {#if extension.compatibility?.status === 'platformNotSupported'}
         <Badge text="{extension.compatibility.platform} not supported" variant="danger" />
       {/if}
+      {#if needsPermissionReview}
+        <Badge text="Permissions need review" variant="danger" />
+      {/if}
     </div>
+
+    {#if !extension.isBuiltIn && extension.permissions && extension.permissions.length > 0}
+      <div class="panel-section">
+        <div class="section-header flex-header">
+          <span>Permissions</span>
+          {#if needsPermissionReview}
+            <button class="review-link" onclick={reviewPermissions}>Review permissions</button>
+          {/if}
+        </div>
+        <PermissionList
+          permissions={extension.permissions}
+          permissionArgs={extension.permissionArgs ?? {}}
+        />
+      </div>
+    {/if}
 
     {#if extension.preferences && extension.preferences.length > 0}
       <div class="panel-section">
@@ -316,6 +362,20 @@
 
   .reset-link:hover {
     color: var(--accent-danger);
+    text-decoration: underline;
+  }
+
+  .review-link {
+    font-size: 10px;
+    color: var(--accent-danger);
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    transition: var(--transition-fast);
+  }
+
+  .review-link:hover {
     text-decoration: underline;
   }
 

--- a/asyar-launcher/src/components/settings/ExtensionDetailPanel.svelte
+++ b/asyar-launcher/src/components/settings/ExtensionDetailPanel.svelte
@@ -41,7 +41,11 @@
   // Consent status is re-derived per selection via IPC: the settings window
   // is a separate webview, so it cannot see the main window's in-memory
   // needs-review state — but the Rust registry it queries is global.
+  // consentVersion re-runs this after an acceptance recorded outside this
+  // panel (e.g. the enable-toggle flow), so the badge clears immediately.
   $effect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    permissionConsentService.consentVersion; // touch to subscribe
     const ext = extension;
     needsPermissionReview = false;
     if (ext?.id && !ext.isBuiltIn && (ext.permissions?.length ?? 0) > 0) {

--- a/asyar-launcher/src/components/settings/ExtensionDetailPanel.svelte
+++ b/asyar-launcher/src/components/settings/ExtensionDetailPanel.svelte
@@ -7,6 +7,7 @@
   import type { ExtensionCommand } from 'asyar-sdk/contracts';
   import { extensionPreferencesService } from '../../services/extension/extensionPreferencesService.svelte';
   import { permissionConsentService } from '../../services/extension/permissionConsentService.svelte';
+  import { feedbackService } from '../../services/feedback/feedbackService.svelte';
   import { diagnosticsService } from '../../services/diagnostics/diagnosticsService.svelte';
   import { logService } from '../../services/log/logService';
   import * as commands from '../../lib/ipc/commands';
@@ -63,6 +64,25 @@
     const accepted = await permissionConsentService.ensureConsent(ext.id, ext.title, 'review');
     if (accepted && extension?.id === ext.id) {
       needsPermissionReview = false;
+    }
+  }
+
+  // Revoking withdraws consent without uninstalling — the extension stays
+  // installed and enabled, but its gated calls fail closed until the user
+  // reviews and re-allows via reviewPermissions() above.
+  async function revokePermissions() {
+    const ext = extension;
+    if (!ext?.id) return;
+    const confirmed = await feedbackService.confirmAlert({
+      title: 'Revoke Permissions',
+      message: `"${ext.title}" will lose access to its granted permissions until you review and re-allow them. It stays installed and enabled.`,
+      confirmText: 'Revoke',
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+    const revoked = await permissionConsentService.revoke(ext.id);
+    if (revoked && extension?.id === ext.id) {
+      needsPermissionReview = true;
     }
   }
 
@@ -227,6 +247,8 @@
           <span>Permissions</span>
           {#if needsPermissionReview}
             <button class="review-link" onclick={reviewPermissions}>Review permissions</button>
+          {:else}
+            <button class="revoke-link" onclick={revokePermissions}>Revoke</button>
           {/if}
         </div>
         <PermissionList
@@ -380,6 +402,20 @@
   }
 
   .review-link:hover {
+    text-decoration: underline;
+  }
+
+  .revoke-link {
+    font-size: 10px;
+    color: var(--accent-danger);
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    transition: var(--transition-fast);
+  }
+
+  .revoke-link:hover {
     text-decoration: underline;
   }
 

--- a/asyar-launcher/src/components/settings/PermissionList.svelte
+++ b/asyar-launcher/src/components/settings/PermissionList.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import { describePermission } from '../../services/extension/permissionCatalog';
+
+  let { permissions, permissionArgs = {} } = $props<{
+    permissions: string[];
+    permissionArgs?: Record<string, unknown>;
+  }>();
+
+  function argsFor(permission: string): { chips: string[] | null; json: string | null } {
+    const value = permissionArgs?.[permission];
+    if (value === undefined || value === null) return { chips: null, json: null };
+    if (Array.isArray(value) && value.every((item) => typeof item === 'string')) {
+      return { chips: value as string[], json: null };
+    }
+    return { chips: null, json: JSON.stringify(value, null, 2) };
+  }
+</script>
+
+<ul class="flex flex-col gap-3">
+  {#each permissions as permission (permission)}
+    {@const info = describePermission(permission)}
+    {@const args = argsFor(permission)}
+    <li class="flex flex-col gap-1">
+      <div class="flex items-baseline gap-2 flex-wrap">
+        <span class="text-sm font-medium text-[var(--text-primary)]">{info.title}</span>
+        <code class="font-mono text-xs text-[var(--text-secondary)]">{permission}</code>
+      </div>
+      <p class="text-xs text-[var(--text-secondary)]">
+        {info.description}
+        {#if !info.known}
+          <span class="permission-caution">⚠️ Review carefully before allowing.</span>
+        {/if}
+      </p>
+      {#if args.chips}
+        <div class="flex flex-wrap gap-1">
+          {#each args.chips as chip (chip)}
+            <code class="permission-arg-chip font-mono text-xs">{chip}</code>
+          {/each}
+        </div>
+      {:else if args.json}
+        <pre class="permission-arg-json font-mono text-xs overflow-x-auto">{args.json}</pre>
+      {/if}
+    </li>
+  {/each}
+</ul>
+
+<style>
+  .permission-arg-chip,
+  .permission-arg-json {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color, transparent);
+    border-radius: 4px;
+    padding: 1px 6px;
+    color: var(--text-primary);
+    word-break: break-all;
+  }
+
+  .permission-arg-json {
+    padding: 6px 8px;
+    white-space: pre;
+  }
+
+  .permission-caution {
+    color: var(--accent-danger);
+  }
+</style>

--- a/asyar-launcher/src/lib/ipc/commands.ts
+++ b/asyar-launcher/src/lib/ipc/commands.ts
@@ -1027,12 +1027,49 @@ export interface PermissionCheckResult {
   reason?: string;
 }
 
+export interface PermissionRegistrationResult {
+  registered: boolean;
+  needsConsent: boolean;
+}
+
+export interface ExtensionConsentRecord {
+  permissions: string[];
+  permissionArgs: Record<string, unknown>;
+  consentedAt: number;
+  grandfathered: boolean;
+}
+
+export interface ExtensionConsentStatus {
+  needsConsent: boolean;
+  declaredPermissions: string[];
+  declaredArgs: Record<string, unknown>;
+  consented: ExtensionConsentRecord | null;
+}
+
 export async function registerExtensionPermissions(
   extensionId: string,
   permissions: string[],
   permissionArgs?: Record<string, unknown> | null,
+): Promise<PermissionRegistrationResult | null> {
+  return invokeSafe<PermissionRegistrationResult>('register_extension_permissions', {
+    extensionId,
+    permissions,
+    permissionArgs: permissionArgs ?? null,
+  });
+}
+
+export async function checkExtensionConsent(
+  extensionId: string,
+): Promise<ExtensionConsentStatus | null> {
+  return invokeSafe<ExtensionConsentStatus>('check_extension_consent', { extensionId });
+}
+
+export async function setExtensionConsent(
+  extensionId: string,
+  permissions: string[],
+  permissionArgs?: Record<string, unknown> | null,
 ): Promise<void> {
-  await invokeSafe('register_extension_permissions', {
+  await invokeSafe('set_extension_consent', {
     extensionId,
     permissions,
     permissionArgs: permissionArgs ?? null,

--- a/asyar-launcher/src/lib/ipc/commands.ts
+++ b/asyar-launcher/src/lib/ipc/commands.ts
@@ -276,7 +276,7 @@ export async function factoryReset(): Promise<void> {
   await invokeSafe('factory_reset');
 }
 
-export async function showSettingsWindow(tab?: string): Promise<void> {
+export async function showSettingsWindow(tab?: string, extensionId?: string): Promise<void> {
   // Direct callers bypass the no-view command hide path, so reset here too.
   // Dynamic import breaks the commands ↔ extensionManager module cycle.
   const { resetLauncherState } = await import('../launcher/launcherReset');
@@ -291,7 +291,10 @@ export async function showSettingsWindow(tab?: string): Promise<void> {
       const { emit } = await import('@tauri-apps/api/event');
       // Delay ensures the settings window's onMount listener is registered
       // before the event fires (relevant when the window was hidden/just shown).
-      setTimeout(() => emit('asyar:navigate-settings-tab', { tab }), 50);
+      setTimeout(
+        () => emit('asyar:navigate-settings-tab', { tab, extensionId: extensionId ?? null }),
+        50,
+      );
     }
   }
 }

--- a/asyar-launcher/src/lib/ipc/commands.ts
+++ b/asyar-launcher/src/lib/ipc/commands.ts
@@ -1079,6 +1079,16 @@ export async function setExtensionConsent(
   });
 }
 
+/**
+ * Withdraw a previously-granted consent record (Settings → Extensions
+ * "Revoke" action). The extension stays installed/enabled; its permissions
+ * are unregistered immediately, so gated calls fail closed without a
+ * restart. Returns whether the IPC call itself succeeded.
+ */
+export async function revokeExtensionConsent(extensionId: string): Promise<boolean> {
+  return invokeSafeVoid('revoke_extension_consent', { extensionId });
+}
+
 export async function checkExtensionPermission(
   extensionId: string,
   callType: string,

--- a/asyar-launcher/src/routes/settings/+page.svelte
+++ b/asyar-launcher/src/routes/settings/+page.svelte
@@ -58,9 +58,15 @@
     await initValidKeys();
     registerProfileProviders();
     cloudSyncService.checkStatus().catch(() => {});
-    unlistenNavTab = await listen<{ tab: string }>('asyar:navigate-settings-tab', (e) => {
-      handler.activeTab = e.payload.tab;
-    });
+    unlistenNavTab = await listen<{ tab: string; extensionId?: string | null }>(
+      'asyar:navigate-settings-tab',
+      (e) => {
+        handler.activeTab = e.payload.tab;
+        if (e.payload.extensionId) {
+          handler.pendingExtensionSelection = e.payload.extensionId;
+        }
+      },
+    );
   });
 
   onDestroy(() => {

--- a/asyar-launcher/src/routes/settings/settingsHandlers.svelte.ts
+++ b/asyar-launcher/src/routes/settings/settingsHandlers.svelte.ts
@@ -9,6 +9,7 @@ import extensionManager from '../../services/extension/extensionManager.svelte';
 import { extensionStateManager } from '../../services/extension/extensionStateManager.svelte';
 import { extensionPreferencesService } from '../../services/extension/extensionPreferencesService.svelte';
 import { feedbackService } from '../../services/feedback/feedbackService.svelte';
+import { permissionConsentService } from '../../services/extension/permissionConsentService.svelte';
 import type { AppSettings } from '../../services/settings/types/AppSettingsType';
 import { logService } from '../../services/log/logService';
 import type { CompatibilityStatus } from '../../types/CompatibilityStatus';
@@ -29,6 +30,8 @@ export interface ExtensionItem {
   commands?: ExtensionCommand[];
   preferences?: any[];
   isBuiltIn?: boolean;
+  permissions?: string[];
+  permissionArgs?: Record<string, unknown>;
 }
 
 // Initialize with default settings first
@@ -279,6 +282,17 @@ export class SettingsHandler {
     const newState = !extension.enabled;
 
     try {
+      // Enabling grants the declared permission set — require consent first.
+      // No-op when a covering consent record exists or nothing is declared.
+      if (newState && !extension.isBuiltIn && extension.id) {
+        const consented = await permissionConsentService.ensureConsent(
+          extension.id,
+          extension.title,
+          'enable',
+        );
+        if (!consented) return;
+      }
+
       const success = await extensionManager.toggleExtensionState(extension.title, newState);
 
       if (success) {

--- a/asyar-launcher/src/routes/settings/settingsHandlers.svelte.ts
+++ b/asyar-launcher/src/routes/settings/settingsHandlers.svelte.ts
@@ -122,6 +122,11 @@ export class SettingsHandler {
   isLoadingExtensions = $state(false);
   extensionError = $state('');
   togglingExtension = $state<string | null>(null);
+  /**
+   * Extension id a deep link (asyar:navigate-settings-tab) asked to select.
+   * Consumed and cleared by ExtensionsTab once the list is loaded.
+   */
+  pendingExtensionSelection = $state<string | null>(null);
 
   private unsubscribe: (() => void) | null = null;
   private unlistenPreferencesChanged: (() => void) | null = null;

--- a/asyar-launcher/src/routes/settings/tabs/ExtensionsTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/ExtensionsTab.svelte
@@ -216,6 +216,20 @@
     selectedCommandId = null;
   }
 
+  // Deep-link selection (asyar:navigate-settings-tab with an extensionId,
+  // e.g. from the needs-permission-review toast). Waits for the list to load,
+  // then consumes the pending id exactly once.
+  $effect(() => {
+    const pending = handler.pendingExtensionSelection;
+    if (!pending || handler.isLoadingExtensions) return;
+    if (handler.extensions.length === 0) return;
+    const ext = handler.extensions.find((e) => (e.id ?? e.title) === pending);
+    if (ext) {
+      selectExtension(ext);
+    }
+    handler.pendingExtensionSelection = null;
+  });
+
   function selectCommand(ext: ExtensionItem, cmd: ExtensionCommand) {
     selectedExtensionId = ext.id ?? ext.title;
     selectedCommandId = cmd.id;

--- a/asyar-launcher/src/services/extension/ExtensionLoader.ts
+++ b/asyar-launcher/src/services/extension/ExtensionLoader.ts
@@ -143,10 +143,11 @@ export class ExtensionLoader {
             logService.warn(
               `[PermissionRegistry] Permissions withheld for ${extensionId}: awaiting user consent`,
             );
-            void feedbackService.showToast({
-              title: `${extensionName} needs a permission review`,
-              message: 'Open Settings → Extensions to review and allow its permissions.',
-            });
+            feedbackService.notice(
+              `${extensionName} needs a permission review`,
+              'Open Settings → Extensions to review and allow its permissions.',
+              'failure',
+            );
           })
           .catch((err: unknown) => {
             logService.warn(`[PermissionRegistry] Failed to register ${extensionId}: ${err}`);

--- a/asyar-launcher/src/services/extension/ExtensionLoader.ts
+++ b/asyar-launcher/src/services/extension/ExtensionLoader.ts
@@ -170,7 +170,7 @@ export class ExtensionLoader {
               feedbackService.notice({
                 title: `${extensionName} needs a permission review`,
                 message: 'Click to review and allow its permissions in Settings.',
-                style: 'failure',
+                style: 'warning',
                 onClick: () => void commands.showSettingsWindow('extensions', extensionId),
               }),
             );

--- a/asyar-launcher/src/services/extension/ExtensionLoader.ts
+++ b/asyar-launcher/src/services/extension/ExtensionLoader.ts
@@ -10,6 +10,8 @@ import * as commands from '../../lib/ipc/commands';
 import { dispatch } from './extensionDispatcher.svelte';
 import { onboardingViewInterception } from './onboardingViewInterception';
 import { extensionPreferencesService } from './extensionPreferencesService.svelte';
+import { permissionConsentService } from './permissionConsentService.svelte';
+import { feedbackService } from '../feedback/feedbackService.svelte';
 import { actionService } from '../action/actionService.svelte';
 import { searchOrchestrator } from '../search/searchOrchestrator.svelte';
 import { searchStores } from '../search/stores/search.svelte';
@@ -122,14 +124,30 @@ export class ExtensionLoader {
         // Sync declared permissions + their sidecar args to the Rust registry
         // for defense-in-depth enforcement. `permissionArgs` carries glob
         // patterns for fs:watch (and will grow to host other parameterized
-        // permissions as they land).
+        // permissions as they land). Rust withholds registration when the
+        // declared set exceeds the recorded user consent (e.g. an update added
+        // permissions); the extension still loads, but its gated calls fail
+        // closed until the user reviews in Settings → Extensions.
         const extended = manifest as ExtendedManifest;
+        const extensionName = manifest.name;
         commands
           .registerExtensionPermissions(
             extensionId,
             extended.permissions ?? [],
             extended.permissionArgs ?? null,
           )
+          .then((result) => {
+            if (!result?.needsConsent) return;
+            if (permissionConsentService.needsReview.includes(extensionId)) return;
+            permissionConsentService.markNeedsReview(extensionId);
+            logService.warn(
+              `[PermissionRegistry] Permissions withheld for ${extensionId}: awaiting user consent`,
+            );
+            void feedbackService.showToast({
+              title: `${extensionName} needs a permission review`,
+              message: 'Open Settings → Extensions to review and allow its permissions.',
+            });
+          })
           .catch((err: unknown) => {
             logService.warn(`[PermissionRegistry] Failed to register ${extensionId}: ${err}`);
           });

--- a/asyar-launcher/src/services/extension/ExtensionLoader.ts
+++ b/asyar-launcher/src/services/extension/ExtensionLoader.ts
@@ -1,3 +1,4 @@
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import { ExtensionBridge, ActionContext } from 'asyar-sdk/contracts';
 import type { Extension, ExtensionManifest, ExtensionCommand } from 'asyar-sdk/contracts';
 import type { ExtendedManifest } from '../../types/ExtendedManifest';
@@ -23,23 +24,25 @@ import { searchStores } from '../search/stores/search.svelte';
 type LoadedExtensionModule = Extension | { default: Extension };
 
 /**
- * Run `show` once the launcher window is visible. Extensions load at startup
- * while the window is still hidden — a toast fired then burns its auto-dismiss
- * timer with nobody watching. Hidden Tauri windows report
- * `document.visibilityState === 'hidden'`, so defer until the next reveal.
+ * Run `show` once the launcher window has the user's attention. Extensions
+ * load at startup while the launcher window is still hidden — a toast fired
+ * then burns its auto-dismiss timer with nobody watching. `onFocusChanged`
+ * is the signal the usage heartbeat already relies on for "the user summoned
+ * the launcher" (the webview's visibilityState is not dependable here).
  */
 function whenWindowVisible(show: () => void): void {
-  if (typeof document === 'undefined' || document.visibilityState === 'visible') {
+  if (typeof document !== 'undefined' && document.hasFocus()) {
     show();
     return;
   }
-  const onVisible = () => {
-    if (document.visibilityState === 'visible') {
-      document.removeEventListener('visibilitychange', onVisible);
+  const promise = getCurrentWindow().onFocusChanged(({ payload: focused }) => {
+    if (focused) {
+      void promise.then((unlisten) => unlisten()).catch(() => {});
       show();
     }
-  };
-  document.addEventListener('visibilitychange', onVisible);
+  });
+  // If the listener can't attach, show now rather than never.
+  promise.catch(() => show());
 }
 
 export class ExtensionLoader {

--- a/asyar-launcher/src/services/extension/ExtensionLoader.ts
+++ b/asyar-launcher/src/services/extension/ExtensionLoader.ts
@@ -22,6 +22,26 @@ import { searchStores } from '../search/stores/search.svelte';
  */
 type LoadedExtensionModule = Extension | { default: Extension };
 
+/**
+ * Run `show` once the launcher window is visible. Extensions load at startup
+ * while the window is still hidden — a toast fired then burns its auto-dismiss
+ * timer with nobody watching. Hidden Tauri windows report
+ * `document.visibilityState === 'hidden'`, so defer until the next reveal.
+ */
+function whenWindowVisible(show: () => void): void {
+  if (typeof document === 'undefined' || document.visibilityState === 'visible') {
+    show();
+    return;
+  }
+  const onVisible = () => {
+    if (document.visibilityState === 'visible') {
+      document.removeEventListener('visibilitychange', onVisible);
+      show();
+    }
+  };
+  document.addEventListener('visibilitychange', onVisible);
+}
+
 export class ExtensionLoader {
   // Internal state built during loadExtensions()
   private extensionModulesById = new Map<string, LoadedExtensionModule>();
@@ -143,10 +163,12 @@ export class ExtensionLoader {
             logService.warn(
               `[PermissionRegistry] Permissions withheld for ${extensionId}: awaiting user consent`,
             );
-            feedbackService.notice(
-              `${extensionName} needs a permission review`,
-              'Open Settings → Extensions to review and allow its permissions.',
-              'failure',
+            whenWindowVisible(() =>
+              feedbackService.notice(
+                `${extensionName} needs a permission review`,
+                'Open Settings → Extensions to review and allow its permissions.',
+                'failure',
+              ),
             );
           })
           .catch((err: unknown) => {

--- a/asyar-launcher/src/services/extension/ExtensionLoader.ts
+++ b/asyar-launcher/src/services/extension/ExtensionLoader.ts
@@ -167,11 +167,12 @@ export class ExtensionLoader {
               `[PermissionRegistry] Permissions withheld for ${extensionId}: awaiting user consent`,
             );
             whenWindowVisible(() =>
-              feedbackService.notice(
-                `${extensionName} needs a permission review`,
-                'Open Settings → Extensions to review and allow its permissions.',
-                'failure',
-              ),
+              feedbackService.notice({
+                title: `${extensionName} needs a permission review`,
+                message: 'Click to review and allow its permissions in Settings.',
+                style: 'failure',
+                onClick: () => void commands.showSettingsWindow('extensions', extensionId),
+              }),
             );
           })
           .catch((err: unknown) => {

--- a/asyar-launcher/src/services/extension/extensionStateManager.svelte.ts
+++ b/asyar-launcher/src/services/extension/extensionStateManager.svelte.ts
@@ -74,6 +74,8 @@ export class ExtensionStateManager {
           compatibility: record.compatibility,
           commands: manifest.commands ?? [],
           preferences: manifest.preferences ?? [],
+          permissions: (manifest as ExtendedManifest).permissions ?? [],
+          permissionArgs: (manifest as ExtendedManifest).permissionArgs ?? {},
         });
       }
       // Ordering (built-in first, then alphabetical) is computed by Rust's

--- a/asyar-launcher/src/services/extension/extensionUpdateService.svelte.ts
+++ b/asyar-launcher/src/services/extension/extensionUpdateService.svelte.ts
@@ -1,6 +1,7 @@
 import * as commands from '../../lib/ipc/commands';
 import { envService } from '../envService';
 import { logService } from '../log/logService';
+import { permissionConsentService } from './permissionConsentService.svelte';
 import { settingsService } from '../settings/settingsService.svelte';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import type { AvailableUpdate, UpdateProgressStatus } from '../../types/ExtensionUpdate';
@@ -148,6 +149,9 @@ class ExtensionUpdateService {
         (u) => u.extensionId !== update.extensionId,
       );
       await reloadCallback();
+      // Prompts only when the update grew the declared permission set beyond
+      // the recorded consent; acceptance re-registers without a restart.
+      await permissionConsentService.ensureConsent(update.extensionId, update.name, 'update');
       return true;
     } catch (e: any) {
       logService.error(`Failed to update ${update.extensionId}: ${e}`);
@@ -171,8 +175,14 @@ class ExtensionUpdateService {
         return;
       }
       const failedIds = new Set(results.filter(([, r]) => r.Err).map(([id]) => id));
+      const updated = this.availableUpdates.filter((u) => !failedIds.has(u.extensionId));
       this.availableUpdates = this.availableUpdates.filter((u) => failedIds.has(u.extensionId));
       await reloadCallback();
+      // Consent prompts queue FIFO; only extensions whose declared set grew
+      // beyond recorded consent actually prompt.
+      for (const u of updated) {
+        await permissionConsentService.ensureConsent(u.extensionId, u.name, 'update');
+      }
     } catch (e: any) {
       logService.error(`Failed to update all extensions: ${e}`);
     } finally {

--- a/asyar-launcher/src/services/extension/permissionCatalog.test.ts
+++ b/asyar-launcher/src/services/extension/permissionCatalog.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { PERMISSION_CATALOG, describePermission } from './permissionCatalog';
+
+describe('permissionCatalog', () => {
+  it('describes a known permission with catalog metadata', () => {
+    const info = describePermission('fs:watch');
+    expect(info.known).toBe(true);
+    expect(info.title).toBe(PERMISSION_CATALOG['fs:watch'].title);
+    expect(info.description.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to the raw string for unknown permissions', () => {
+    const info = describePermission('quantum:entangle');
+    expect(info.known).toBe(false);
+    expect(info.title).toBe('quantum:entangle');
+  });
+
+  it('covers every permission the Rust gate can require', () => {
+    // Mirror of the permission strings mapped in src-tauri/src/permissions.rs
+    // get_required_permission. If this fails, a permission became requirable
+    // without display copy — add it to PERMISSION_CATALOG.
+    const gatedPermissions = [
+      'clipboard:read',
+      'clipboard:write',
+      'notifications:send',
+      'network',
+      'shell:open-url',
+      'fs:read',
+      'fs:write',
+      'fs:watch',
+      'shell:spawn',
+      'entitlements:read',
+      'storage:read',
+      'storage:write',
+      'cache:read',
+      'cache:write',
+      'selection:read',
+      'ai:use',
+      'oauth:use',
+      'extension:invoke',
+      'application:read',
+      'window:manage',
+      'preferences:read',
+      'preferences:write',
+      'power:inhibit',
+      'process:read',
+      'process:kill',
+      'systemEvents:read',
+      'app:frontmost-watch',
+      'timers:schedule',
+      'timers:cancel',
+      'timers:list',
+      'snippets:contribute',
+      'browser:tabs.read',
+      'browser:tabs.write',
+      'browser:bookmarks.read',
+      'browser:history.read',
+      'browser:page.read',
+      'browser:page.write',
+      'files:search',
+    ];
+    for (const permission of gatedPermissions) {
+      expect(describePermission(permission).known, `missing catalog entry: ${permission}`).toBe(
+        true,
+      );
+    }
+  });
+});

--- a/asyar-launcher/src/services/extension/permissionCatalog.ts
+++ b/asyar-launcher/src/services/extension/permissionCatalog.ts
@@ -68,8 +68,7 @@ export const PERMISSION_CATALOG: Record<string, PermissionInfo> = {
   },
   'files:search': {
     title: 'Search local files',
-    description:
-      'Search the local file index (file names and metadata, not file contents).',
+    description: 'Search the local file index (file names and metadata, not file contents).',
   },
   'shell:spawn': {
     title: 'Run programs',
@@ -106,7 +105,8 @@ export const PERMISSION_CATALOG: Record<string, PermissionInfo> = {
   },
   'window:manage': {
     title: 'Manage windows',
-    description: 'Read and change the position, size, and fullscreen state of the frontmost window.',
+    description:
+      'Read and change the position, size, and fullscreen state of the frontmost window.',
   },
   'power:inhibit': {
     title: 'Keep system awake',

--- a/asyar-launcher/src/services/extension/permissionCatalog.ts
+++ b/asyar-launcher/src/services/extension/permissionCatalog.ts
@@ -1,0 +1,209 @@
+/**
+ * Human-readable display metadata for manifest permission strings, used by the
+ * consent dialog and the read-only permission lists in settings and the store.
+ *
+ * Descriptions are derived from `docs/reference/permissions.md`. Permission
+ * strings not in the catalog (a newer launcher's permission, or a typo in a
+ * manifest) render with the raw string and `known: false` so the UI can show a
+ * caution note instead of silently pretending to understand them.
+ */
+
+export interface PermissionInfo {
+  title: string;
+  description: string;
+}
+
+export const PERMISSION_CATALOG: Record<string, PermissionInfo> = {
+  network: {
+    title: 'Network access',
+    description: 'Make outbound HTTP requests.',
+  },
+  'notifications:send': {
+    title: 'Send notifications',
+    description: 'Post notifications to the system notification center.',
+  },
+  'clipboard:read': {
+    title: 'Read clipboard',
+    description: 'Read current clipboard content and clipboard history.',
+  },
+  'clipboard:write': {
+    title: 'Write clipboard',
+    description: 'Write, paste, and manage clipboard content.',
+  },
+  'storage:read': {
+    title: 'Read extension storage',
+    description: "Read from the extension's own key-value store.",
+  },
+  'storage:write': {
+    title: 'Write extension storage',
+    description: "Write to the extension's own key-value store.",
+  },
+  'store:read': {
+    title: 'Read extension store data',
+    description: "Read from the extension's data store.",
+  },
+  'store:write': {
+    title: 'Write extension store data',
+    description: "Write to the extension's data store.",
+  },
+  'cache:read': {
+    title: 'Read extension cache',
+    description: "Read from the extension's cache.",
+  },
+  'cache:write': {
+    title: 'Write extension cache',
+    description: "Write to the extension's cache.",
+  },
+  'fs:read': {
+    title: 'Reveal files',
+    description: 'Show files in the system file manager.',
+  },
+  'fs:write': {
+    title: 'Move files to trash',
+    description: 'Move files to the system trash.',
+  },
+  'fs:watch': {
+    title: 'Watch files',
+    description: 'Observe filesystem changes under the declared glob patterns.',
+  },
+  'files:search': {
+    title: 'Search local files',
+    description:
+      'Search the local file index (file names and metadata, not file contents).',
+  },
+  'shell:spawn': {
+    title: 'Run programs',
+    description: 'Spawn OS processes and read their output. Grants broad system access.',
+  },
+  'shell:open-url': {
+    title: 'Open URLs',
+    description: 'Open URLs in the system browser.',
+  },
+  'entitlements:read': {
+    title: 'Read subscription status',
+    description: "Read the user's active subscription entitlements.",
+  },
+  'selection:read': {
+    title: 'Read selection',
+    description:
+      'Read the currently selected text or file-manager items from the frontmost application.',
+  },
+  'ai:use': {
+    title: 'Use AI',
+    description: "Stream responses from the user's configured AI provider.",
+  },
+  'oauth:use': {
+    title: 'Sign in to services',
+    description: 'Run OAuth authorization flows with third-party providers.',
+  },
+  'extension:invoke': {
+    title: 'Invoke other extensions',
+    description: 'Launch commands in other installed extensions.',
+  },
+  'application:read': {
+    title: 'Read installed apps',
+    description: 'List installed applications and query the frontmost or running apps.',
+  },
+  'window:manage': {
+    title: 'Manage windows',
+    description: 'Read and change the position, size, and fullscreen state of the frontmost window.',
+  },
+  'power:inhibit': {
+    title: 'Keep system awake',
+    description: 'Prevent the OS from sleeping while extension logic is running.',
+  },
+  'process:read': {
+    title: 'List processes',
+    description: 'List running processes with CPU and memory usage.',
+  },
+  'process:kill': {
+    title: 'Terminate processes',
+    description: 'Terminate or force-kill running processes.',
+  },
+  'systemEvents:read': {
+    title: 'Observe system events',
+    description: 'Subscribe to OS sleep, wake, lid, battery, and power-source events.',
+  },
+  'app:frontmost-watch': {
+    title: 'Observe app activity',
+    description: 'Subscribe to application launched, terminated, and frontmost-changed events.',
+  },
+  'timers:schedule': {
+    title: 'Schedule timers',
+    description: 'Schedule persistent one-shot timers that fire even after relaunch.',
+  },
+  'timers:cancel': {
+    title: 'Cancel timers',
+    description: 'Cancel previously scheduled timers.',
+  },
+  'timers:list': {
+    title: 'List timers',
+    description: 'List scheduled timers.',
+  },
+  'preferences:read': {
+    title: 'Read preferences',
+    description: "Read the extension's own preference values.",
+  },
+  'preferences:write': {
+    title: 'Write preferences',
+    description: "Change the extension's own preference values.",
+  },
+  'diagnostics:report': {
+    title: 'Report diagnostics',
+    description: 'Send diagnostic reports.',
+  },
+  'tools:register': {
+    title: 'Register agent tools',
+    description: 'Expose tools to the agent runtime for use during tool-calling.',
+  },
+  'snippets:contribute': {
+    title: 'Contribute snippets',
+    description:
+      'Contribute shortcode expansions to the global keystroke matcher, replacing typed shortcodes in any app.',
+  },
+  'runs:track': {
+    title: 'Track background runs',
+    description: "Start and manage long-running work shown in the launcher's runs UI.",
+  },
+  'browser:tabs.read': {
+    title: 'Read browser tabs',
+    description: 'List and inspect tabs in the paired browser.',
+  },
+  'browser:tabs.write': {
+    title: 'Control browser tabs',
+    description: 'Open, activate, and close tabs in the paired browser.',
+  },
+  'browser:bookmarks.read': {
+    title: 'Read bookmarks',
+    description: "Read the paired browser's bookmarks.",
+  },
+  'browser:history.read': {
+    title: 'Read browsing history',
+    description: "Search the paired browser's history.",
+  },
+  'browser:page.read': {
+    title: 'Read page content',
+    description: 'Read the content of the current page in the paired browser.',
+  },
+  'browser:page.write': {
+    title: 'Act on pages',
+    description: 'Interact with page content in the paired browser.',
+  },
+};
+
+export interface PermissionDisplay extends PermissionInfo {
+  /** False when the permission string is not in the catalog. */
+  known: boolean;
+}
+
+export function describePermission(permission: string): PermissionDisplay {
+  const info = PERMISSION_CATALOG[permission];
+  if (info) {
+    return { ...info, known: true };
+  }
+  return {
+    title: permission,
+    description: 'Not recognized by this version of Asyar.',
+    known: false,
+  };
+}

--- a/asyar-launcher/src/services/extension/permissionConsentService.svelte.ts
+++ b/asyar-launcher/src/services/extension/permissionConsentService.svelte.ts
@@ -37,6 +37,14 @@ class PermissionConsentService {
    */
   needsReview = $state<string[]>([]);
 
+  /**
+   * Bumped whenever a consent record is written in this webview. UI that
+   * derives consent state via `checkExtensionConsent` (e.g. the settings
+   * detail panel's needs-review badge) reads this in its $effect so it
+   * re-checks after an acceptance recorded outside its own flow.
+   */
+  consentVersion = $state(0);
+
   private queue: QueuedRequest[] = [];
   private activeResolver: ((accepted: boolean) => void) | null = null;
 
@@ -128,6 +136,7 @@ class PermissionConsentService {
       status.declaredArgs,
     );
     this.markReviewed(extensionId);
+    this.consentVersion++;
     return true;
   }
 

--- a/asyar-launcher/src/services/extension/permissionConsentService.svelte.ts
+++ b/asyar-launcher/src/services/extension/permissionConsentService.svelte.ts
@@ -140,6 +140,22 @@ class PermissionConsentService {
     return true;
   }
 
+  /**
+   * Withdraw a previously-granted consent record (Settings → Extensions
+   * "Revoke" action). Bumps `consentVersion` on success so any panel
+   * deriving `needsConsent` via `checkExtensionConsent` (e.g. the settings
+   * detail panel's badge) re-checks and reflects the withdrawal
+   * immediately — enforcement itself is already live the moment Rust's
+   * `revoke_extension_consent` returns, since it unregisters synchronously.
+   */
+  async revoke(extensionId: string): Promise<boolean> {
+    const ok = await commands.revokeExtensionConsent(extensionId);
+    if (ok) {
+      this.consentVersion++;
+    }
+    return ok;
+  }
+
   private pump(): void {
     if (this.activeRequest !== null) return;
     const next = this.queue.shift();

--- a/asyar-launcher/src/services/extension/permissionConsentService.svelte.ts
+++ b/asyar-launcher/src/services/extension/permissionConsentService.svelte.ts
@@ -1,0 +1,151 @@
+import * as commands from '../../lib/ipc/commands';
+import { logService } from '../log/logService';
+
+/** Why the consent dialog is being shown; drives its subtitle copy. */
+export type ConsentReason = 'install' | 'enable' | 'update' | 'review';
+
+export interface PermissionConsentRequest {
+  extensionId: string;
+  extensionName: string;
+  reason: ConsentReason;
+  permissions: string[];
+  permissionArgs: Record<string, unknown>;
+}
+
+interface QueuedRequest {
+  request: PermissionConsentRequest;
+  resolve: (accepted: boolean) => void;
+}
+
+/**
+ * Host-side consent prompt state, following the `feedbackService.activeDialog`
+ * resolver pattern. Unlike `confirmAlert` (which cancels a second concurrent
+ * caller), requests are FIFO-queued — a consent decision must never silently
+ * default to "declined" because another dialog happened to be open.
+ *
+ * The actual enforcement lives in Rust (`register_extension_permissions`
+ * withholds undeclared-consent permission sets); this service only drives the
+ * UI and records acceptance.
+ */
+class PermissionConsentService {
+  activeRequest = $state<PermissionConsentRequest | null>(null);
+
+  /**
+   * Extensions whose load-time permission registration was withheld because
+   * the declared set exceeds recorded consent. Per-webview, populated by the
+   * extension loader; the settings panel re-derives via `checkExtensionConsent`.
+   */
+  needsReview = $state<string[]>([]);
+
+  private queue: QueuedRequest[] = [];
+  private activeResolver: ((accepted: boolean) => void) | null = null;
+
+  reset(): void {
+    this.activeRequest = null;
+    this.needsReview = [];
+    this.queue = [];
+    this.activeResolver = null;
+  }
+
+  /** Show the consent dialog (queued behind any dialog already open). */
+  requestConsent(request: PermissionConsentRequest): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      this.queue.push({ request, resolve });
+      this.pump();
+    });
+  }
+
+  /** Called by the dialog when the user accepts. */
+  onAccepted(): void {
+    this.settle(true);
+  }
+
+  /** Called by the dialog on Cancel, Escape, or backdrop click. */
+  onDeclined(): void {
+    this.settle(false);
+  }
+
+  markNeedsReview(extensionId: string): void {
+    if (!this.needsReview.includes(extensionId)) {
+      this.needsReview = [...this.needsReview, extensionId];
+    }
+  }
+
+  private markReviewed(extensionId: string): void {
+    if (this.needsReview.includes(extensionId)) {
+      this.needsReview = this.needsReview.filter((id) => id !== extensionId);
+    }
+  }
+
+  /**
+   * Ensure the user has consented to `extensionId`'s currently declared
+   * permission set, prompting if not. On acceptance the consent record is
+   * persisted and the permissions are (re-)registered in the Rust registry,
+   * so acceptance takes effect without a restart.
+   *
+   * Returns true when the caller may proceed (consent already covered,
+   * nothing to consent to, or the user accepted). On an IPC failure the
+   * caller may also proceed: the Rust load-time backstop still withholds
+   * unconsented permissions, so failing open here only affects UX, not
+   * enforcement.
+   */
+  async ensureConsent(
+    extensionId: string,
+    extensionName: string,
+    reason: ConsentReason,
+  ): Promise<boolean> {
+    const status = await commands.checkExtensionConsent(extensionId);
+    if (!status) {
+      logService.warn(
+        `[PermissionConsent] checkExtensionConsent failed for ${extensionId}; proceeding (Rust backstop still enforces)`,
+      );
+      return true;
+    }
+    if (!status.needsConsent) {
+      this.markReviewed(extensionId);
+      return true;
+    }
+
+    const accepted = await this.requestConsent({
+      extensionId,
+      extensionName,
+      reason,
+      permissions: status.declaredPermissions,
+      permissionArgs: status.declaredArgs,
+    });
+    if (!accepted) {
+      return false;
+    }
+
+    await commands.setExtensionConsent(
+      extensionId,
+      status.declaredPermissions,
+      status.declaredArgs,
+    );
+    await commands.registerExtensionPermissions(
+      extensionId,
+      status.declaredPermissions,
+      status.declaredArgs,
+    );
+    this.markReviewed(extensionId);
+    return true;
+  }
+
+  private pump(): void {
+    if (this.activeRequest !== null) return;
+    const next = this.queue.shift();
+    if (!next) return;
+    this.activeResolver = next.resolve;
+    this.activeRequest = next.request;
+  }
+
+  private settle(accepted: boolean): void {
+    const resolver = this.activeResolver;
+    this.activeResolver = null;
+    this.activeRequest = null;
+    resolver?.(accepted);
+    this.pump();
+  }
+}
+
+export const permissionConsentService = new PermissionConsentService();

--- a/asyar-launcher/src/services/extension/permissionConsentService.test.ts
+++ b/asyar-launcher/src/services/extension/permissionConsentService.test.ts
@@ -83,6 +83,7 @@ describe('permissionConsentService', () => {
       consented: null,
     });
 
+    const versionBefore = permissionConsentService.consentVersion;
     const promise = permissionConsentService.ensureConsent('ext.a', 'Ext A', 'update');
     await vi.waitFor(() => {
       expect(permissionConsentService.activeRequest).not.toBeNull();
@@ -97,6 +98,7 @@ describe('permissionConsentService', () => {
     expect(registerExtensionPermissions).toHaveBeenCalledWith('ext.a', ['fs:watch'], {
       'fs:watch': ['~/a/**'],
     });
+    expect(permissionConsentService.consentVersion).toBe(versionBefore + 1);
   });
 
   it('ensureConsent neither persists nor registers on decline', async () => {

--- a/asyar-launcher/src/services/extension/permissionConsentService.test.ts
+++ b/asyar-launcher/src/services/extension/permissionConsentService.test.ts
@@ -1,0 +1,144 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/ipc/commands', () => ({
+  checkExtensionConsent: vi.fn(),
+  setExtensionConsent: vi.fn().mockResolvedValue(undefined),
+  registerExtensionPermissions: vi
+    .fn()
+    .mockResolvedValue({ registered: true, needsConsent: false }),
+}));
+vi.mock('../log/logService', () => ({
+  logService: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import * as commands from '../../lib/ipc/commands';
+import { permissionConsentService } from './permissionConsentService.svelte';
+
+const checkExtensionConsent = vi.mocked(commands.checkExtensionConsent);
+const setExtensionConsent = vi.mocked(commands.setExtensionConsent);
+const registerExtensionPermissions = vi.mocked(commands.registerExtensionPermissions);
+
+function request(id = 'ext.a') {
+  return {
+    extensionId: id,
+    extensionName: id,
+    reason: 'install' as const,
+    permissions: ['network'],
+    permissionArgs: {},
+  };
+}
+
+describe('permissionConsentService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    permissionConsentService.reset();
+  });
+
+  it('resolves true on accept and clears the active request', async () => {
+    const promise = permissionConsentService.requestConsent(request());
+    expect(permissionConsentService.activeRequest?.extensionId).toBe('ext.a');
+    permissionConsentService.onAccepted();
+    await expect(promise).resolves.toBe(true);
+    expect(permissionConsentService.activeRequest).toBeNull();
+  });
+
+  it('resolves false on decline', async () => {
+    const promise = permissionConsentService.requestConsent(request());
+    permissionConsentService.onDeclined();
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it('queues concurrent requests FIFO instead of cancelling the second', async () => {
+    const first = permissionConsentService.requestConsent(request('ext.a'));
+    const second = permissionConsentService.requestConsent(request('ext.b'));
+
+    expect(permissionConsentService.activeRequest?.extensionId).toBe('ext.a');
+    permissionConsentService.onAccepted();
+    await expect(first).resolves.toBe(true);
+
+    expect(permissionConsentService.activeRequest?.extensionId).toBe('ext.b');
+    permissionConsentService.onDeclined();
+    await expect(second).resolves.toBe(false);
+  });
+
+  it('ensureConsent skips the prompt when consent already covers', async () => {
+    checkExtensionConsent.mockResolvedValue({
+      needsConsent: false,
+      declaredPermissions: ['network'],
+      declaredArgs: {},
+      consented: null,
+    });
+    const result = await permissionConsentService.ensureConsent('ext.a', 'Ext A', 'enable');
+    expect(result).toBe(true);
+    expect(permissionConsentService.activeRequest).toBeNull();
+    expect(setExtensionConsent).not.toHaveBeenCalled();
+  });
+
+  it('ensureConsent persists and re-registers on acceptance', async () => {
+    checkExtensionConsent.mockResolvedValue({
+      needsConsent: true,
+      declaredPermissions: ['fs:watch'],
+      declaredArgs: { 'fs:watch': ['~/a/**'] },
+      consented: null,
+    });
+
+    const promise = permissionConsentService.ensureConsent('ext.a', 'Ext A', 'update');
+    await vi.waitFor(() => {
+      expect(permissionConsentService.activeRequest).not.toBeNull();
+    });
+    expect(permissionConsentService.activeRequest?.permissions).toEqual(['fs:watch']);
+    permissionConsentService.onAccepted();
+
+    await expect(promise).resolves.toBe(true);
+    expect(setExtensionConsent).toHaveBeenCalledWith('ext.a', ['fs:watch'], {
+      'fs:watch': ['~/a/**'],
+    });
+    expect(registerExtensionPermissions).toHaveBeenCalledWith('ext.a', ['fs:watch'], {
+      'fs:watch': ['~/a/**'],
+    });
+  });
+
+  it('ensureConsent neither persists nor registers on decline', async () => {
+    checkExtensionConsent.mockResolvedValue({
+      needsConsent: true,
+      declaredPermissions: ['network'],
+      declaredArgs: {},
+      consented: null,
+    });
+
+    const promise = permissionConsentService.ensureConsent('ext.a', 'Ext A', 'enable');
+    await vi.waitFor(() => {
+      expect(permissionConsentService.activeRequest).not.toBeNull();
+    });
+    permissionConsentService.onDeclined();
+
+    await expect(promise).resolves.toBe(false);
+    expect(setExtensionConsent).not.toHaveBeenCalled();
+    expect(registerExtensionPermissions).not.toHaveBeenCalled();
+  });
+
+  it('ensureConsent proceeds without prompting when the consent check fails', async () => {
+    // Rust's load-time backstop still withholds unconsented permissions, so
+    // failing open here only affects UX, never enforcement.
+    checkExtensionConsent.mockResolvedValue(null);
+    const result = await permissionConsentService.ensureConsent('ext.a', 'Ext A', 'enable');
+    expect(result).toBe(true);
+    expect(permissionConsentService.activeRequest).toBeNull();
+  });
+
+  it('markNeedsReview dedupes and ensureConsent clears it once covered', async () => {
+    permissionConsentService.markNeedsReview('ext.a');
+    permissionConsentService.markNeedsReview('ext.a');
+    expect(permissionConsentService.needsReview).toEqual(['ext.a']);
+
+    checkExtensionConsent.mockResolvedValue({
+      needsConsent: false,
+      declaredPermissions: ['network'],
+      declaredArgs: {},
+      consented: null,
+    });
+    await permissionConsentService.ensureConsent('ext.a', 'Ext A', 'review');
+    expect(permissionConsentService.needsReview).toEqual([]);
+  });
+});

--- a/asyar-launcher/src/services/extension/permissionConsentService.test.ts
+++ b/asyar-launcher/src/services/extension/permissionConsentService.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../lib/ipc/commands', () => ({
   registerExtensionPermissions: vi
     .fn()
     .mockResolvedValue({ registered: true, needsConsent: false }),
+  revokeExtensionConsent: vi.fn().mockResolvedValue(true),
 }));
 vi.mock('../log/logService', () => ({
   logService: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -18,6 +19,7 @@ import { permissionConsentService } from './permissionConsentService.svelte';
 const checkExtensionConsent = vi.mocked(commands.checkExtensionConsent);
 const setExtensionConsent = vi.mocked(commands.setExtensionConsent);
 const registerExtensionPermissions = vi.mocked(commands.registerExtensionPermissions);
+const revokeExtensionConsent = vi.mocked(commands.revokeExtensionConsent);
 
 function request(id = 'ext.a') {
   return {
@@ -142,5 +144,26 @@ describe('permissionConsentService', () => {
     });
     await permissionConsentService.ensureConsent('ext.a', 'Ext A', 'review');
     expect(permissionConsentService.needsReview).toEqual([]);
+  });
+
+  it('revoke calls the IPC command and bumps consentVersion on success', async () => {
+    revokeExtensionConsent.mockResolvedValue(true);
+    const versionBefore = permissionConsentService.consentVersion;
+
+    const result = await permissionConsentService.revoke('ext.a');
+
+    expect(result).toBe(true);
+    expect(revokeExtensionConsent).toHaveBeenCalledWith('ext.a');
+    expect(permissionConsentService.consentVersion).toBe(versionBefore + 1);
+  });
+
+  it('revoke does not bump consentVersion when the IPC call fails', async () => {
+    revokeExtensionConsent.mockResolvedValue(false);
+    const versionBefore = permissionConsentService.consentVersion;
+
+    const result = await permissionConsentService.revoke('ext.a');
+
+    expect(result).toBe(false);
+    expect(permissionConsentService.consentVersion).toBe(versionBefore);
   });
 });

--- a/asyar-launcher/src/services/feedback/feedbackService.svelte.ts
+++ b/asyar-launcher/src/services/feedback/feedbackService.svelte.ts
@@ -5,7 +5,7 @@ interface ActiveToast {
   id: string;
   title: string;
   message?: string;
-  style: 'animated';
+  style: 'animated' | 'success' | 'failure';
 }
 
 interface ActiveDialog {
@@ -60,6 +60,27 @@ class FeedbackService implements IFeedbackService {
       style: 'animated',
     };
     return id;
+  }
+
+  /**
+   * Host-only transient notice: symbol style (✓/✕, no spinner) with
+   * auto-dismiss. Unlike the SDK `showToast` contract — whose only style is
+   * `animated` and whose callers are expected to `hideToast` when their
+   * operation finishes — this is fire-and-forget for one-off notifications.
+   */
+  notice(
+    title: string,
+    message: string | undefined,
+    style: 'success' | 'failure',
+    durationMs = 6000,
+  ): void {
+    const id = `toast-${++this.toastIdCounter}`;
+    this.activeToast = { id, title, message, style };
+    setTimeout(() => {
+      if (this.activeToast?.id === id) {
+        this.activeToast = null;
+      }
+    }, durationMs);
   }
 
   async updateToast(toastId: string, options: Partial<ShowToastOptions>): Promise<void> {

--- a/asyar-launcher/src/services/feedback/feedbackService.svelte.ts
+++ b/asyar-launcher/src/services/feedback/feedbackService.svelte.ts
@@ -14,8 +14,14 @@ export interface NoticeOptions {
   title: string;
   message?: string;
   style: 'success' | 'failure';
-  /** Auto-dismiss delay. Defaults to 6000ms. */
+  /** Auto-dismiss delay. Defaults to 6000ms. Ignored when `onClick` is set. */
   durationMs?: number;
+  /**
+   * Makes the notice actionable: clicking the toast runs this and dismisses.
+   * Actionable notices are sticky — they stay until clicked or explicitly
+   * dismissed via the ✕ (a timed popup for something the user must act on is
+   * a race against the timer).
+   */
   onClick?: () => void;
 }
 
@@ -89,6 +95,7 @@ class FeedbackService implements IFeedbackService {
       style: options.style,
       onClick: options.onClick,
     };
+    if (options.onClick) return; // actionable notices are sticky
     setTimeout(() => {
       if (this.activeToast?.id === id) {
         this.activeToast = null;
@@ -102,6 +109,11 @@ class FeedbackService implements IFeedbackService {
     if (!toast?.onClick) return;
     this.activeToast = null;
     toast.onClick();
+  }
+
+  /** Called by `<ToastHost />` when a sticky toast's ✕ is clicked. */
+  onToastDismissed(): void {
+    this.activeToast = null;
   }
 
   async updateToast(toastId: string, options: Partial<ShowToastOptions>): Promise<void> {

--- a/asyar-launcher/src/services/feedback/feedbackService.svelte.ts
+++ b/asyar-launcher/src/services/feedback/feedbackService.svelte.ts
@@ -5,7 +5,7 @@ interface ActiveToast {
   id: string;
   title: string;
   message?: string;
-  style: 'animated' | 'success' | 'failure';
+  style: 'animated' | 'success' | 'failure' | 'warning';
   /** When set, the toast renders as a button; clicking runs this and dismisses. */
   onClick?: () => void;
 }
@@ -13,7 +13,11 @@ interface ActiveToast {
 export interface NoticeOptions {
   title: string;
   message?: string;
-  style: 'success' | 'failure';
+  /**
+   * `success`/`failure` report an operation's outcome; `warning` flags an
+   * attention-required state (e.g. permissions awaiting review).
+   */
+  style: 'success' | 'failure' | 'warning';
   /** Auto-dismiss delay. Defaults to 6000ms. Ignored when `onClick` is set. */
   durationMs?: number;
   /**

--- a/asyar-launcher/src/services/feedback/feedbackService.svelte.ts
+++ b/asyar-launcher/src/services/feedback/feedbackService.svelte.ts
@@ -6,6 +6,17 @@ interface ActiveToast {
   title: string;
   message?: string;
   style: 'animated' | 'success' | 'failure';
+  /** When set, the toast renders as a button; clicking runs this and dismisses. */
+  onClick?: () => void;
+}
+
+export interface NoticeOptions {
+  title: string;
+  message?: string;
+  style: 'success' | 'failure';
+  /** Auto-dismiss delay. Defaults to 6000ms. */
+  durationMs?: number;
+  onClick?: () => void;
 }
 
 interface ActiveDialog {
@@ -67,20 +78,30 @@ class FeedbackService implements IFeedbackService {
    * auto-dismiss. Unlike the SDK `showToast` contract — whose only style is
    * `animated` and whose callers are expected to `hideToast` when their
    * operation finishes — this is fire-and-forget for one-off notifications.
+   * An `onClick` makes the toast clickable (it dismisses after running).
    */
-  notice(
-    title: string,
-    message: string | undefined,
-    style: 'success' | 'failure',
-    durationMs = 6000,
-  ): void {
+  notice(options: NoticeOptions): void {
     const id = `toast-${++this.toastIdCounter}`;
-    this.activeToast = { id, title, message, style };
+    this.activeToast = {
+      id,
+      title: options.title,
+      message: options.message,
+      style: options.style,
+      onClick: options.onClick,
+    };
     setTimeout(() => {
       if (this.activeToast?.id === id) {
         this.activeToast = null;
       }
-    }, durationMs);
+    }, options.durationMs ?? 6000);
+  }
+
+  /** Called by `<ToastHost />` when a clickable toast is activated. */
+  onToastClicked(): void {
+    const toast = this.activeToast;
+    if (!toast?.onClick) return;
+    this.activeToast = null;
+    toast.onClick();
   }
 
   async updateToast(toastId: string, options: Partial<ShowToastOptions>): Promise<void> {

--- a/asyar-launcher/src/services/feedback/feedbackService.test.ts
+++ b/asyar-launcher/src/services/feedback/feedbackService.test.ts
@@ -41,6 +41,35 @@ describe('showToast', () => {
   });
 });
 
+describe('notice', () => {
+  it('shows a symbol-style toast and auto-dismisses after durationMs', () => {
+    vi.useFakeTimers();
+    try {
+      feedbackService.notice('Ext needs review', 'Open Settings', 'failure', 5000);
+      expect(feedbackService.activeToast?.style).toBe('failure');
+      expect(feedbackService.activeToast?.title).toBe('Ext needs review');
+      vi.advanceTimersByTime(5000);
+      expect(feedbackService.activeToast).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not dismiss a newer toast that replaced it', () => {
+    vi.useFakeTimers();
+    try {
+      feedbackService.notice('First', undefined, 'failure', 5000);
+      feedbackService.notice('Second', undefined, 'success', 10000);
+      vi.advanceTimersByTime(5000); // first toast's timer fires
+      expect(feedbackService.activeToast?.title).toBe('Second');
+      vi.advanceTimersByTime(5000);
+      expect(feedbackService.activeToast).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe('updateToast', () => {
   it('updates title in place when id matches', async () => {
     const id = await feedbackService.showToast({ title: 'Loading', style: 'animated' });

--- a/asyar-launcher/src/services/feedback/feedbackService.test.ts
+++ b/asyar-launcher/src/services/feedback/feedbackService.test.ts
@@ -74,11 +74,30 @@ describe('notice', () => {
     }
   });
 
+  it('actionable notices are sticky — no auto-dismiss', () => {
+    vi.useFakeTimers();
+    try {
+      feedbackService.notice({ title: 'Clickable', style: 'failure', onClick: vi.fn() });
+      vi.advanceTimersByTime(60_000);
+      expect(feedbackService.activeToast?.title).toBe('Clickable');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('onToastClicked runs onClick and dismisses', () => {
     const onClick = vi.fn();
     feedbackService.notice({ title: 'Clickable', style: 'failure', onClick });
     feedbackService.onToastClicked();
     expect(onClick).toHaveBeenCalledOnce();
+    expect(feedbackService.activeToast).toBeNull();
+  });
+
+  it('onToastDismissed clears without running onClick', () => {
+    const onClick = vi.fn();
+    feedbackService.notice({ title: 'Clickable', style: 'failure', onClick });
+    feedbackService.onToastDismissed();
+    expect(onClick).not.toHaveBeenCalled();
     expect(feedbackService.activeToast).toBeNull();
   });
 

--- a/asyar-launcher/src/services/feedback/feedbackService.test.ts
+++ b/asyar-launcher/src/services/feedback/feedbackService.test.ts
@@ -77,9 +77,10 @@ describe('notice', () => {
   it('actionable notices are sticky — no auto-dismiss', () => {
     vi.useFakeTimers();
     try {
-      feedbackService.notice({ title: 'Clickable', style: 'failure', onClick: vi.fn() });
+      feedbackService.notice({ title: 'Clickable', style: 'warning', onClick: vi.fn() });
       vi.advanceTimersByTime(60_000);
       expect(feedbackService.activeToast?.title).toBe('Clickable');
+      expect(feedbackService.activeToast?.style).toBe('warning');
     } finally {
       vi.useRealTimers();
     }

--- a/asyar-launcher/src/services/feedback/feedbackService.test.ts
+++ b/asyar-launcher/src/services/feedback/feedbackService.test.ts
@@ -45,7 +45,12 @@ describe('notice', () => {
   it('shows a symbol-style toast and auto-dismisses after durationMs', () => {
     vi.useFakeTimers();
     try {
-      feedbackService.notice('Ext needs review', 'Open Settings', 'failure', 5000);
+      feedbackService.notice({
+        title: 'Ext needs review',
+        message: 'Open Settings',
+        style: 'failure',
+        durationMs: 5000,
+      });
       expect(feedbackService.activeToast?.style).toBe('failure');
       expect(feedbackService.activeToast?.title).toBe('Ext needs review');
       vi.advanceTimersByTime(5000);
@@ -58,8 +63,8 @@ describe('notice', () => {
   it('does not dismiss a newer toast that replaced it', () => {
     vi.useFakeTimers();
     try {
-      feedbackService.notice('First', undefined, 'failure', 5000);
-      feedbackService.notice('Second', undefined, 'success', 10000);
+      feedbackService.notice({ title: 'First', style: 'failure', durationMs: 5000 });
+      feedbackService.notice({ title: 'Second', style: 'success', durationMs: 10000 });
       vi.advanceTimersByTime(5000); // first toast's timer fires
       expect(feedbackService.activeToast?.title).toBe('Second');
       vi.advanceTimersByTime(5000);
@@ -67,6 +72,20 @@ describe('notice', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('onToastClicked runs onClick and dismisses', () => {
+    const onClick = vi.fn();
+    feedbackService.notice({ title: 'Clickable', style: 'failure', onClick });
+    feedbackService.onToastClicked();
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(feedbackService.activeToast).toBeNull();
+  });
+
+  it('onToastClicked is a no-op for toasts without onClick', () => {
+    feedbackService.notice({ title: 'Plain', style: 'success' });
+    feedbackService.onToastClicked();
+    expect(feedbackService.activeToast?.title).toBe('Plain');
   });
 });
 

--- a/asyar-sdk/src/types/ExtensionType.ts
+++ b/asyar-sdk/src/types/ExtensionType.ts
@@ -109,6 +109,12 @@ export interface ExtensionManifest {
   minAppVersion?: string;
   platforms?: string[];
   permissions?: string[];
+  /**
+   * Sidecar values for parameterized permissions, keyed by permission string.
+   * Each key must also appear in `permissions`. Value shape is
+   * permission-specific — `fs:watch` takes a `string[]` of glob patterns.
+   */
+  permissionArgs?: Record<string, unknown>;
   /** Extension-level preferences (apply to all commands). */
   preferences?: PreferenceDeclaration[];
   /** Extension-level actions (show when any command from this extension is selected). */


### PR DESCRIPTION
Builds the generic permission-consent surface discussed in #448 and #449 — the prerequisite both features land on top of. Today nothing shows a user what an extension's manifest declares: permissions are registered unconditionally at load and enforced only per call. This PR renders each requested permission plus its declared `permissionArgs` at install/enable time and requires acceptance before the permissions become usable. `fs:watch` globs are the first args consumer; `files:read` globs (#448) and `shell:open-url` schemes (#449) slot in with no further UI work.

### How it works

- **Consent records** live in `settings.dat` under `settings.extensions.consent.<id>` (next to `extensions.enabled.<id>`), holding the accepted `permissions` + `permissionArgs` and a timestamp. Comparison is subset semantics (`consent_covers` in the new `extensions/consent.rs`): added permissions or grown arg values re-prompt; removed ones never do.
- **Load-time backstop:** `register_extension_permissions` now resolves the declared set from the discovered manifest (caller-supplied values are only trusted when no discovery record exists) and refuses to populate the permission registry without a covering consent record — every gated call fails closed until the user accepts, regardless of how an extension arrived. Same double-layer shape as `fs:watch`.
- **Prompt points:** store install (prompted from listing metadata before download, then reconciled against the actual packaged manifest after install — metadata/package drift re-prompts with the real set), settings enable toggle, dev-extension registration, and manual updates. Extensions declaring no permissions never prompt; built-ins are exempt.
- **Anything that slips past** (e.g. a silent auto-update adding a permission) loads UI-visible but with permissions withheld, and surfaces a sticky warning toast on the launcher's next reveal — click-through opens Settings → Extensions with the extension selected; ✕ dismisses for the session. The settings detail panel shows a "Permissions need review" badge + review button as the durable signal. (Toast plumbing added along the way: a host-only `feedbackService.notice()` with symbol styles and auto-dismiss for non-actionable notices, and `showSettingsWindow` gained an `extensionId` deep-link riding the existing `asyar:navigate-settings-tab` event.)
- **Always-visible audit:** read-only Permissions sections (human-readable titles/descriptions from a new catalog, args as code chips, unknown permission strings flagged) in the settings extension detail panel and the store detail view.
- **Grandfathering:** a one-shot migration records the current manifest set as consented for extensions already installed and enabled before this ships — the browser-extension rollout pattern; prompting a wall of dialogs for existing installs would train users to click through the very surface this adds. Uninstall removes the record, so reinstalling re-prompts.

### Verification

- `cargo test` (2489+ passed; the one failure is `fs_watcher::registry_tests::rejects_when_global_total_paths_would_exceed_limit`, which reproduces on clean `main` under WSL's `fs.inotify.max_user_instances=128` — unrelated), `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt` clean, `pnpm -r test:run` green (new suites: `consent_covers`/registration decision matrix, consent service, catalog, notice toasts), `prettier --check` clean.
- Manual walkthrough on Windows with a dev-registered extension declaring `fs:watch` globs plus a store extension declaring `process:*`: grandfather on first launch; consent-record wipe → warning toast → click lands on the selected extension → review dialog lists the glob chips → accept restores function without restart; enable-toggle prompt with Cancel snapping the toggle back; store install prompts pre-download, Cancel aborts, uninstall removes the record and reinstalling re-prompts.

One unrelated finding while testing, not addressed here: the settings window's extension list is loaded once at boot and never refreshed by store installs from the main webview, so newly installed extensions don't appear until restart. Reproduces on `main`; happy to file/fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
