### PR TITLE
fix(cli): narrow GitHub device-flow scope to public_repo

### DIFF
--- a/asyar-sdk/cli/lib/auth.ts
+++ b/asyar-sdk/cli/lib/auth.ts
@@ -137,7 +137,12 @@ export async function getOrAuthorizeGitHub(): Promise<string> {
       },
       body: new URLSearchParams({
         client_id: GITHUB_CLI_CLIENT_ID,
-        scope: 'repo read:user',
+        // Publishing only ever touches the publisher's public extension
+        // repos (create repo, push, create release, upload asset), so
+        // public_repo suffices — full `repo` would also grant read/write
+        // on every private repo the account can reach. No read:user
+        // either: the CLI never calls an endpoint that needs it.
+        scope: 'public_repo',
       }).toString(),
     });
   } catch (err: any) {


### PR DESCRIPTION
## Summary

The CLI half of #473, per your review there: the device flow requested `repo read:user` — full `repo` grants read/write on every private repository the account can reach, far more than publishing needs. Publishing only ever creates a public repo, pushes to it, creates a release, and uploads an asset, so the scope is now `public_repo` — and `read:user` is dropped entirely since no CLI code path calls an endpoint that needs it.

Classic OAuth scopes are requested at runtime, so no OAuth-app reconfiguration is needed. Previously stored broad tokens can be swapped with `asyar publish --reset-auth`.

As you noted, the store-login scope is a server-side change on your end, so this addresses the CLI portion only.

## Testing

- `tsc -p tsconfig.cli.json --noEmit` clean; Prettier clean; SDK CLI suite passing.

Refs #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)