### PR TITLE
fix(build): embed the Windows app manifest via the linker so cargo test can load

### DIFF
--- a/asyar-launcher/src-tauri/build.rs
+++ b/asyar-launcher/src-tauri/build.rs
@@ -114,7 +114,34 @@ fn main() {
     println!("cargo:rustc-env=ASYAR_SDK_VERSION={}", sdk_version);
     println!("cargo:rerun-if-changed={}", sdk_pkg_path.display());
 
-    tauri_build::build()
+    // Windows (MSVC): make `cargo test` loadable.
+    //
+    // tauri_build's default app manifest — whose entire content is the
+    // Common-Controls v6 side-by-side dependency — is embedded as a compiled
+    // resource that embed-resource links into *bins only*. The `cargo test`
+    // harness for the lib target is not a bin: it gets no manifest, binds
+    // legacy comctl32 v5, and dies at load with STATUS_ENTRYPOINT_NOT_FOUND
+    // (0xc0000139) on the comctl6-only export `TaskDialogIndirect` (imported
+    // transitively via tao/muda/dialog code) — before a single test runs.
+    // Cargo has no directive scoped to the unit-test harness
+    // (`rustc-link-arg-tests` covers only `tests/*.rs` targets), so instead:
+    // drop the resource-based manifest and have the LINKER embed an identical
+    // one into every product it links — app binary and test harnesses alike.
+    // `/MANIFESTDEPENDENCY` reproduces the default tauri manifest 1:1.
+    let is_windows_msvc = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+        && std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc");
+    if is_windows_msvc {
+        const COMCTL6_DEPENDENCY: &str = "type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'";
+        println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+        println!("cargo:rustc-link-arg=/MANIFESTDEPENDENCY:{COMCTL6_DEPENDENCY}");
+    }
+
+    let mut attributes = tauri_build::Attributes::new();
+    if is_windows_msvc {
+        attributes = attributes
+            .windows_attributes(tauri_build::WindowsAttributes::new_without_app_manifest());
+    }
+    tauri_build::try_build(attributes).expect("failed to run tauri-build");
 }
 
 /// Recursively copy the capability spec tree, skipping dev-only `*.test.ts`


### PR DESCRIPTION
Closes #498.

## What

Makes `cargo test` runnable on Windows. The test harness binary previously failed to *load* — `STATUS_ENTRYPOINT_NOT_FOUND` (0xc0000139) before a single test ran — so the Rust suite has never been runnable on Windows at all (CI runs it on ubuntu only).

## Why it broke

The default tauri-build app manifest — whose entire content is the **Common-Controls v6** side-by-side dependency — is embedded as a compiled resource that embed-resource links into **bins only**. The `cargo test` harness for the lib target is not a bin: it gets no manifest, binds legacy **comctl32 v5**, and the loader kills it on the comctl6-only export **`TaskDialogIndirect`** (imported transitively via tao/muda/dialog code). Full diagnosis in #498.

## How

`build.rs`, Windows/MSVC only — switch the manifest from a compiled resource to the linker, so every linked product gets it:

- `tauri_build::try_build` with `WindowsAttributes::new_without_app_manifest()` (drops the resource-based manifest), plus
- `cargo:rustc-link-arg=/MANIFEST:EMBED` and `cargo:rustc-link-arg=/MANIFESTDEPENDENCY:<Common-Controls v6>` — applied to the app binary and test harnesses alike. The dependency string reproduces `tauri-build`'s default `windows-app-manifest.xml` 1:1.

Why not something smaller:

- `cargo:rustc-link-arg-tests` only applies to `tests/*.rs` targets (`LinkArgTarget::Test => target.is_test()` in cargo) — it never reaches the lib unit-test harness, which is the binary that fails.
- Keeping the winres manifest and adding `/MANIFEST:EMBED` globally would double-manifest the app binary (duplicate `RT_MANIFEST`).
- A `.cargo/config.toml` can't be used — `src-tauri/.cargo/config.toml` is deliberately gitignored as a per-developer file.

No-op on macOS/Linux (`CARGO_CFG_TARGET_OS`/`CARGO_CFG_TARGET_ENV` gated; non-Windows keeps the exact previous `tauri_build::build()` behavior via `Attributes::default()`).

## Verification

- Windows 11, `rustc 1.96.1`: `cargo test` now loads and runs — **2808 passed, 38 failed, 9 ignored** (previously: instant loader death). The 38 are pre-existing Windows-environment test issues that were invisible while the harness couldn't load (POSIX-shell assumptions, path semantics, keyboard-layout-dependent tests) — tracked in #498 as a follow-up, not addressed here.
- App binary unregressed: manifest extracted from the built `asyar.exe` with `mt -inputresource` still declares `Microsoft.Windows.Common-Controls` 6.0.0.0; dev launcher runs normally. One cosmetic delta: the linker-generated manifest also contains the default `<requestedExecutionLevel level="asInvoker"/>` trustInfo block — functionally identical, as `asInvoker` is what Windows assumes when the section is absent.
- Linux (WSL): `cargo check` clean; `cargo fmt` clean. The new code path is cfg-gated off, preserving previous behavior — ubuntu CI unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
