### PR TITLE
feat(cli): also honor GH_TOKEN, preferring it over GITHUB_TOKEN

### DIFF
--- a/asyar-sdk/cli/lib/auth.test.ts
+++ b/asyar-sdk/cli/lib/auth.test.ts
@@ -67,24 +67,45 @@ describe('openBrowser', () => {
 });
 
 describe('getOrAuthorizeGitHub', () => {
-  const originalToken = process.env.GITHUB_TOKEN;
+  const originalGithubToken = process.env.GITHUB_TOKEN;
+  const originalGhToken = process.env.GH_TOKEN;
 
   beforeEach(() => {
+    // Clear both variables so an ambient token on the developer's machine
+    // (common for gh CLI users) can't leak into the single-variable cases.
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
     vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    if (originalToken === undefined) {
+    if (originalGithubToken === undefined) {
       delete process.env.GITHUB_TOKEN;
     } else {
-      process.env.GITHUB_TOKEN = originalToken;
+      process.env.GITHUB_TOKEN = originalGithubToken;
+    }
+    if (originalGhToken === undefined) {
+      delete process.env.GH_TOKEN;
+    } else {
+      process.env.GH_TOKEN = originalGhToken;
     }
   });
 
   it('returns a GITHUB_TOKEN from the environment without touching stored auth', async () => {
     process.env.GITHUB_TOKEN = 'github_pat_test_value';
     await expect(getOrAuthorizeGitHub()).resolves.toBe('github_pat_test_value');
+  });
+
+  it('returns a GH_TOKEN from the environment when GITHUB_TOKEN is not set', async () => {
+    process.env.GH_TOKEN = 'gh_pat_test_value';
+    await expect(getOrAuthorizeGitHub()).resolves.toBe('gh_pat_test_value');
+  });
+
+  it('prefers GH_TOKEN over GITHUB_TOKEN, matching the gh CLI ordering', async () => {
+    process.env.GITHUB_TOKEN = 'github_pat_test_value';
+    process.env.GH_TOKEN = 'gh_pat_test_value';
+    await expect(getOrAuthorizeGitHub()).resolves.toBe('gh_pat_test_value');
   });
 
   it('trims surrounding whitespace from the environment token', async () => {

--- a/asyar-sdk/cli/lib/auth.ts
+++ b/asyar-sdk/cli/lib/auth.ts
@@ -120,14 +120,18 @@ export async function requireAuth(): Promise<{
 }
 
 export async function getOrAuthorizeGitHub(): Promise<string> {
-  // A GITHUB_TOKEN in the environment wins over the stored token and the
-  // device flow. This lets publishers scope access themselves — e.g. a
-  // fine-grained PAT with Contents read/write on the one extension repo —
-  // instead of granting the OAuth app's account-wide scope, and lets CI
-  // publish without an interactive flow.
-  const envToken = process.env.GITHUB_TOKEN?.trim();
+  // A GH_TOKEN or GITHUB_TOKEN in the environment wins over the stored
+  // token and the device flow. This lets publishers scope access
+  // themselves — e.g. a fine-grained PAT with Contents read/write on the
+  // one extension repo — instead of granting the OAuth app's account-wide
+  // scope, and lets CI publish without an interactive flow. GH_TOKEN takes
+  // precedence, matching the gh CLI's documented ordering: GITHUB_TOKEN is
+  // ambient in GitHub Actions, while GH_TOKEN is only ever set on purpose.
+  const ghToken = process.env.GH_TOKEN?.trim();
+  const envToken = ghToken || process.env.GITHUB_TOKEN?.trim();
   if (envToken) {
-    console.log(chalk.gray('Using GitHub token from GITHUB_TOKEN environment variable.'));
+    const source = ghToken ? 'GH_TOKEN' : 'GITHUB_TOKEN';
+    console.log(chalk.gray(`Using GitHub token from ${source} environment variable.`));
     return envToken;
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #479: the review there suggested also accepting `GH_TOKEN`, and I pushed that change to the PR branch — but a few hours after it had already been squash-merged, so it never landed. This PR carries that commit.

- `GH_TOKEN` is accepted alongside `GITHUB_TOKEN` and takes precedence, matching the gh CLI's documented ordering. The ordering is deliberate: in GitHub Actions `GITHUB_TOKEN` is the ambient workflow-injected token, while `GH_TOKEN` is only ever set on purpose — the explicit variable should win.
- Tests cover the fallback and precedence, and clear both variables in `beforeEach` so an ambient `GH_TOKEN` on a contributor's machine can't leak into the `GITHUB_TOKEN`-only cases.

## Testing

- Auth suite 10/10; `tsc -p tsconfig.cli.json --noEmit` clean; Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)