### PR TITLE
fix: send wire-safe tool id instead of display name to Gemini and OpenAI-compatible providers

### DIFF
--- a/asyar-launcher/src/built-in-features/agents/agentLoop.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentLoop.test.ts
@@ -51,7 +51,8 @@ vi.mock('../../services/log/logService', () => ({
   logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-import { runAgent, encodeToolIdForWire, coalesceConsecutiveSameRole } from './agentLoop';
+import { runAgent, coalesceConsecutiveSameRole } from './agentLoop';
+import { encodeToolIdForWire } from '../../services/ai/IProviderPlugin';
 import type { ToolCall } from '../../services/ai/IProviderPlugin';
 import { getProvider } from '../../services/ai/providerRegistry';
 import { streamChat } from '../../services/ai/aiEngine';
@@ -1257,30 +1258,6 @@ describe('runAgent', () => {
     expect(capturedSignal!.aborted).toBe(true);
 
     await runPromise;
-  });
-});
-
-// ── encodeToolIdForWire — wire-name encoder for provider tool-name regexes ────
-
-describe('encodeToolIdForWire', () => {
-  it('encodes the colon in builtin FQIDs', () => {
-    expect(encodeToolIdForWire('builtin:calculator')).toBe('builtin__calculator');
-  });
-
-  it('encodes both dots and colons in Tier 2 FQIDs', () => {
-    expect(encodeToolIdForWire('ext.foo:bar')).toBe('ext--foo__bar');
-  });
-
-  it('produces only chars allowed by Anthropic tool-name regex', () => {
-    const allowed = /^[a-zA-Z0-9_-]+$/;
-    expect(encodeToolIdForWire('builtin:calculator')).toMatch(allowed);
-    expect(encodeToolIdForWire('ext.foo:bar')).toMatch(allowed);
-    expect(encodeToolIdForWire('ext.scope.deep:tool-name')).toMatch(allowed);
-  });
-
-  it('is a no-op for ids that are already wire-safe', () => {
-    expect(encodeToolIdForWire('plain_id')).toBe('plain_id');
-    expect(encodeToolIdForWire('with-hyphen')).toBe('with-hyphen');
   });
 });
 

--- a/asyar-launcher/src/built-in-features/agents/agentLoop.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentLoop.ts
@@ -11,6 +11,7 @@ import { logService } from '../../services/log/logService';
 import { extractErrorMessage } from '../../lib/errors';
 import type { LocalRunHandle } from '../../services/run/runService.svelte';
 import type { AgentDef, MessageDef } from './types';
+import { encodeToolIdForWire } from '../../services/ai/IProviderPlugin';
 import type {
   IProviderPlugin,
   ChatMessage,
@@ -587,18 +588,4 @@ export function coalesceConsecutiveSameRole(messages: LoopMessage[]): LoopMessag
     }
   }
   return out;
-}
-
-/**
- * Anthropic (and likely other) tool name regex: `^[a-zA-Z0-9_-]{1,64}$`.
- * Our FQIDs use `:` to separate source from id and `.` inside extension ids,
- * both of which the API rejects. Encode for the wire and keep a per-request
- * map (in `runToolLoop`) for exact-match decode of incoming `tool_use.name`.
- *
- * Encoding: `:` → `__`, `.` → `--`. Both are wire-safe characters. Decoding
- * is map-based (not transform-based) so any naturally-occurring `__` or `--`
- * in a tool id can't cause collisions.
- */
-export function encodeToolIdForWire(fullyQualifiedId: string): string {
-  return fullyQualifiedId.replace(/:/g, '__').replace(/\./g, '--');
 }

--- a/asyar-launcher/src/built-in-features/agents/silentDispatch.ts
+++ b/asyar-launcher/src/built-in-features/agents/silentDispatch.ts
@@ -33,7 +33,7 @@ import { logService } from '../../services/log/logService';
 import { extractErrorMessage } from '../../lib/errors';
 import { agentService } from './agentService.svelte';
 import { invokeTool } from './toolDispatch';
