### PR TITLE
feat(cli): honor GITHUB_TOKEN to bypass the device flow

### DIFF
--- a/asyar-sdk/cli/lib/auth.test.ts
+++ b/asyar-sdk/cli/lib/auth.test.ts
@@ -6,7 +6,7 @@ vi.mock('child_process', () => {
 });
 
 import { execFile } from 'child_process';
-import { openBrowser } from './auth';
+import { openBrowser, getOrAuthorizeGitHub } from './auth';
 
 describe('openBrowser', () => {
   const realPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
@@ -63,5 +63,32 @@ describe('openBrowser', () => {
     openBrowser('https://example.com/a"b`c');
     const [, args] = vi.mocked(execFile).mock.calls[0] as unknown as [string, string[]];
     expect(args[0]).toBe('https://example.com/a%22b%60c');
+  });
+});
+
+describe('getOrAuthorizeGitHub', () => {
+  const originalToken = process.env.GITHUB_TOKEN;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalToken;
+    }
+  });
+
+  it('returns a GITHUB_TOKEN from the environment without touching stored auth', async () => {
+    process.env.GITHUB_TOKEN = 'github_pat_test_value';
+    await expect(getOrAuthorizeGitHub()).resolves.toBe('github_pat_test_value');
+  });
+
+  it('trims surrounding whitespace from the environment token', async () => {
+    process.env.GITHUB_TOKEN = '  github_pat_test_value\n';
+    await expect(getOrAuthorizeGitHub()).resolves.toBe('github_pat_test_value');
   });
 });

--- a/asyar-sdk/cli/lib/auth.ts
+++ b/asyar-sdk/cli/lib/auth.ts
@@ -120,6 +120,17 @@ export async function requireAuth(): Promise<{
 }
 
 export async function getOrAuthorizeGitHub(): Promise<string> {
+  // A GITHUB_TOKEN in the environment wins over the stored token and the
+  // device flow. This lets publishers scope access themselves — e.g. a
+  // fine-grained PAT with Contents read/write on the one extension repo —
+  // instead of granting the OAuth app's account-wide scope, and lets CI
+  // publish without an interactive flow.
+  const envToken = process.env.GITHUB_TOKEN?.trim();
+  if (envToken) {
+    console.log(chalk.gray('Using GitHub token from GITHUB_TOKEN environment variable.'));
+    return envToken;
+  }
+
   const keytar = require('keytar');
   const existing = await keytar.getPassword(KEYCHAIN_SERVICE, KEY_GITHUB_TOKEN);
   if (existing) return existing;


### PR DESCRIPTION
## Summary

The quick follow-up you endorsed in #473: `getOrAuthorizeGitHub()` now checks a `GITHUB_TOKEN` environment variable before the stored token and the device flow. Publishers who want tighter control than any classic OAuth scope can use a fine-grained PAT scoped to Contents read/write on the single extension repo, and CI can publish without an interactive flow.

## Testing

- Two new vitest cases in `auth.test.ts` (env token returned without touching stored auth; whitespace trimmed).
- `tsc -p tsconfig.cli.json --noEmit` clean; Prettier clean; full auth suite 8/8.

Refs #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)