### PR TITLE
fix(launcher): resolve new Clippy lints from Rust 1.97

### DIFF
--- a/asyar-launcher/src-tauri/src/commands/profile.rs
+++ b/asyar-launcher/src-tauri/src/commands/profile.rs
@@ -152,7 +152,7 @@ pub async fn import_profile(
             let salt = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, salt_b64)
                 .unwrap_or_default();
 
-            for (_filename, json_str) in contents.category_files.iter_mut() {
+            for json_str in contents.category_files.values_mut() {
                 let mut value: Value = serde_json::from_str(json_str)?;
                 decrypt_sensitive_fields(&mut value, pw, &salt)?;
                 *json_str = serde_json::to_string_pretty(&value)?;

--- a/asyar-launcher/src-tauri/src/commands/shortcuts.rs
+++ b/asyar-launcher/src-tauri/src/commands/shortcuts.rs
@@ -186,7 +186,7 @@ pub fn resume_user_shortcuts(
 ) -> Result<(), AppError> {
     let user_shortcuts = state.user_shortcuts.lock().map_err(|_| AppError::Lock)?;
     let shortcut_manager = app_handle.global_shortcut();
-    for (shortcut_str, _object_id) in user_shortcuts.iter() {
+    for shortcut_str in user_shortcuts.keys() {
         if let Ok(shortcut) = parse_shortcut(shortcut_str) {
             // Ignore errors — shortcut may already be registered
             let _ = shortcut_manager.register(shortcut);
@@ -239,7 +239,7 @@ pub fn resume_all_shortcuts(
 
     // Resume user item shortcuts
     let user_shortcuts = state.user_shortcuts.lock().map_err(|_| AppError::Lock)?;
-    for (shortcut_str, _object_id) in user_shortcuts.iter() {
+    for shortcut_str in user_shortcuts.keys() {
         if let Ok(shortcut) = parse_shortcut(shortcut_str) {
             let _ = shortcut_manager.register(shortcut);
         }

--- a/asyar-launcher/src-tauri/src/extensions/updater.rs
+++ b/asyar-launcher/src-tauri/src/extensions/updater.rs
@@ -146,8 +146,8 @@ pub async fn update_extension(
 ) -> Result<(), AppError> {
     let base_dir = get_app_data_dir(app_handle)?.join("extensions");
     let live_dir = base_dir.join(&update.extension_id);
-    let staging_dir = base_dir.join(format!("{}_updating", &update.extension_id));
-    let backup_dir = base_dir.join(format!("{}_old", &update.extension_id));
+    let staging_dir = base_dir.join(format!("{}_updating", update.extension_id));
+    let backup_dir = base_dir.join(format!("{}_old", update.extension_id));
 
     // Clean up any leftover dirs from a previous failed update
     if staging_dir.exists() {


### PR DESCRIPTION
## Summary

Rust 1.97.0 (released 2026-07-07) ships a Clippy that flags five existing spots in the launcher, so the `cargo clippy --all-targets -- -D warnings` CI step now fails on every PR regardless of what it touches (e.g. the TypeScript-only #475).

- `for_kv_map`: iterate `category_files.values_mut()` in `profile.rs`, and `user_shortcuts.keys()` (×2) in `shortcuts.rs`, instead of destructuring pairs and ignoring half.
- `useless_borrows_in_formatting`: drop the redundant `&` on `update.extension_id` in two `format!` calls in `updater.rs`.

Mechanical only; no behavior change.

## Testing

- `cargo clippy --all-targets -- -D warnings` clean on Rust 1.97.0 (reproduced the 5 CI errors on unpatched `main` first).
- `cargo fmt --check` clean; tests covering the touched modules pass (80 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)