-import { encodeToolIdForWire } from './agentLoop';
+import { encodeToolIdForWire } from '../../services/ai/IProviderPlugin';
 import type { AgentDef, SilentInputSource, SilentOutputAction } from './types';
 import type {
   IProviderPlugin,

--- a/asyar-launcher/src/services/ai/IProviderPlugin.test.ts
+++ b/asyar-launcher/src/services/ai/IProviderPlugin.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { encodeToolIdForWire } from './IProviderPlugin';
+
+// ── encodeToolIdForWire — wire-name encoder for provider tool-name regexes ────
+
+describe('encodeToolIdForWire', () => {
+  it('encodes the colon in builtin FQIDs', () => {
+    expect(encodeToolIdForWire('builtin:calculator')).toBe('builtin__calculator');
+  });
+
+  it('encodes both dots and colons in Tier 2 FQIDs', () => {
+    expect(encodeToolIdForWire('ext.foo:bar')).toBe('ext--foo__bar');
+  });
+
+  it('produces only chars allowed by Anthropic tool-name regex', () => {
+    const allowed = /^[a-zA-Z0-9_-]+$/;
+    expect(encodeToolIdForWire('builtin:calculator')).toMatch(allowed);
+    expect(encodeToolIdForWire('ext.foo:bar')).toMatch(allowed);
+    expect(encodeToolIdForWire('ext.scope.deep:tool-name')).toMatch(allowed);
+  });
+
+  it('is a no-op for ids that are already wire-safe', () => {
+    expect(encodeToolIdForWire('plain_id')).toBe('plain_id');
+    expect(encodeToolIdForWire('with-hyphen')).toBe('with-hyphen');
+  });
+});

--- a/asyar-launcher/src/services/ai/IProviderPlugin.ts
+++ b/asyar-launcher/src/services/ai/IProviderPlugin.ts
@@ -67,6 +67,22 @@ export interface LoopMessage {
   toolUseId?: string;
 }
 
+/**
+ * Anthropic (and likely other) tool name regex: `^[a-zA-Z0-9_-]{1,64}$`.
+ * Our FQIDs use `:` to separate source from id and `.` inside extension ids,
+ * both of which the API rejects. Encode for the wire — both when declaring
+ * tools and when serializing historical `toolUse`/`toolResult` messages, so
+ * every `name` a provider sees (declarations, function calls, and function
+ * responses) uses the same wire-safe form. Decoding back to the FQID is
+ * map-based (not transform-based) so any naturally-occurring `__` or `--`
+ * in a tool id can't cause collisions.
+ *
+ * Encoding: `:` → `__`, `.` → `--`. Both are wire-safe characters.
+ */
+export function encodeToolIdForWire(fullyQualifiedId: string): string {
+  return fullyQualifiedId.replace(/:/g, '__').replace(/\./g, '--');
+}
+
 // ─── Provider Plugin Interface ─────────────────────────────────────────────────
 
 export interface IProviderPlugin {

--- a/asyar-launcher/src/services/ai/providers/_openaiCompat.test.ts
+++ b/asyar-launcher/src/services/ai/providers/_openaiCompat.test.ts
@@ -103,6 +103,27 @@ describe('buildOpenAIToolsBody', () => {
     expect(body.stream).toBe(true);
     expect(body.model).toBe(fakeParams.modelId);
   });
+
+  it('openaiCompat_buildToolsBody_uses_wire_safe_id_not_display_name', () => {
+    // Built-in tools have human-readable display names with spaces (e.g.
+    // "Search Launcher Index"). OpenAI's function name validation rejects
+    // spaces, and the wire-safe `id` is also what `wireToFqid` in
+    // agentLoop.ts uses to resolve tool_calls back to the original tool.
+    const messages: LoopMessage[] = [{ role: 'user', content: 'search for files' }];
+    const tools = [
+      {
+        id: 'builtin__search-launcher-index',
+        name: 'Search Launcher Index',
+        description: 'Searches the launcher index',
+        parameters: { type: 'object', properties: {} } as Record<string, unknown>,
+      },
+    ];
+
+    const body = buildOpenAIToolsBody(messages, fakeParams, tools) as Record<string, unknown>;
+    const toolsArray = body.tools as Array<{ function: { name: string } }>;
+
+    expect(toolsArray[0].function.name).toBe('builtin__search-launcher-index');
+  });
 });
 
 // ─── parseOpenAIToolStream ────────────────────────────────────────────────────

