### PR TITLE
fix(sync): gate cloud sync on auth state and a user-facing toggle

### DIFF
--- a/asyar-launcher/src/routes/settings/tabs/AccountTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/AccountTab.svelte
@@ -57,16 +57,27 @@
     syncToggleState = cloudSyncService.enabled;
   });
 
+  function revertSyncToggle(previous: boolean, reason: string) {
+    logService.error(`[AccountTab] toggling cloud sync failed: ${reason}`);
+    syncToggleState = previous;
+    // updateSettings mutates the in-memory settings BEFORE saving, so a
+    // failed save leaves the new value live (and the sync watcher acting
+    // on it) — re-reading cloudSyncService.enabled here would return the
+    // value that just failed to persist. Write the old value back so the
+    // UI, the in-memory settings, and the service agree again; if
+    // persistence is still failing this at least restores the in-session
+    // state.
+    settingsService.updateSettings('user', { syncEnabled: previous }).catch(() => {});
+  }
+
   function onSyncToggleClick(target: boolean) {
+    const previous = cloudSyncService.enabled;
     settingsService
       .updateSettings('user', { syncEnabled: target })
       .then((ok) => {
-        if (!ok) syncToggleState = cloudSyncService.enabled;
+        if (!ok) revertSyncToggle(previous, 'settings save returned false');
       })
-      .catch((err) => {
-        logService.error(`[AccountTab] toggling cloud sync failed: ${err}`);
-        syncToggleState = cloudSyncService.enabled;
-      });
+      .catch((err) => revertSyncToggle(previous, String(err)));
   }
 
   function resetToggle() {

--- a/asyar-launcher/src/routes/settings/tabs/AccountTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/AccountTab.svelte
@@ -12,6 +12,7 @@
   import type { SettingsHandler } from '../settingsHandlers.svelte';
   import { authService } from '../../../services/auth/authService.svelte';
   import { cloudSyncService } from '../../../services/sync/cloudSyncService.svelte';
+  import { settingsService } from '../../../services/settings/settingsService.svelte';
   import { entitlementService } from '../../../services/auth/entitlementService.svelte';
   import { diagnosticsService } from '../../../services/diagnostics/diagnosticsService.svelte';
   import { logService } from '../../../services/log/logService';
@@ -46,6 +47,27 @@
   $effect(() => {
     toggleState = syncEncryptionService.enabled;
   });
+
+  // Same mirror idiom for the cloud-sync preference toggle. The tab only
+  // writes the setting — cloudSyncService watches it and starts/stops
+  // itself — so the mirror snaps back only if the write fails.
+  let syncToggleState = $state(cloudSyncService.enabled);
+
+  $effect(() => {
+    syncToggleState = cloudSyncService.enabled;
+  });
+
+  function onSyncToggleClick(target: boolean) {
+    settingsService
+      .updateSettings('user', { syncEnabled: target })
+      .then((ok) => {
+        if (!ok) syncToggleState = cloudSyncService.enabled;
+      })
+      .catch((err) => {
+        logService.error(`[AccountTab] toggling cloud sync failed: ${err}`);
+        syncToggleState = cloudSyncService.enabled;
+      });
+  }
 
   function resetToggle() {
     toggleState = syncEncryptionService.enabled;
@@ -259,70 +281,86 @@
   {#if entitlementService.check('sync:settings')}
     <div class="no-separators">
       <SettingsForm>
-        <SettingsFormRow label="Last Synced" separator>
-          <div class="sync-status">
+        <SettingsFormRow label="Cloud Sync" separator>
+          <div class="sync-enable-row">
             <span class="secondary-text">
-              {cloudSyncService.lastSyncedAt
-                ? formatRelativeTime(cloudSyncService.lastSyncedAt)
-                : 'Not yet synced'}
+              {syncToggleState
+                ? 'Syncing your data across devices.'
+                : 'Your data stays on this device.'}
             </span>
-            {#if cloudSyncService.lastError}
-              <span class="error-text">{cloudSyncService.lastError}</span>
-            {/if}
-          </div>
-        </SettingsFormRow>
-
-        <SettingsFormRow label="Sync Now">
-          <Button
-            onclick={() => cloudSyncService.syncNow().catch((err) => reportSyncFailure(err))}
-            disabled={cloudSyncService.status === 'syncing'}
-          >
-            {cloudSyncService.status === 'syncing' ? 'Syncing…' : 'Sync Now'}
-          </Button>
-        </SettingsFormRow>
-
-        <SettingsFormRow label="Encrypted Sync" separator>
-          <div class="e2ee-row">
-            <div class="e2ee-status">
-              {#if !syncEncryptionService.enabled}
-                <Badge text="Off" variant="default" />
-                <span class="secondary-text">Server can read your synced data.</span>
-              {:else if syncEncryptionService.locked}
-                <div class="e2ee-badge-with-dot">
-                  <StatusDot color="warning" />
-                  <Badge text="Locked" variant="warning" />
-                </div>
-                <span class="secondary-text">Passphrase needed to continue.</span>
-              {:else}
-                <div class="e2ee-badge-with-dot">
-                  <StatusDot color="success" />
-                  <Badge text="On" variant="success" />
-                </div>
-                <span class="secondary-text">Server stores only ciphertext.</span>
-              {/if}
-            </div>
             <Toggle
-              bind:checked={toggleState}
-              onchange={(e) => onToggleClick((e.target as HTMLInputElement).checked)}
+              bind:checked={syncToggleState}
+              onchange={(e) => onSyncToggleClick((e.target as HTMLInputElement).checked)}
             />
           </div>
         </SettingsFormRow>
 
-        {#if syncEncryptionService.enabled}
-          {#if syncEncryptionService.locked}
-            <SettingsFormRow label="Unlock">
-              <Button onclick={() => (activeDialog = 'unlock')}>Enter passphrase</Button>
-            </SettingsFormRow>
-          {/if}
-          <SettingsFormRow label="Passphrase">
-            <Button onclick={() => (activeDialog = 'rotate')}>Change passphrase</Button>
-          </SettingsFormRow>
-          <SettingsFormRow label="Recovery phrase">
-            <div class="e2ee-phrase-actions">
-              <Button onclick={() => (activeDialog = 'phrase')}>View recovery phrase</Button>
-              <Button onclick={() => (activeDialog = 'recover')}>I forgot my passphrase</Button>
+        {#if cloudSyncService.enabled}
+          <SettingsFormRow label="Last Synced" separator>
+            <div class="sync-status">
+              <span class="secondary-text">
+                {cloudSyncService.lastSyncedAt
+                  ? formatRelativeTime(cloudSyncService.lastSyncedAt)
+                  : 'Not yet synced'}
+              </span>
+              {#if cloudSyncService.lastError}
+                <span class="error-text">{cloudSyncService.lastError}</span>
+              {/if}
             </div>
           </SettingsFormRow>
+
+          <SettingsFormRow label="Sync Now">
+            <Button
+              onclick={() => cloudSyncService.syncNow().catch((err) => reportSyncFailure(err))}
+              disabled={cloudSyncService.status === 'syncing'}
+            >
+              {cloudSyncService.status === 'syncing' ? 'Syncing…' : 'Sync Now'}
+            </Button>
+          </SettingsFormRow>
+
+          <SettingsFormRow label="Encrypted Sync" separator>
+            <div class="e2ee-row">
+              <div class="e2ee-status">
+                {#if !syncEncryptionService.enabled}
+                  <Badge text="Off" variant="default" />
+                  <span class="secondary-text">Server can read your synced data.</span>
+                {:else if syncEncryptionService.locked}
+                  <div class="e2ee-badge-with-dot">
+                    <StatusDot color="warning" />
+                    <Badge text="Locked" variant="warning" />
+                  </div>
+                  <span class="secondary-text">Passphrase needed to continue.</span>
+                {:else}
+                  <div class="e2ee-badge-with-dot">
+                    <StatusDot color="success" />
+                    <Badge text="On" variant="success" />
+                  </div>
+                  <span class="secondary-text">Server stores only ciphertext.</span>
+                {/if}
+              </div>
+              <Toggle
+                bind:checked={toggleState}
+                onchange={(e) => onToggleClick((e.target as HTMLInputElement).checked)}
+              />
+            </div>
+          </SettingsFormRow>
+
+          {#if syncEncryptionService.enabled}
+            {#if syncEncryptionService.locked}
+              <SettingsFormRow label="Unlock">
+                <Button onclick={() => (activeDialog = 'unlock')}>Enter passphrase</Button>
+              </SettingsFormRow>
+            {/if}
+            <SettingsFormRow label="Passphrase">
+              <Button onclick={() => (activeDialog = 'rotate')}>Change passphrase</Button>
+            </SettingsFormRow>
+            <SettingsFormRow label="Recovery phrase">
+              <div class="e2ee-phrase-actions">
+                <Button onclick={() => (activeDialog = 'phrase')}>View recovery phrase</Button>
+                <Button onclick={() => (activeDialog = 'recover')}>I forgot my passphrase</Button>
+              </div>
+            </SettingsFormRow>
+          {/if}
         {/if}
       </SettingsForm>
     </div>
@@ -548,6 +586,18 @@
   }
 
   /* Sync status */
+  .sync-enable-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    width: 100%;
+  }
+
+  .sync-enable-row .secondary-text {
+    flex: 1;
+    min-width: 0;
+  }
+
   .sync-status {
     display: flex;
     align-items: center;

--- a/asyar-launcher/src/services/auth/authService.svelte.ts
+++ b/asyar-launcher/src/services/auth/authService.svelte.ts
@@ -238,6 +238,17 @@ class AuthService {
     if (result.entitlements) this.entitlements = result.entitlements;
     this.isLoggedIn = true;
     logService.info(`Auth: logged in as ${result.user?.email ?? 'unknown'}`);
+
+    // Start cloud sync for this fresh session — appInitializer only calls
+    // cloudSyncService.init() at startup, where it no-ops if the launcher
+    // came up signed-out. Mirror of the dispose() in logout(); same dynamic
+    // import to break the module cycle.
+    try {
+      const { cloudSyncService } = await import('../sync/cloudSyncService.svelte');
+      await cloudSyncService.init();
+    } catch (err) {
+      logService.warn(`Auth: cloud sync init failed after login: ${err}`);
+    }
   }
 }
 

--- a/asyar-launcher/src/services/sync/cloudSyncService.svelte.ts
+++ b/asyar-launcher/src/services/sync/cloudSyncService.svelte.ts
@@ -1,5 +1,7 @@
 import { profileService } from '../profile/profileService';
+import { authService } from '../auth/authService.svelte';
 import { entitlementService } from '../auth/entitlementService.svelte';
+import { settingsService } from '../settings/settingsService.svelte';
 import { logService } from '../log/logService';
 import { diagnosticsService } from '../diagnostics/diagnosticsService.svelte';
 import * as commands from '../../lib/ipc/commands';
@@ -31,6 +33,12 @@ export const PERIODIC_SYNC_INTERVAL_MS = 60 * 1000;
  * sources to Rust, lets Rust's hash-based dirty tracking decide what to
  * upload, and fans the server's pulled records back through each
  * provider's `applyItemUpsert` / `applyItemDelete`.
+ *
+ * The whole machine only runs for a signed-in, entitled user who hasn't
+ * turned the `user.syncEnabled` preference off (see [`blockedReason`]).
+ * [`init`] (startup and post-login) arms a settings watcher that starts /
+ * stops sync when that preference flips; [`dispose`] (logout) tears
+ * everything down.
  */
 class CloudSyncService {
   status = $state<'idle' | 'syncing' | 'error'>('idle');
@@ -45,16 +53,55 @@ class CloudSyncService {
   private syncTimer: ReturnType<typeof setInterval> | null = null;
   private currentRun: Promise<void> | null = null;
   private providerUnsubs: Unsubscribe[] = [];
+  private settingsUnsub: (() => void) | null = null;
+  private lastEnabledSeen: boolean | null = null;
+
+  /**
+   * User preference (`user.syncEnabled`), defaulting to `true` so existing
+   * signed-in installs keep syncing. Reactive: reads through
+   * settingsService's `$state`, so UI bound to it updates when the setting
+   * flips (including via a pulled settings upsert).
+   */
+  get enabled(): boolean {
+    return settingsService.getSettings().user?.syncEnabled ?? true;
+  }
+
+  /**
+   * Why sync must not run right now, or `null` when it may. Sync needs an
+   * authenticated session (`sync_run` rejects without a token, so running
+   * signed-out just raises `sync.run-failed` diagnostics forever), the
+   * `sync:settings` entitlement, and the user preference. The entitlement
+   * check alone is NOT a sufficient gate: it fails open for signed-out
+   * users ("free tier: unrestricted").
+   */
+  private blockedReason(): string | null {
+    if (!authService.isLoggedIn) return 'cloud sync requires a signed-in account';
+    if (!entitlementService.check('sync:settings')) return 'sync:settings entitlement required';
+    if (!this.enabled) return 'cloud sync is disabled in settings';
+    return null;
+  }
 
   async init(): Promise<void> {
-    if (!entitlementService.check('sync:settings')) return;
+    this.watchSettings();
+    await this.start();
+  }
+
+  /**
+   * Begin actively syncing: startup pull/push, periodic timer, provider
+   * change subscriptions. No-ops unless every gate in [`blockedReason`]
+   * passes. Safe on the re-entry paths that exist — `startPeriodicSync`
+   * refuses a second timer and `subscribeToProviders` detaches stale
+   * handlers first.
+   */
+  private async start(): Promise<void> {
+    if (this.blockedReason() !== null) return;
 
     await this.checkStatus().catch((err) => {
       logService.warn(`Cloud sync checkStatus failed: ${err}`);
     });
 
     // Background syncNow — do not await; errors flow through diagnostics
-    // and `lastError`, but the caller of `init` shouldn't block on a
+    // and `lastError`, but the caller of `start` shouldn't block on a
     // network round-trip.
     this.syncNow().catch((err) => {
       logService.warn(`Cloud sync initial run failed: ${err}`);
@@ -62,6 +109,37 @@ class CloudSyncService {
 
     this.startPeriodicSync();
     this.subscribeToProviders();
+  }
+
+  /**
+   * Watch `user.syncEnabled` and start/stop sync when it flips, so the
+   * settings UI stays a plain settings-writer. `settingsService.subscribe`
+   * fires eagerly with the current settings (see its contract comment) —
+   * that priming call only records the starting value; [`init`] decides
+   * whether to start.
+   *
+   * The disable path tolerates a benign race: the settings write that
+   * flips the flag also fires settingsSyncProvider's change event, which
+   * can trigger one last change-driven [`syncNow`] before this watcher's
+   * [`stop`] detaches it — harmless, because the gate inside `syncNow`
+   * already sees the flag and rejects the run.
+   */
+  private watchSettings(): void {
+    if (this.settingsUnsub !== null) return;
+    this.settingsUnsub = settingsService.subscribe((settings) => {
+      const enabled = settings.user?.syncEnabled ?? true;
+      if (this.lastEnabledSeen === enabled) return;
+      const isPriming = this.lastEnabledSeen === null;
+      this.lastEnabledSeen = enabled;
+      if (isPriming) return;
+      if (enabled) {
+        this.start().catch((err) => {
+          logService.warn(`Cloud sync: start after enable failed: ${err}`);
+        });
+      } else {
+        this.stop();
+      }
+    });
   }
 
   startPeriodicSync(): void {
@@ -81,12 +159,11 @@ class CloudSyncService {
   }
 
   /**
-   * Full teardown — clears the periodic timer AND unsubscribes every
-   * provider change handler that `init()` wired up. Use on logout, hot
-   * reload, or any flow where the service should fully stop reacting.
-   * Safe to call multiple times.
+   * Pause active syncing — clears the periodic timer AND unsubscribes
+   * every provider change handler that [`start`] wired up. The settings
+   * watcher stays armed, so a later `syncEnabled` re-enable restarts sync.
    */
-  dispose(): void {
+  private stop(): void {
     this.stopPeriodicSync();
     for (const unsub of this.providerUnsubs) {
       try {
@@ -99,6 +176,24 @@ class CloudSyncService {
   }
 
   /**
+   * Full teardown — [`stop`] plus the settings watcher. Use on logout, hot
+   * reload, or any flow where the service should fully stop reacting; a
+   * later [`init`] re-arms everything. Safe to call multiple times.
+   */
+  dispose(): void {
+    this.stop();
+    if (this.settingsUnsub !== null) {
+      try {
+        this.settingsUnsub();
+      } catch (err) {
+        logService.warn(`Cloud sync: settings unsubscribe threw: ${err}`);
+      }
+      this.settingsUnsub = null;
+    }
+    this.lastEnabledSeen = null;
+  }
+
+  /**
    * Manually trigger one delta-sync round-trip. Replaces the old
    * `upload()` + `restore()` split — a single `sync_run` performs the
    * pull then the push.
@@ -108,8 +203,9 @@ class CloudSyncService {
    * events into one HTTP round-trip without any extra state.
    */
   async syncNow(): Promise<void> {
-    if (!entitlementService.check('sync:settings')) {
-      throw new Error('sync:settings entitlement required');
+    const blocked = this.blockedReason();
+    if (blocked !== null) {
+      throw new Error(blocked);
     }
     if (this.currentRun) {
       return this.currentRun;
@@ -121,7 +217,7 @@ class CloudSyncService {
   }
 
   async checkStatus(): Promise<void> {
-    if (!entitlementService.check('sync:settings')) return;
+    if (this.blockedReason() !== null) return;
     const statusResp = await commands.syncGetStatus();
     if (statusResp?.lastFullSyncAtIso) {
       this.lastSyncedAt = new Date(statusResp.lastFullSyncAtIso);

--- a/asyar-launcher/src/services/sync/cloudSyncService.test.ts
+++ b/asyar-launcher/src/services/sync/cloudSyncService.test.ts
@@ -18,9 +18,22 @@ vi.mock('../profile/profileService', () => ({
   },
 }));
 
+vi.mock('../auth/authService.svelte', () => ({
+  authService: {
+    isLoggedIn: true,
+  },
+}));
+
 vi.mock('../auth/entitlementService.svelte', () => ({
   entitlementService: {
     check: vi.fn(),
+  },
+}));
+
+vi.mock('../settings/settingsService.svelte', () => ({
+  settingsService: {
+    getSettings: vi.fn(),
+    subscribe: vi.fn(),
   },
 }));
 
@@ -43,9 +56,17 @@ vi.mock('../log/logService', () => ({
 import { cloudSyncService, PERIODIC_SYNC_INTERVAL_MS } from './cloudSyncService.svelte';
 import * as commands from '../../lib/ipc/commands';
 import { profileService } from '../profile/profileService';
+import { authService } from '../auth/authService.svelte';
 import { entitlementService } from '../auth/entitlementService.svelte';
+import { settingsService } from '../settings/settingsService.svelte';
 import { diagnosticsService } from '../diagnostics/diagnosticsService.svelte';
 import type { ISyncProvider, SyncChangeEvent, Unsubscribe } from '../profile/types';
+import type { AppSettings } from '../settings/types/AppSettingsType';
+
+/** Shorthand: point the settings mock at a given `user.syncEnabled` shape. */
+function mockUserSettings(user: AppSettings['user']): void {
+  vi.mocked(settingsService.getSettings).mockReturnValue({ user } as AppSettings);
+}
 
 const okReport: commands.SyncRunReport = {
   uploaded: [],
@@ -103,6 +124,21 @@ function asProviderList(...fakes: FakeProvider[]): ISyncProvider[] {
   return fakes as unknown as ISyncProvider[];
 }
 
+/**
+ * Let the startup run's microtask chain fully settle (`currentRun` → null).
+ *
+ * `vi.waitFor(syncRun called once)` can pass on its immediate first check —
+ * the un-awaited startup `syncNow()` reaches the `commands.syncRun` invoke
+ * before the test resumes from `await init()` — while `runOnce` still has a
+ * few microtasks left before its `.finally` clears the promise-singleton. A
+ * provider event emitted in that window is (by design) collapsed into the
+ * in-flight run and never produces a second `syncRun` call. One macrotask
+ * flushes the whole pending microtask queue.
+ */
+function settleInFlightRun(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
 describe('CloudSyncService (Task 4B delta-sync rewrite)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -110,9 +146,21 @@ describe('CloudSyncService (Task 4B delta-sync rewrite)', () => {
     cloudSyncService.lastSyncedAt = null;
     cloudSyncService.lastError = null;
     cloudSyncService.lastReport = null;
-    cloudSyncService.stopPeriodicSync();
-    // Default: entitlement granted + status returns no last-sync time.
+    // Reset the singleton's lifecycle state from the previous test —
+    // dispose() drops the settings watcher (and its priming memory) plus
+    // any provider subscriptions, so each test's init() re-arms cleanly.
+    cloudSyncService.dispose();
+    // Default: signed in, entitlement granted, sync enabled in settings,
+    // status returns no last-sync time.
+    authService.isLoggedIn = true;
     vi.mocked(entitlementService.check).mockReturnValue(true);
+    mockUserSettings({ syncEnabled: true });
+    // Mimic the real subscribe contract: fire eagerly with the current
+    // settings (the watcher's priming call), return an unsubscribe.
+    vi.mocked(settingsService.subscribe).mockImplementation((cb) => {
+      cb(settingsService.getSettings());
+      return vi.fn();
+    });
     vi.mocked(commands.syncGetStatus).mockResolvedValue({
       cursor: 0,
       deviceId: 'dev-A',
@@ -139,6 +187,42 @@ describe('CloudSyncService (Task 4B delta-sync rewrite)', () => {
       expect(commands.syncGetStatus).not.toHaveBeenCalled();
       expect(commands.syncRun).not.toHaveBeenCalled();
       expect(profileService.getProviders).not.toHaveBeenCalled();
+    });
+
+    // Regression (#461): the entitlement check fails open for signed-out
+    // users ("free tier: unrestricted"), so it alone must not gate sync —
+    // a signed-out launcher used to arm the timer and subscriptions, and
+    // every run failed Rust-side with "Not logged in", raising a
+    // `sync.run-failed` diagnostic each 60 s tick and provider change.
+    it('init_skips_when_signed_out_even_though_entitlement_check_passes', async () => {
+      authService.isLoggedIn = false;
+      vi.mocked(entitlementService.check).mockReturnValue(true);
+
+      await cloudSyncService.init();
+
+      expect(commands.syncGetStatus).not.toHaveBeenCalled();
+      expect(commands.syncRun).not.toHaveBeenCalled();
+      expect(profileService.getProviders).not.toHaveBeenCalled();
+    });
+
+    it('init_skips_when_user_disabled_sync_in_settings', async () => {
+      mockUserSettings({ syncEnabled: false });
+
+      await cloudSyncService.init();
+
+      expect(commands.syncGetStatus).not.toHaveBeenCalled();
+      expect(commands.syncRun).not.toHaveBeenCalled();
+      expect(profileService.getProviders).not.toHaveBeenCalled();
+    });
+
+    it('init_treats_absent_syncEnabled_setting_as_enabled', async () => {
+      // Pre-toggle installs have no `user.syncEnabled` key — sync must
+      // keep working for them without a migration.
+      mockUserSettings(undefined);
+
+      await cloudSyncService.init();
+
+      expect(commands.syncGetStatus).toHaveBeenCalledTimes(1);
     });
 
     it('init_pulls_then_pushes_then_starts_periodic_tick', async () => {
@@ -206,6 +290,22 @@ describe('CloudSyncService (Task 4B delta-sync rewrite)', () => {
       await expect(cloudSyncService.syncNow()).rejects.toThrow(
         'sync:settings entitlement required',
       );
+    });
+
+    it('throws when signed out', async () => {
+      authService.isLoggedIn = false;
+      await expect(cloudSyncService.syncNow()).rejects.toThrow(
+        'cloud sync requires a signed-in account',
+      );
+      expect(commands.syncRun).not.toHaveBeenCalled();
+    });
+
+    it('throws when sync is disabled in settings', async () => {
+      mockUserSettings({ syncEnabled: false });
+      await expect(cloudSyncService.syncNow()).rejects.toThrow(
+        'cloud sync is disabled in settings',
+      );
+      expect(commands.syncRun).not.toHaveBeenCalled();
     });
 
     it('stripField_strips_sensitive_fields_per_item', async () => {
@@ -495,6 +595,8 @@ describe('CloudSyncService (Task 4B delta-sync rewrite)', () => {
         expect(commands.syncRun).toHaveBeenCalledTimes(1);
       });
 
+      await settleInFlightRun();
+
       // Simulate a local change event from the provider.
       provider.__emit?.({ type: 'upsert', itemId: 's1', categoryId: 'snippets' });
 
@@ -522,6 +624,7 @@ describe('CloudSyncService (Task 4B delta-sync rewrite)', () => {
       await vi.waitFor(() => {
         expect(commands.syncRun).toHaveBeenCalledTimes(1);
       });
+      await settleInFlightRun();
 
       provider.__emit?.({ type: 'delete', itemId: 's-doomed', categoryId: 'snippets' });
 
@@ -541,6 +644,7 @@ describe('CloudSyncService (Task 4B delta-sync rewrite)', () => {
       await vi.waitFor(() => {
         expect(commands.syncRun).toHaveBeenCalledTimes(1);
       });
+      await settleInFlightRun();
 
       provider.__emit?.({ type: 'upsert', itemId: 's-edited', categoryId: 'snippets' });
 
@@ -562,6 +666,7 @@ describe('CloudSyncService (Task 4B delta-sync rewrite)', () => {
       await vi.waitFor(() => {
         expect(commands.syncRun).toHaveBeenCalledTimes(1);
       });
+      await settleInFlightRun();
 
       provider.__emit?.({ type: 'delete', itemId: 's-x', categoryId: 'snippets' });
 
@@ -569,6 +674,123 @@ describe('CloudSyncService (Task 4B delta-sync rewrite)', () => {
         expect(commands.syncMarkTombstone).toHaveBeenCalledTimes(1);
         expect(commands.syncRun).toHaveBeenCalledTimes(2);
       });
+    });
+  });
+
+  // ── reactive syncEnabled lifecycle ─────────────────────────────────────────
+
+  describe('settings watcher (user.syncEnabled)', () => {
+    it('flipping syncEnabled off stops the timer and provider subscriptions', async () => {
+      vi.useFakeTimers();
+      try {
+        const provider = makeProvider({ id: 'snippets' });
+        vi.mocked(profileService.getProviders).mockReturnValue(asProviderList(provider));
+
+        await cloudSyncService.init();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(commands.syncRun).toHaveBeenCalledTimes(1);
+        expect(provider.__emit).toBeDefined();
+
+        const watch = vi.mocked(settingsService.subscribe).mock.calls[0][0];
+        mockUserSettings({ syncEnabled: false });
+        watch(settingsService.getSettings());
+
+        // Provider subscription is gone — the AccountTab toggle never
+        // touches the service, so this watcher is the only off switch.
+        expect(provider.__emit).toBeUndefined();
+
+        // Timer is gone — periodic ticks no longer fire.
+        vi.mocked(commands.syncRun).mockClear();
+        await vi.advanceTimersByTimeAsync(PERIODIC_SYNC_INTERVAL_MS);
+        expect(commands.syncRun).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('flipping syncEnabled back on restarts sync', async () => {
+      const provider = makeProvider({ id: 'snippets' });
+      vi.mocked(profileService.getProviders).mockReturnValue(asProviderList(provider));
+
+      await cloudSyncService.init();
+      await vi.waitFor(() => {
+        expect(commands.syncRun).toHaveBeenCalledTimes(1);
+      });
+      const watch = vi.mocked(settingsService.subscribe).mock.calls[0][0];
+
+      mockUserSettings({ syncEnabled: false });
+      watch(settingsService.getSettings());
+      expect(provider.__emit).toBeUndefined();
+
+      mockUserSettings({ syncEnabled: true });
+      watch(settingsService.getSettings());
+
+      // start() runs again asynchronously — the status check fires first
+      // and the provider re-subscription lands a few microtasks later, so
+      // both belong inside the waitFor.
+      await vi.waitFor(() => {
+        expect(commands.syncGetStatus).toHaveBeenCalledTimes(2);
+        expect(provider.subscribeToChanges).toHaveBeenCalledTimes(2);
+      });
+      expect(provider.__emit).toBeDefined();
+    });
+
+    it('the priming call and unchanged re-fires are no-ops', async () => {
+      const provider = makeProvider({ id: 'snippets' });
+      vi.mocked(profileService.getProviders).mockReturnValue(asProviderList(provider));
+
+      // init() already produced the priming call via the subscribe mock.
+      await cloudSyncService.init();
+      await vi.waitFor(() => {
+        expect(commands.syncRun).toHaveBeenCalledTimes(1);
+      });
+      expect(provider.subscribeToChanges).toHaveBeenCalledTimes(1);
+
+      // The subscribe callback re-fires on ANY settings change; a re-fire
+      // with the same enabled value must not restart or stop anything.
+      const watch = vi.mocked(settingsService.subscribe).mock.calls[0][0];
+      watch(settingsService.getSettings());
+
+      expect(provider.subscribeToChanges).toHaveBeenCalledTimes(1);
+      expect(provider.__emit).toBeDefined();
+      expect(commands.syncGetStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it('flip to enabled while signed out does not start sync', async () => {
+      authService.isLoggedIn = false;
+      mockUserSettings({ syncEnabled: false });
+
+      // Arms the watcher; start() itself is gated on auth.
+      await cloudSyncService.init();
+      const watch = vi.mocked(settingsService.subscribe).mock.calls[0][0];
+
+      mockUserSettings({ syncEnabled: true });
+      watch(settingsService.getSettings());
+
+      // Give a (buggy) async start a beat to surface before asserting.
+      await new Promise((r) => setTimeout(r, 0));
+      expect(commands.syncGetStatus).not.toHaveBeenCalled();
+      expect(commands.syncRun).not.toHaveBeenCalled();
+    });
+
+    it('init() arms the settings watcher exactly once across re-entry', async () => {
+      // Startup + post-login both call init(); the watcher must not stack.
+      await cloudSyncService.init();
+      await cloudSyncService.init();
+      expect(settingsService.subscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispose() drops the settings watcher; a later init() re-arms it', async () => {
+      await cloudSyncService.init();
+      const watcherUnsub = vi.mocked(settingsService.subscribe).mock.results[0].value as ReturnType<
+        typeof vi.fn
+      >;
+
+      cloudSyncService.dispose();
+      expect(watcherUnsub).toHaveBeenCalledTimes(1);
+
+      await cloudSyncService.init();
+      expect(settingsService.subscribe).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -596,6 +818,14 @@ describe('CloudSyncService (Task 4B delta-sync rewrite)', () => {
       await cloudSyncService.checkStatus();
 
       expect(cloudSyncService.lastSyncedAt).toBeNull();
+    });
+
+    it('is a no-op when signed out', async () => {
+      authService.isLoggedIn = false;
+
+      await cloudSyncService.checkStatus();
+
+      expect(commands.syncGetStatus).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Closes #461, following the design discussed there.

### Problem

Cloud sync's only guard was `entitlementService.check('sync:settings')`, which intentionally fails open for signed-out users ("free tier: unrestricted"). Three consequences, detailed in #461:

1. A signed-out launcher armed the 60-second timer and all provider change subscriptions; every `sync_run` failed Rust-side with `Not logged in`, surfacing `sync.run-failed` diagnostics on every tick and every local change (e.g. each clipboard copy) — with no sync UI rendered to stop it.
2. Signing in mid-session never started sync: only `appInitializer` calls `cloudSyncService.init()`.
3. There was no way to turn sync off while staying signed in.

### Changes

- **Auth guard lives in `cloudSyncService`** (not in `entitlementService.check()`, whose logged-out-permissive default other callers rely on): a single `blockedReason()` requires `authService.isLoggedIn` AND the `sync:settings` entitlement AND the `user.syncEnabled` preference. `init()`/`checkStatus()` no-op and `syncNow()` throws (with the reason) when any gate fails; the entitlement-missing error string is unchanged.
- **`user.syncEnabled` is now honored** — it was already declared in `AppSettingsType` but never read. Absent = enabled, so existing installs keep syncing without a migration.
- **Reactive lifecycle:** `init()` (startup and post-login) arms an idempotent watcher on `settingsService.subscribe()`; the service splits into `start()` (status check, startup sync, timer, provider subscriptions — gated) and `stop()` (timer + provider unsubscriptions), and the watcher flips between them when `user.syncEnabled` changes. The eager priming call just records the starting value. `dispose()` (logout) is `stop()` plus dropping the watcher. The settings write that disables sync can race one last change-driven `syncNow()` from its own change event — harmless, the gate rejects it (commented in the code).
- **Login wiring:** `authService._applyPollResult()` — the choke point both login paths go through — starts sync after a fresh login, mirroring the `dispose()` already wired into `logout()`, with the same dynamic import to break the module cycle.
- **Account tab:** new "Cloud Sync" toggle row that only writes the setting (optimistic local mirror, reset if the write fails — same idiom as the Encrypted Sync toggle); the Last Synced / Sync Now / Encrypted Sync rows render only while enabled.

### Test notes

- New coverage: init/syncNow/checkStatus skip or throw when signed out (regression for the fail-open gate) or when disabled in settings; absent `syncEnabled` treated as enabled; watcher flip-off detaches the timer and provider subscriptions; flip-on restarts; priming and unchanged re-fires are no-ops; flip-on while signed out stays stopped; double-`init()` doesn't stack watchers; `dispose()` drops the watcher for re-arming.
- Four pre-existing provider-change tests gained an explicit `settleInFlightRun()` between "startup run observed" and the provider emit. `init()` now awaits an intermediate `start()`, which shifts the startup `syncRun` call one microtask earlier — `vi.waitFor(called once)` can then pass while the startup run's promise-singleton is still in flight, and an event emitted in that window is (by design) collapsed into it. The helper's doc comment carries the full explanation; production behavior is unchanged.
- Full frontend suite + Prettier green. No Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016njrrKV7JXYwwwwqoAs9GB
