### PR TITLE
feat(launcher): add an isolated dev flavor via a separate Tauri identifier

### DIFF
--- a/asyar-launcher/package.json
+++ b/asyar-launcher/package.json
@@ -11,6 +11,7 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "tauri": "tauri",
+    "tauri:dev:isolated": "tauri dev --config src-tauri/tauri.dev.conf.json",
     "release": "node scripts/release.js",
     "test": "vitest",
     "test:run": "vitest run",

--- a/asyar-launcher/src-tauri/src/commands/oauth.rs
+++ b/asyar-launcher/src-tauri/src/commands/oauth.rs
@@ -1,3 +1,4 @@
+use crate::deeplink::deep_link_scheme;
 use crate::error::AppError;
 use crate::oauth::{
     service, token_store, OAuthExchangeResponse, OAuthPendingFlowState, OAuthStartResponse,
@@ -15,6 +16,7 @@ use tauri::{AppHandle, State};
 #[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn oauth_start_flow(
+    app: AppHandle,
     extension_id: String,
     provider_id: String,
     client_id: String,
@@ -26,6 +28,9 @@ pub async fn oauth_start_flow(
 ) -> Result<OAuthStartResponse, AppError> {
     let (code_verifier, code_challenge) = crate::oauth::pkce::generate_pkce_pair();
     let state = crate::oauth::pkce::generate_state();
+    // Use this instance's own deep-link scheme (asyar vs asyar-dev) so the
+    // provider's redirect comes back to the flavor that started the flow.
+    let redirect_uri = format!("{}://oauth/callback", deep_link_scheme(&app));
 
     let auth_url = crate::oauth::pkce::build_auth_url(
         &authorization_url,
@@ -33,6 +38,7 @@ pub async fn oauth_start_flow(
         &code_challenge,
         &state,
         &scopes,
+        &redirect_uri,
     )?;
 
     pending_flows.insert(
@@ -44,6 +50,7 @@ pub async fn oauth_start_flow(
             code_verifier,
             token_url,
             client_id,
+            redirect_uri,
         },
     );
 

--- a/asyar-launcher/src-tauri/src/deeplink.rs
+++ b/asyar-launcher/src-tauri/src/deeplink.rs
@@ -1,8 +1,23 @@
 use serde::Serialize;
 use std::collections::HashMap;
+use tauri::AppHandle;
+
+/// The custom URL scheme this running instance is registered for with the
+/// OS. Mirrors `plugins.deep-link.desktop.schemes` in the active tauri
+/// config — `tauri.conf.json` (`asyar`) for production, `tauri.dev.conf.json`
+/// (`asyar-dev`) for the local dev flavor. Production and dev must never
+/// register the same scheme, or the OS can deliver an OAuth or extension
+/// deep link to the wrong flavor.
+pub fn deep_link_scheme(app: &AppHandle) -> &'static str {
+    if app.config().identifier == "org.asyar.dev" {
+        "asyar-dev"
+    } else {
+        "asyar"
+    }
+}
 
 /// Typed payload emitted as `asyar:deeplink:extension` when a deep link
-/// targets an extension command: `asyar://extensions/{extensionId}/{commandId}?args`.
+/// targets an extension command: `{scheme}://extensions/{extensionId}/{commandId}?args`.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtensionDeeplinkPayload {
@@ -11,15 +26,18 @@ pub struct ExtensionDeeplinkPayload {
     pub args: HashMap<String, String>,
 }
 
-/// Attempts to parse an `asyar://extensions/{extensionId}/{commandId}?args` URL.
+/// Attempts to parse a `{expected_scheme}://extensions/{extensionId}/{commandId}?args` URL.
 ///
 /// Returns `None` (and logs a warning) if the URL is not an extension deep link,
 /// has missing/empty segments, or contains unsafe characters in the extension ID.
-pub fn parse_extension_deeplink(raw: &str) -> Option<ExtensionDeeplinkPayload> {
+pub fn parse_extension_deeplink(
+    raw: &str,
+    expected_scheme: &str,
+) -> Option<ExtensionDeeplinkPayload> {
     let parsed = url::Url::parse(raw).ok()?;
 
-    // Must be the asyar scheme
-    if parsed.scheme() != "asyar" {
+    // Must be this flavor's registered scheme
+    if parsed.scheme() != expected_scheme {
         return None;
     }
 
@@ -85,6 +103,7 @@ mod tests {
     fn parses_valid_deeplink_with_args() {
         let result = parse_extension_deeplink(
             "asyar://extensions/com.example.weather/check?city=Berlin&units=metric",
+            "asyar",
         );
         let payload = result.expect("should parse successfully");
         assert_eq!(payload.extension_id, "com.example.weather");
@@ -95,7 +114,7 @@ mod tests {
 
     #[test]
     fn parses_valid_deeplink_without_args() {
-        let result = parse_extension_deeplink("asyar://extensions/com.example.calc/run");
+        let result = parse_extension_deeplink("asyar://extensions/com.example.calc/run", "asyar");
         let payload = result.expect("should parse successfully");
         assert_eq!(payload.extension_id, "com.example.calc");
         assert_eq!(payload.command_id, "run");
@@ -104,12 +123,12 @@ mod tests {
 
     #[test]
     fn rejects_missing_command_id() {
-        assert!(parse_extension_deeplink("asyar://extensions/com.example.calc").is_none());
+        assert!(parse_extension_deeplink("asyar://extensions/com.example.calc", "asyar").is_none());
     }
 
     #[test]
     fn rejects_empty_extension_id() {
-        assert!(parse_extension_deeplink("asyar://extensions//run").is_none());
+        assert!(parse_extension_deeplink("asyar://extensions//run", "asyar").is_none());
     }
 
     #[test]
@@ -117,18 +136,21 @@ mod tests {
         // Dots in isolation are fine (e.g. "com.example"), but characters like
         // slashes or percent-encoded slashes would be caught by the URL parser
         // or the character allowlist. Test that special chars are rejected:
-        assert!(parse_extension_deeplink("asyar://extensions/ext%2F..%2Fetc/run").is_none());
-        assert!(parse_extension_deeplink("asyar://extensions/ext%00id/run").is_none());
+        assert!(
+            parse_extension_deeplink("asyar://extensions/ext%2F..%2Fetc/run", "asyar").is_none()
+        );
+        assert!(parse_extension_deeplink("asyar://extensions/ext%00id/run", "asyar").is_none());
     }
 
     #[test]
     fn rejects_non_extension_deeplinks() {
-        assert!(parse_extension_deeplink("asyar://auth/callback?code=abc").is_none());
+        assert!(parse_extension_deeplink("asyar://auth/callback?code=abc", "asyar").is_none());
     }
 
     #[test]
     fn handles_url_encoded_args() {
-        let result = parse_extension_deeplink("asyar://extensions/ext/cmd?q=hello%20world&n=42");
+        let result =
+            parse_extension_deeplink("asyar://extensions/ext/cmd?q=hello%20world&n=42", "asyar");
         let payload = result.expect("should parse successfully");
         assert_eq!(payload.args.get("q"), Some(&"hello world".to_string()));
         assert_eq!(payload.args.get("n"), Some(&"42".to_string()));
@@ -136,12 +158,12 @@ mod tests {
 
     #[test]
     fn rejects_non_asyar_scheme() {
-        assert!(parse_extension_deeplink("https://extensions/com.example/cmd").is_none());
+        assert!(parse_extension_deeplink("https://extensions/com.example/cmd", "asyar").is_none());
     }
 
     #[test]
     fn accepts_hyphenated_and_underscored_ids() {
-        let result = parse_extension_deeplink("asyar://extensions/my-ext_v2/do-thing_now");
+        let result = parse_extension_deeplink("asyar://extensions/my-ext_v2/do-thing_now", "asyar");
         let payload = result.expect("should parse successfully");
         assert_eq!(payload.extension_id, "my-ext_v2");
         assert_eq!(payload.command_id, "do-thing_now");
@@ -162,14 +184,35 @@ mod tests {
 
     #[test]
     fn parses_store_browse_deeplink_with_slug() {
-        let result =
-            parse_extension_deeplink("asyar://extensions/store/browse?slug=pomodoro-timer");
+        let result = parse_extension_deeplink(
+            "asyar://extensions/store/browse?slug=pomodoro-timer",
+            "asyar",
+        );
         let payload = result.expect("should parse store browse deeplink");
         assert_eq!(payload.extension_id, "store");
         assert_eq!(payload.command_id, "browse");
         assert_eq!(
             payload.args.get("slug"),
             Some(&"pomodoro-timer".to_string())
+        );
+    }
+
+    #[test]
+    fn accepts_dev_scheme_when_expected() {
+        let result =
+            parse_extension_deeplink("asyar-dev://extensions/com.example.calc/run", "asyar-dev");
+        let payload = result.expect("should parse the dev-flavor scheme");
+        assert_eq!(payload.extension_id, "com.example.calc");
+        assert_eq!(payload.command_id, "run");
+    }
+
+    #[test]
+    fn rejects_prod_scheme_when_dev_expected() {
+        // A link for the installed production app must not be accepted by a
+        // dev-flavor instance, and vice versa — the two must stay isolated.
+        assert!(
+            parse_extension_deeplink("asyar://extensions/com.example.calc/run", "asyar-dev")
+                .is_none()
         );
     }
 }

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -946,18 +946,22 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         app.manage(extension_tray::ExtensionTrayManager::new(Box::new(backend)));
     }
 
-    // Deep link handler — routes incoming asyar:// URLs.
-    // Extension deep links (asyar://extensions/{extId}/{cmdId}?args) are parsed
-    // in Rust and emitted as a typed "asyar:deeplink:extension" event.
+    // Deep link handler — routes incoming {scheme}:// URLs, where scheme is
+    // "asyar" for production or "asyar-dev" for the local dev flavor (see
+    // deeplink::deep_link_scheme and tauri.dev.conf.json).
+    // Extension deep links ({scheme}://extensions/{extId}/{cmdId}?args) are
+    // parsed in Rust and emitted as a typed "asyar:deeplink:extension" event.
     // All other URLs (auth, OAuth) are emitted as raw "asyar:deep-link" strings.
     {
         use tauri_plugin_deep_link::DeepLinkExt;
         let handle = app.handle().clone();
+        let scheme = deeplink::deep_link_scheme(&handle);
+        let extensions_prefix = format!("{scheme}://extensions/");
         app.deep_link().on_open_url(move |event| {
             let urls: Vec<String> = event.urls().iter().map(|u| u.to_string()).collect();
             for url in urls {
-                if url.starts_with("asyar://extensions/") {
-                    match deeplink::parse_extension_deeplink(&url) {
+                if url.starts_with(&extensions_prefix) {
+                    match deeplink::parse_extension_deeplink(&url, scheme) {
                         Some(payload) => {
                             log::info!(
                                 "[Deeplink] Extension trigger: {}/{}",

--- a/asyar-launcher/src-tauri/src/oauth/mod.rs
+++ b/asyar-launcher/src-tauri/src/oauth/mod.rs
@@ -21,6 +21,11 @@ pub struct PendingOAuthFlow {
     pub code_verifier: String,
     pub token_url: String,
     pub client_id: String,
+    /// The redirect_uri sent to the authorization request, using this
+    /// instance's own deep-link scheme (`deeplink::deep_link_scheme`).
+    /// Reused verbatim for the token exchange — the provider requires an
+    /// exact match between the two.
+    pub redirect_uri: String,
 }
 
 /// An OAuth 2.0 token set returned to the extension after a successful flow.

--- a/asyar-launcher/src-tauri/src/oauth/pkce.rs
+++ b/asyar-launcher/src-tauri/src/oauth/pkce.rs
@@ -33,20 +33,24 @@ pub fn generate_state() -> String {
 /// Build the full authorization URL with PKCE + state query params.
 ///
 /// Appends: client_id, response_type=code, redirect_uri, code_challenge,
-/// code_challenge_method=S256, state, scope.
+/// code_challenge_method=S256, state, scope. `redirect_uri` must use this
+/// running instance's registered deep-link scheme (see
+/// `deeplink::deep_link_scheme`) so the OS delivers the callback to the
+/// flavor that started the flow rather than whichever one owns `asyar://`.
 pub fn build_auth_url(
     authorization_url: &str,
     client_id: &str,
     code_challenge: &str,
     state: &str,
     scopes: &[String],
+    redirect_uri: &str,
 ) -> Result<String, AppError> {
     let mut url = url::Url::parse(authorization_url)
         .map_err(|_| AppError::Validation("Invalid authorization URL".into()))?;
     url.query_pairs_mut()
         .append_pair("client_id", client_id)
         .append_pair("response_type", "code")
-        .append_pair("redirect_uri", "asyar://oauth/callback")
+        .append_pair("redirect_uri", redirect_uri)
         .append_pair("code_challenge", code_challenge)
         .append_pair("code_challenge_method", "S256")
         .append_pair("state", state)
@@ -113,6 +117,7 @@ mod tests {
             "abc123challenge",
             "xyz-state",
             &scopes,
+            "asyar://oauth/callback",
         )
         .unwrap();
 
@@ -131,8 +136,31 @@ mod tests {
     }
 
     #[test]
+    fn build_auth_url_uses_the_given_redirect_uri() {
+        // The dev flavor must send its own scheme, not the prod one — see
+        // deeplink::deep_link_scheme.
+        let url = build_auth_url(
+            "https://github.com/login/oauth/authorize",
+            "cid",
+            "ch",
+            "st",
+            &[],
+            "asyar-dev://oauth/callback",
+        )
+        .unwrap();
+        assert!(url.contains("redirect_uri=asyar-dev%3A%2F%2Foauth%2Fcallback"));
+    }
+
+    #[test]
     fn build_auth_url_invalid_base_url_returns_error() {
-        let result = build_auth_url("not-a-url", "cid", "ch", "st", &[]);
+        let result = build_auth_url(
+            "not-a-url",
+            "cid",
+            "ch",
+            "st",
+            &[],
+            "asyar://oauth/callback",
+        );
         assert!(result.is_err());
     }
 }

--- a/asyar-launcher/src-tauri/src/oauth/service.rs
+++ b/asyar-launcher/src-tauri/src/oauth/service.rs
@@ -68,7 +68,7 @@ pub(crate) async fn exchange_code_for_token(
     let params = [
         ("grant_type", "authorization_code"),
         ("code", code),
-        ("redirect_uri", "asyar://oauth/callback"),
+        ("redirect_uri", flow.redirect_uri.as_str()),
         ("client_id", &flow.client_id),
         ("code_verifier", &flow.code_verifier),
     ];

--- a/asyar-launcher/src-tauri/tauri.dev.conf.json
+++ b/asyar-launcher/src-tauri/tauri.dev.conf.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Asyar Dev",
-  "identifier": "org.asyar.dev"
+  "identifier": "org.asyar.dev",
+  "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": ["asyar-dev"]
+      }
+    }
+  }
 }

--- a/asyar-launcher/src-tauri/tauri.dev.conf.json
+++ b/asyar-launcher/src-tauri/tauri.dev.conf.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Asyar Dev",
+  "identifier": "org.asyar.dev"
+}

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -28,7 +28,14 @@ const sdkWatch = spawn('pnpm', ['run', 'watch'], {
   shell: true,
 });
 
-const launcherDev = spawn('pnpm', ['tauri', 'dev'], {
+// --config merges tauri.dev.conf.json (JSON Merge Patch) over tauri.conf.json,
+// giving the dev build its own identifier (org.asyar.dev) so it gets a fully
+// separate app data dir from the installed production app — extensions,
+// snippets, search index, caches, and login/auth are all isolated. The only
+// thing shared by default is which backend they talk to (both point at
+// asyar.org); override with ASYAR_API_BASE to test against a different one
+// (see auth/api_client.rs).
+const launcherDev = spawn('pnpm', ['tauri', 'dev', '--config', 'src-tauri/tauri.dev.conf.json'], {
   cwd: resolve(root, 'asyar-launcher'),
   stdio: 'inherit',
   shell: true,


### PR DESCRIPTION
Local `pnpm dev` builds were sharing extensions, snippets, search index,
and login with the installed production app. --config-merge a
tauri.dev.conf.json (org.asyar.dev) so the dev flavor gets its own app
data dir, keeping only the backend URL (overridable via ASYAR_API_BASE)
shared with production.