--- a/asyar-launcher/src/services/ai/providers/_openaiCompat.test.ts
+++ b/asyar-launcher/src/services/ai/providers/_openaiCompat.test.ts
@@ -64,6 +64,38 @@ describe('openAIToolsMessages', () => {
 
     expect(result).toEqual([{ role: 'tool', tool_call_id: 'call_1', content: '42' }]);
   });
+
+  it('openaiCompat_messages_encodes_fqid_in_historical_tool_calls', () => {
+    // agentLoop.ts stores the resolved FQID (e.g. "builtin:calculator") as
+    // `toolUse[].name`, not the wire-safe id. On turn 2+ of a tool
+    // conversation, that FQID gets replayed as history — it must be
+    // re-encoded so it matches the wire-safe name declared in `tools`,
+    // otherwise OpenAI-compatible providers reject the invalid characters.
+    const messages: LoopMessage[] = [
+      {
+        role: 'assistant',
+        content: 'thinking',
+        toolUse: [{ id: 'call_1', name: 'builtin:calculator', input: { x: 1 } }],
+      },
+    ];
+
+    const result = openAIToolsMessages(messages);
+
+    expect(result).toContainEqual({
+      role: 'assistant',
+      content: 'thinking',
+      tool_calls: [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: {
+            name: 'builtin__calculator',
+            arguments: JSON.stringify({ x: 1 }),
+          },
+        },
+      ],
+    });
+  });
 });
 
 // ─── buildOpenAIToolsBody ─────────────────────────────────────────────────────

--- a/asyar-launcher/src/services/ai/providers/_openaiCompat.ts
+++ b/asyar-launcher/src/services/ai/providers/_openaiCompat.ts
@@ -1,3 +1,4 @@
+import { encodeToolIdForWire } from '../IProviderPlugin';
 import type { LoopMessage, ChatParams, ToolStreamEvent } from '../IProviderPlugin';
 
 export interface OpenAIToolDescriptor {
@@ -23,7 +24,9 @@ export function openAIToolsMessages(messages: LoopMessage[]): unknown[] {
             id: tu.id,
             type: 'function',
             function: {
-              name: tu.name,
+              // tu.name holds the original FQID (e.g. `builtin:calculator`);
+              // encode it so it matches the wire-safe name declared in `tools`.
+              name: encodeToolIdForWire(tu.name),
               arguments: JSON.stringify(tu.input),
             },
           })),

--- a/asyar-launcher/src/services/ai/providers/_openaiCompat.ts
+++ b/asyar-launcher/src/services/ai/providers/_openaiCompat.ts
@@ -50,7 +50,7 @@ export function buildOpenAIToolsBody(
     tools: tools.map((t) => ({
       type: 'function',
       function: {
-        name: t.name,
+        name: t.id,
         description: t.description,
         parameters: t.parameters,
       },

--- a/asyar-launcher/src/services/ai/providers/anthropic.test.ts
+++ b/asyar-launcher/src/services/ai/providers/anthropic.test.ts
@@ -88,6 +88,33 @@ describe('anthropicPlugin.buildToolRequest', () => {
     expect(content).toContainEqual({ type: 'tool_use', id: 'tu1', name: 'calc', input: { x: 1 } });
   });
 
+  it('anthropic_buildToolRequest_encodes_fqid_in_historical_tool_use', () => {
+    // agentLoop.ts stores the resolved FQID (e.g. "builtin:calculator") as
+    // `toolUse[].name`, not the wire-safe id. On turn 2+ of a tool
+    // conversation, that FQID gets replayed as history — it must be
+    // re-encoded so it matches the wire-safe name declared in `tools`,
+    // otherwise Anthropic rejects the invalid characters.
+    const messages: LoopMessage[] = [
+      {
+        role: 'assistant',
+        content: 'thinking...',
+        toolUse: [{ id: 'tu1', name: 'builtin:calculator', input: { x: 1 } }],
+      },
+    ];
+
+    const spec = anthropicPlugin.buildToolRequest(messages, fakeConfig, fakeParams, []);
+    const body = spec.body as Record<string, unknown>;
+    const msgs = body.messages as Array<Record<string, unknown>>;
+    const content = msgs[0].content as Array<Record<string, unknown>>;
+
+    expect(content).toContainEqual({
+      type: 'tool_use',
+      id: 'tu1',
+      name: 'builtin__calculator',
+      input: { x: 1 },
+    });
+  });
+
   it('anthropic_buildToolRequest_emits_tool_result_block_for_tool_role', () => {
     const messages: LoopMessage[] = [{ role: 'tool', content: '42', toolUseId: 'tu1' }];
 

--- a/asyar-launcher/src/services/ai/providers/anthropic.ts
+++ b/asyar-launcher/src/services/ai/providers/anthropic.ts
@@ -1,4 +1,5 @@
 import { fetch } from '@tauri-apps/plugin-http';
+import { encodeToolIdForWire } from '../IProviderPlugin';
 import type {
   IProviderPlugin,
   ModelInfo,
@@ -109,7 +110,14 @@ export const anthropicPlugin: IProviderPlugin = {
         }
         if (msg.toolUse && msg.toolUse.length > 0) {
           for (const tu of msg.toolUse) {
-            contentBlocks.push({ type: 'tool_use', id: tu.id, name: tu.name, input: tu.input });
+            // tu.name holds the original FQID (e.g. `builtin:calculator`);
+            // encode it so it matches the wire-safe name declared in `tools` below.
+            contentBlocks.push({
+              type: 'tool_use',
+              id: tu.id,
+              name: encodeToolIdForWire(tu.name),
+              input: tu.input,
+            });
           }
         }
         anthropicMessages.push({ role: 'assistant', content: contentBlocks });

--- a/asyar-launcher/src/services/ai/providers/google.test.ts
+++ b/asyar-launcher/src/services/ai/providers/google.test.ts
@@ -182,6 +182,31 @@ describe('googlePlugin.buildToolRequest', () => {
       },
     ]);
   });
+
+  it('google_buildToolRequest_uses_wire_safe_id_not_display_name', () => {
+    // Built-in tools have human-readable display names with spaces (e.g.
+    // "Search Launcher Index"), which Gemini's function name validation
+    // rejects (must match ^[a-zA-Z_][a-zA-Z0-9_.-]*$). The wire-safe `id`
+    // (e.g. "builtin__search-launcher-index") must be sent instead — it's
+    // also what `wireToFqid` in agentLoop.ts uses to resolve tool_use
+    // blocks back to the original tool.
+    const messages: LoopMessage[] = [{ role: 'user', content: 'search for files' }];
+    const tools = [
+      {
+        id: 'builtin__search-launcher-index',
+        name: 'Search Launcher Index',
+        description: 'Searches the launcher index',
+        parameters: { type: 'object', properties: {} } as Record<string, unknown>,
+      },
+    ];
+
+    const spec = googlePlugin.buildToolRequest(messages, fakeConfig, fakeParams, tools);
+    const body = spec.body as Record<string, unknown>;
+    const declarations = (body.tools as Array<{ functionDeclarations: Array<{ name: string }> }>)[0]
+      .functionDeclarations;
+
+    expect(declarations[0].name).toBe('builtin__search-launcher-index');
+  });
 });
 
 // ─── parseToolStream ──────────────────────────────────────────────────────────

--- a/asyar-launcher/src/services/ai/providers/google.test.ts
+++ b/asyar-launcher/src/services/ai/providers/google.test.ts
@@ -183,6 +183,44 @@ describe('googlePlugin.buildToolRequest', () => {
     ]);
   });
 
+  it('google_buildToolRequest_encodes_fqid_in_historical_functionCall_and_functionResponse', () => {
+    // agentLoop.ts stores the resolved FQID (e.g. "builtin:calculator") as
+    // `toolUse[].name` on persisted/loop messages, not the wire-safe id. On
+    // turn 2+ of a tool conversation, that FQID gets replayed as history —
+    // it must be re-encoded so it matches the wire-safe name declared in
+    // functionDeclarations, otherwise Gemini rejects the request (same
+    // "Invalid function name" error, now triggered on turn 2 instead of 1).
+    const messages: LoopMessage[] = [
+      { role: 'user', content: 'use the calc' },
+      {
+        role: 'assistant',
+        content: '',
+        toolUse: [{ id: 'tu1', name: 'builtin:calculator', input: { x: 1 } }],
+      },
+      { role: 'tool', content: '42', toolUseId: 'tu1' },
+    ];
+
+    const spec = googlePlugin.buildToolRequest(messages, fakeConfig, fakeParams, []);
+    const body = spec.body as Record<string, unknown>;
+    const contents = body.contents as Array<Record<string, unknown>>;
+
+    const assistantParts = contents[1].parts as Array<Record<string, unknown>>;
+    expect(assistantParts).toContainEqual({
+      functionCall: { id: 'tu1', name: 'builtin__calculator', args: { x: 1 } },
+    });
+
+    const toolParts = contents[2].parts as Array<Record<string, unknown>>;
+    expect(toolParts).toEqual([
+      {
+        functionResponse: {
+          id: 'tu1',
+          name: 'builtin__calculator',
+          response: { output: 42 },
+        },
+      },
+    ]);
+  });
+
   it('google_buildToolRequest_uses_wire_safe_id_not_display_name', () => {
     // Built-in tools have human-readable display names with spaces (e.g.
     // "Search Launcher Index"), which Gemini's function name validation

--- a/asyar-launcher/src/services/ai/providers/google.ts
+++ b/asyar-launcher/src/services/ai/providers/google.ts
@@ -1,4 +1,5 @@
 import { fetch } from '@tauri-apps/plugin-http';
+import { encodeToolIdForWire } from '../IProviderPlugin';
 import type {
   IProviderPlugin,
   ModelInfo,
@@ -71,11 +72,14 @@ export const googlePlugin: IProviderPlugin = {
       parameters: Record<string, unknown>;
     }>,
   ): RequestSpec {
-    // Gemini requires `name` in functionResponse; look up from prior assistant turn's functionCall
+    // Gemini requires `name` in functionResponse; look up from prior assistant turn's functionCall.
+    // `tu.name` holds the original FQID (e.g. `builtin:calculator`), not the
+    // wire-safe form — encode it here so historical function calls/responses
+    // match the wire-safe names declared in `functionDeclarations` below.
     const idToName = new Map<string, string>();
     for (const m of messages) {
       if (m.role === 'assistant' && Array.isArray(m.toolUse)) {
-        for (const tu of m.toolUse) idToName.set(tu.id, tu.name);
+        for (const tu of m.toolUse) idToName.set(tu.id, encodeToolIdForWire(tu.name));
       }
     }
 
@@ -96,7 +100,9 @@ export const googlePlugin: IProviderPlugin = {
         if (m.content) parts.push({ text: m.content });
         if (Array.isArray(m.toolUse)) {
           for (const tu of m.toolUse) {
-            parts.push({ functionCall: { id: tu.id, name: tu.name, args: tu.input } });
+            parts.push({
+              functionCall: { id: tu.id, name: encodeToolIdForWire(tu.name), args: tu.input },
+            });
           }
         }
         contents.push({ role: 'model', parts });

--- a/asyar-launcher/src/services/ai/providers/google.ts
+++ b/asyar-launcher/src/services/ai/providers/google.ts
@@ -124,7 +124,7 @@ export const googlePlugin: IProviderPlugin = {
       tools: [
         {
           functionDeclarations: tools.map((t) => ({
-            name: t.name,
+            name: t.id,
             description: t.description,
             parameters: t.parameters,
           })),


### PR DESCRIPTION
Gemini rejects function names containing spaces (e.g. "Search Launcher
Index"), and OpenAI-compatible providers would silently fail tool-call
resolution since wireToFqid is keyed by id, not name. Anthropic already
sent the correct id; align google.ts and _openaiCompat.ts to match.