### PR TITLE
test(file_index): make index/query/snapshot/watcher tests portable to Windows

### DIFF
--- a/asyar-launcher/src-tauri/src/file_index/index.rs
+++ b/asyar-launcher/src-tauri/src/file_index/index.rs
@@ -555,9 +555,19 @@ fn classify(it: &ScannedEntry) -> FileType {
 mod tests {
     use super::*;
 
+    /// Convert a unix-style fixture path to the platform's native
+    /// separators. The index joins components with `MAIN_SEPARATOR` (via
+    /// `materialize_path`) and compares that against requested paths, so a
+    /// fixture must use native separators to round-trip — otherwise on
+    /// Windows a `/tmp/rootA` root joins with `\` to `/tmp/rootA\docs`,
+    /// which never equals the unix-spelled lookup key. No-op on Unix.
+    fn np(unix: &str) -> String {
+        unix.replace('/', std::path::MAIN_SEPARATOR_STR)
+    }
+
     fn scanned(path: &str, kind: EntryKind, mtime: u32) -> ScannedEntry {
         ScannedEntry {
-            path: PathBuf::from(path),
+            path: PathBuf::from(np(path)),
             kind,
             mtime,
             hidden: false,
@@ -569,7 +579,7 @@ mod tests {
 
     /// A small realistic tree under one root.
     fn small_index() -> FileIndex {
-        let root = PathBuf::from("/tmp/rootA");
+        let root = PathBuf::from(np("/tmp/rootA"));
         let items = vec![
             scanned("/tmp/rootA/docs", EntryKind::Dir, NOW as u32 - 86_400 * 40),
             scanned(
@@ -608,7 +618,7 @@ mod tests {
 
     #[test]
     fn lc_names_are_lowercased_and_roots_unmatchable() {
-        let root = PathBuf::from("/tmp/RootB");
+        let root = PathBuf::from(np("/tmp/RootB"));
         let items = vec![scanned("/tmp/RootB/MyFile.TXT", EntryKind::File, 0)];
         let idx = FileIndex::build(vec![root], items, NOW);
         assert_eq!(idx.entry(0).lc_len, 0, "root has an empty match region");
@@ -660,11 +670,14 @@ mod tests {
         let report = (0..idx.entries_len() as u32)
             .find(|&i| idx.disp_name(i) == "report.pdf")
             .unwrap();
-        assert_eq!(idx.materialize_path(report), "/tmp/rootA/docs/report.pdf");
+        assert_eq!(
+            idx.materialize_path(report),
+            np("/tmp/rootA/docs/report.pdf")
+        );
         let notes = (0..idx.entries_len() as u32)
             .find(|&i| idx.disp_name(i) == "old-notes.txt")
             .unwrap();
-        assert_eq!(idx.materialize_path(notes), "/tmp/rootA/old-notes.txt");
+        assert_eq!(idx.materialize_path(notes), np("/tmp/rootA/old-notes.txt"));
     }
 
     #[test]
@@ -684,17 +697,19 @@ mod tests {
     #[test]
     fn lookup_path_finds_entries_and_misses_unknown() {
         let idx = small_index();
-        let found = idx.lookup_path(Path::new("/tmp/rootA/docs/report.pdf"));
+        let found = idx.lookup_path(Path::new(&np("/tmp/rootA/docs/report.pdf")));
         assert!(found.is_some());
         assert_eq!(idx.disp_name(found.unwrap()), "report.pdf");
-        assert!(idx.lookup_path(Path::new("/tmp/rootA/nope.txt")).is_none());
+        assert!(idx
+            .lookup_path(Path::new(&np("/tmp/rootA/nope.txt")))
+            .is_none());
     }
 
     #[test]
     fn removed_tombstones_and_upsert_revives() {
         let mut idx = small_index();
         let gen0 = idx.generation();
-        let target = PathBuf::from("/tmp/rootA/docs/report.pdf");
+        let target = PathBuf::from(np("/tmp/rootA/docs/report.pdf"));
 
         idx.apply_batch(vec![IndexUpdate::Removed(target.clone())], NOW);
         let i = idx
@@ -721,7 +736,7 @@ mod tests {
     fn upsert_existing_updates_mtime_without_growing() {
         let mut idx = small_index();
         let len_before = idx.entries_len();
-        let target = PathBuf::from("/tmp/rootA/old-notes.txt");
+        let target = PathBuf::from(np("/tmp/rootA/old-notes.txt"));
         idx.apply_batch(
             vec![IndexUpdate::Upserted(scanned(
                 "/tmp/rootA/old-notes.txt",
@@ -748,10 +763,10 @@ mod tests {
             NOW,
         );
         let i = idx
-            .lookup_path(Path::new("/tmp/rootA/brand-new.md"))
+            .lookup_path(Path::new(&np("/tmp/rootA/brand-new.md")))
             .unwrap();
         assert!(i as usize >= sealed, "tail entry must live after sealed");
-        assert_eq!(idx.materialize_path(i), "/tmp/rootA/brand-new.md");
+        assert_eq!(idx.materialize_path(i), np("/tmp/rootA/brand-new.md"));
         assert_eq!(idx.lc_name(i), b"brand-new.md");
     }
 
@@ -767,12 +782,14 @@ mod tests {
             NOW,
         );
         let i = idx
-            .lookup_path(Path::new("/tmp/rootA/new1/new2/deep.txt"))
+            .lookup_path(Path::new(&np("/tmp/rootA/new1/new2/deep.txt")))
             .unwrap();
-        assert_eq!(idx.materialize_path(i), "/tmp/rootA/new1/new2/deep.txt");
+        assert_eq!(idx.materialize_path(i), np("/tmp/rootA/new1/new2/deep.txt"));
         assert_eq!(idx.depth(i), 3);
         // Intermediate dirs are real, findable entries.
-        let mid = idx.lookup_path(Path::new("/tmp/rootA/new1/new2")).unwrap();
+        let mid = idx
+            .lookup_path(Path::new(&np("/tmp/rootA/new1/new2")))
+            .unwrap();
         assert!(idx.entry(mid).is_dir());
     }
 
@@ -784,7 +801,9 @@ mod tests {
         assert_eq!(idx.generation(), gen0);
         // Removing an unknown path changes nothing either.
         idx.apply_batch(
-            vec![IndexUpdate::Removed(PathBuf::from("/tmp/rootA/ghost.txt"))],
+            vec![IndexUpdate::Removed(PathBuf::from(np(
+                "/tmp/rootA/ghost.txt",
+            )))],
             NOW,
         );
         assert_eq!(idx.generation(), gen0);

--- a/asyar-launcher/src-tauri/src/file_index/index.rs
+++ b/asyar-launcher/src-tauri/src/file_index/index.rs
@@ -562,7 +562,15 @@ mod tests {
     /// Windows a `/tmp/rootA` root joins with `\` to `/tmp/rootA\docs`,
     /// which never equals the unix-spelled lookup key. No-op on Unix.
     fn np(unix: &str) -> String {
-        unix.replace('/', std::path::MAIN_SEPARATOR_STR)
+        unix.chars()
+            .map(|c| {
+                if c == '/' {
+                    std::path::MAIN_SEPARATOR
+                } else {
+                    c
+                }
+            })
+            .collect()
     }
 
     fn scanned(path: &str, kind: EntryKind, mtime: u32) -> ScannedEntry {

--- a/asyar-launcher/src-tauri/src/file_index/query.rs
+++ b/asyar-launcher/src-tauri/src/file_index/query.rs
@@ -556,9 +556,18 @@ mod tests {
 
     const NOW: i64 = 100_000_000;
 
+    /// Unix-style fixture path → native separators, so it round-trips
+    /// through the index (which materializes with `MAIN_SEPARATOR`). No-op
+    /// on Unix. Slash-token queries are unaffected: `tokenize` splits the
+    /// query on `/` and matches component names, not the stored separator.
+    fn np(unix: &str) -> String {
+        unix.replace('/', std::path::MAIN_SEPARATOR_STR)
+    }
+
     fn entry(path: &str, kind: EntryKind, mtime: u32) -> ScannedEntry {
         ScannedEntry {
-            path: PathBuf::from(path),
+            // hidden detection stays on the unix spelling (rsplit '/').
+            path: PathBuf::from(np(path)),
             kind,
             mtime,
             hidden: path.rsplit('/').next().unwrap_or("").starts_with('.'),
@@ -579,7 +588,7 @@ mod tests {
                 entry(p.trim_end_matches('/'), kind, NOW as u32)
             })
             .collect();
-        FileIndex::build(vec![PathBuf::from("/r")], items, NOW)
+        FileIndex::build(vec![PathBuf::from(np("/r"))], items, NOW)
     }
 
     fn never() -> impl Fn() -> bool {
@@ -652,7 +661,7 @@ mod tests {
         ]);
         let r = run(&idx, &mut None, "docs/report");
         assert_eq!(r.hits.len(), 1);
-        assert_eq!(r.hits[0].path, "/r/docs/report.txt");
+        assert_eq!(r.hits[0].path, np("/r/docs/report.txt"));
     }
 
     #[test]
@@ -866,7 +875,7 @@ mod tests {
         assert_eq!(r.hits.len(), 1);
         let h = &r.hits[0];
         assert_eq!(h.name, "Report.PDF");
-        assert_eq!(h.path, "/r/docs/Report.PDF");
+        assert_eq!(h.path, np("/r/docs/Report.PDF"));
         assert_eq!(h.file_type, FileType::Document);
         assert!(!h.is_dir);
         assert_eq!(h.modified_at, NOW);
@@ -903,7 +912,7 @@ mod tests {
             .map(|d| entry(&format!("/r/d{d}"), EntryKind::Dir, NOW as u32))
             .collect();
         items.extend(paths.iter().map(|p| entry(p, EntryKind::File, NOW as u32)));
-        let idx = FileIndex::build(vec![PathBuf::from("/r")], items, NOW);
+        let idx = FileIndex::build(vec![PathBuf::from(np("/r"))], items, NOW);
 
         let learning = LearningCache::new();
         let mut matcher = Matcher::new();
@@ -981,7 +990,7 @@ mod tests {
             ));
         }
         let build_start = std::time::Instant::now();
-        let idx = FileIndex::build(vec![PathBuf::from("/r")], items, NOW);
+        let idx = FileIndex::build(vec![PathBuf::from(np("/r"))], items, NOW);
         eprintln!("build 1M: {:?}", build_start.elapsed());
 
         let learning = LearningCache::new();

--- a/asyar-launcher/src-tauri/src/file_index/query.rs
+++ b/asyar-launcher/src-tauri/src/file_index/query.rs
@@ -561,7 +561,15 @@ mod tests {
     /// on Unix. Slash-token queries are unaffected: `tokenize` splits the
     /// query on `/` and matches component names, not the stored separator.
     fn np(unix: &str) -> String {
-        unix.replace('/', std::path::MAIN_SEPARATOR_STR)
+        unix.chars()
+            .map(|c| {
+                if c == '/' {
+                    std::path::MAIN_SEPARATOR
+                } else {
+                    c
+                }
+            })
+            .collect()
     }
 
     fn entry(path: &str, kind: EntryKind, mtime: u32) -> ScannedEntry {

--- a/asyar-launcher/src-tauri/src/file_index/snapshot.rs
+++ b/asyar-launcher/src-tauri/src/file_index/snapshot.rs
@@ -52,7 +52,15 @@ mod tests {
     /// Unix fixture path → native separators so it round-trips through the
     /// index (materialized with `MAIN_SEPARATOR`). No-op on Unix.
     fn np(unix: &str) -> String {
-        unix.replace('/', std::path::MAIN_SEPARATOR_STR)
+        unix.chars()
+            .map(|c| {
+                if c == '/' {
+                    std::path::MAIN_SEPARATOR
+                } else {
+                    c
+                }
+            })
+            .collect()
     }
 
     const NOW: i64 = 100_000_000;

--- a/asyar-launcher/src-tauri/src/file_index/snapshot.rs
+++ b/asyar-launcher/src-tauri/src/file_index/snapshot.rs
@@ -49,6 +49,12 @@ mod tests {
     use crate::file_index::types::EntryKind;
     use std::path::PathBuf;
 
+    /// Unix fixture path → native separators so it round-trips through the
+    /// index (materialized with `MAIN_SEPARATOR`). No-op on Unix.
+    fn np(unix: &str) -> String {
+        unix.replace('/', std::path::MAIN_SEPARATOR_STR)
+    }
+
     const NOW: i64 = 100_000_000;
 
     fn tmp_path() -> PathBuf {
@@ -62,25 +68,25 @@ mod tests {
     fn sample_index() -> FileIndex {
         let items = vec![
             ScannedEntry {
-                path: PathBuf::from("/tmp/rootA/docs"),
+                path: PathBuf::from(np("/tmp/rootA/docs")),
                 kind: EntryKind::Dir,
                 mtime: NOW as u32 - 86_400,
                 hidden: false,
                 placeholder: false,
             },
             ScannedEntry {
-                path: PathBuf::from("/tmp/rootA/docs/Report.pdf"),
+                path: PathBuf::from(np("/tmp/rootA/docs/Report.pdf")),
                 kind: EntryKind::File,
                 mtime: NOW as u32,
                 hidden: false,
                 placeholder: false,
             },
         ];
-        let mut idx = FileIndex::build(vec![PathBuf::from("/tmp/rootA")], items, NOW);
+        let mut idx = FileIndex::build(vec![PathBuf::from(np("/tmp/rootA"))], items, NOW);
         // Give it a tail entry and a tombstone so those survive too.
         idx.apply_batch(
             vec![IndexUpdate::Upserted(ScannedEntry {
-                path: PathBuf::from("/tmp/rootA/tail.txt"),
+                path: PathBuf::from(np("/tmp/rootA/tail.txt")),
                 kind: EntryKind::File,
                 mtime: NOW as u32,
                 hidden: false,
@@ -89,9 +95,9 @@ mod tests {
             NOW,
         );
         idx.apply_batch(
-            vec![IndexUpdate::Removed(PathBuf::from(
+            vec![IndexUpdate::Removed(PathBuf::from(np(
                 "/tmp/rootA/docs/Report.pdf",
-            ))],
+            )))],
             NOW,
         );
         idx
@@ -112,12 +118,12 @@ mod tests {
 
         // Lookups must be rebuilt and functional for sealed AND tail entries.
         let tail = loaded
-            .lookup_path(Path::new("/tmp/rootA/tail.txt"))
+            .lookup_path(Path::new(&np("/tmp/rootA/tail.txt")))
             .expect("tail entry resolves after load");
-        assert_eq!(loaded.materialize_path(tail), "/tmp/rootA/tail.txt");
+        assert_eq!(loaded.materialize_path(tail), np("/tmp/rootA/tail.txt"));
 
         let report = loaded
-            .lookup_path(Path::new("/tmp/rootA/docs/Report.pdf"))
+            .lookup_path(Path::new(&np("/tmp/rootA/docs/Report.pdf")))
             .expect("sealed entry resolves after load");
         assert!(
             loaded.is_tombstoned(report),
@@ -129,7 +135,7 @@ mod tests {
 
     #[test]
     fn load_missing_returns_none() {
-        assert!(load(Path::new("/definitely/does/not/exist.bin")).is_none());
+        assert!(load(Path::new(&np("/definitely/does/not/exist.bin"))).is_none());
     }
 
     #[test]

--- a/asyar-launcher/src-tauri/src/file_index/watcher.rs
+++ b/asyar-launcher/src-tauri/src/file_index/watcher.rs
@@ -320,6 +320,66 @@ mod tests {
     use notify::event::{AccessKind, AccessMode, CreateKind, Flag, ModifyKind, RemoveKind};
     use std::fs;
 
+    /// Exclusion set with only `pattern`, mirroring `build_exclusion_set`'s
+    /// glob shape. The real-FS tests below use this instead of the full
+    /// default set: the OS temp dir on Windows lives under `AppData/Local`
+    /// — itself a default-ignored pattern — so `build_exclusion_set(&[])`
+    /// would match the test's own watched root and drop every event, which
+    /// is exactly why these tests passed on Linux (`/tmp`) but not Windows.
+    /// The default patterns are verified by the pure-coalescer unit tests.
+    fn exclude_only(pattern: &str) -> GlobSet {
+        let mut b = GlobSetBuilder::new();
+        b.add(Glob::new(&format!("**/{pattern}")).unwrap());
+        b.add(Glob::new(&format!("**/{pattern}/**")).unwrap());
+        b.build().unwrap()
+    }
+
+    fn no_exclusions() -> GlobSet {
+        GlobSetBuilder::new().build().unwrap()
+    }
+
+    /// Upper bound the real-filesystem watcher tests below wait for an
+    /// expected event before giving up. Backend delivery latency varies by
+    /// platform (inotify vs `ReadDirectoryChangesW`); a bounded poll stays
+    /// fast in the common case and only spends the full budget on failure.
+    const WATCHER_EVENT_BUDGET: Duration = Duration::from_secs(10);
+
+    /// Poll `cond` until it holds or `budget` elapses. Returns the final
+    /// value of `cond`.
+    fn wait_until(budget: Duration, mut cond: impl FnMut() -> bool) -> bool {
+        let start = std::time::Instant::now();
+        while start.elapsed() < budget {
+            if cond() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        cond()
+    }
+
+    /// Confirm the watcher is actually delivering events before the test's
+    /// real writes. On Linux `watch()` arms inotify synchronously, but on
+    /// Windows `ReadDirectoryChangesW` is issued asynchronously by the
+    /// notify backend thread, so a write that races the arming is silently
+    /// missed. Rather than guess a fixed warmup, actively probe: write a
+    /// throwaway file until an event for *anything* lands, then clear it.
+    /// Panics if nothing is ever delivered — that would be a real backend
+    /// failure, not a flaky race. (Production never hits the race: it arms
+    /// once at startup and watches for the process lifetime.)
+    fn await_armed(root: &Path, received: &Arc<Mutex<Vec<IndexUpdate>>>) {
+        let probe = root.join(".asyar-arm-probe");
+        let armed = wait_until(WATCHER_EVENT_BUDGET, || {
+            let _ = fs::write(&probe, b"1");
+            !received.lock().unwrap().is_empty()
+        });
+        assert!(
+            armed,
+            "watcher never delivered a probe event — backend not arming"
+        );
+        let _ = fs::remove_file(&probe);
+        received.lock().unwrap().clear();
+    }
+
     fn ev(kind: EventKind, path: &Path) -> notify::Event {
         notify::Event::new(kind).add_path(path.to_path_buf())
     }
@@ -527,7 +587,7 @@ mod tests {
         let _ = fs::remove_dir_all(&root);
         fs::create_dir_all(root.join("node_modules")).unwrap();
 
-        let exclusions = build_exclusion_set(&[]);
+        let exclusions = exclude_only("node_modules");
         let received: Arc<Mutex<Vec<IndexUpdate>>> = Arc::new(Mutex::new(Vec::new()));
         let received_cb = received.clone();
         let rescans = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -542,14 +602,23 @@ mod tests {
             },
         )
         .expect("watcher starts");
+        await_armed(&root, &received);
 
         // Excluded: must never surface.
         fs::write(root.join("node_modules/pkg.json"), "{}").unwrap();
         // Not excluded: must surface.
         fs::write(root.join("keep.txt"), "hi").unwrap();
 
-        // Give the coalesce window (500ms) time to flush.
-        std::thread::sleep(Duration::from_millis(1200));
+        let has_kept = || {
+            received.lock().unwrap().iter().any(|u| match u {
+                IndexUpdate::Upserted(e) => e.path.ends_with("keep.txt"),
+                IndexUpdate::Removed(p) => p.ends_with("keep.txt"),
+            })
+        };
+        wait_until(WATCHER_EVENT_BUDGET, has_kept);
+        // Give any excluded event that was going to leak a flush window to
+        // arrive, so the negative assertion isn't merely racing it.
+        std::thread::sleep(Duration::from_millis(600));
         drop(watcher);
 
         let updates = received.lock().unwrap();
@@ -557,15 +626,17 @@ mod tests {
             IndexUpdate::Upserted(e) => e.path.to_string_lossy().contains("node_modules"),
             IndexUpdate::Removed(p) => p.to_string_lossy().contains("node_modules"),
         });
-        let has_kept = updates.iter().any(|u| match u {
-            IndexUpdate::Upserted(e) => e.path.ends_with("keep.txt"),
-            IndexUpdate::Removed(p) => p.ends_with("keep.txt"),
-        });
         assert!(
             !has_excluded,
             "node_modules event must be dropped, got {updates:?}"
         );
-        assert!(has_kept, "non-excluded event must surface, got {updates:?}");
+        assert!(
+            updates.iter().any(|u| match u {
+                IndexUpdate::Upserted(e) => e.path.ends_with("keep.txt"),
+                IndexUpdate::Removed(p) => p.ends_with("keep.txt"),
+            }),
+            "non-excluded event must surface, got {updates:?}"
+        );
         assert_eq!(rescans.load(std::sync::atomic::Ordering::SeqCst), 0);
 
         let _ = fs::remove_dir_all(&root);
@@ -584,16 +655,30 @@ mod tests {
         let received_cb = received.clone();
         let watcher = start_watcher(
             std::slice::from_ref(&root),
-            build_exclusion_set(&[]),
+            no_exclusions(),
             move |updates| received_cb.lock().unwrap().extend(updates),
             || {},
         )
         .expect("watcher starts");
+        await_armed(&root, &received);
 
         let new = root.join("new-name.txt");
         fs::rename(&old, &new).unwrap();
 
-        std::thread::sleep(Duration::from_millis(1200));
+        let old_removed = || {
+            received
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|u| matches!(u, IndexUpdate::Removed(p) if p.ends_with("old-name.txt")))
+        };
+        let new_upserted =
+            || {
+                received.lock().unwrap().iter().any(
+                    |u| matches!(u, IndexUpdate::Upserted(e) if e.path.ends_with("new-name.txt")),
+                )
+            };
+        wait_until(WATCHER_EVENT_BUDGET, || old_removed() && new_upserted());
         drop(watcher);
 
         let updates = received.lock().unwrap();


### PR DESCRIPTION
Third slice of fixing the 38 Windows test failures that became visible once #499 made `cargo test` loadable on Windows (context in #498). **Test-only** — no product change.

## Two distinct Windows-only failures

**1. Hardcoded unix paths in fixtures (9 tests: 6 `index`, 2 `query`, 1 `snapshot`).**
The index materializes paths with `MAIN_SEPARATOR` and compares that against requested paths, so on Windows a `/tmp/rootA` root joined with `\` (`/tmp/rootA\docs`) never equals the unix-spelled lookup key — lookups miss and materialize/`.path` assertions differ by separator. Route fixture paths and their expected strings through a local `np()` helper (`/` → `MAIN_SEPARATOR`; no-op on Unix). Slash-token queries are unaffected: `tokenize()` splits the *query* on `/` and matches component names, not the stored separator.

**2. The two real-filesystem watcher e2e tests watched the OS temp dir (2 tests).**
On Windows that is `C:\Users\<u>\AppData\Local\Temp`, and `AppData/Local` is one of `DEFAULT_IGNORE_PATTERNS` — so `build_exclusion_set(&[])` matched the tests' *own watched root* via `**/AppData/Local/**` and the coalescer correctly dropped every event (`got []`). It only passed on Linux because `/tmp` matches no default pattern. The exclusion logic was working perfectly — the test just put its root inside an excluded directory.

Fix: give those tests an exclusion set scoped to just the pattern under test (`node_modules`, or none for the rename test), so the temp root isn't collaterally excluded. The default patterns are already covered by the pure-coalescer unit tests.

While there, I also replaced the fixed post-arm sleep with an active arming probe + bounded poll: write a throwaway file until an event lands (proving the backend delivers), then run the real writes and poll up to a budget for the expected events. It's robust to notify's async `ReadDirectoryChangesW` arming and self-diagnosing — it asserts clearly if a backend ever genuinely fails to deliver, instead of a silent empty list. (That assertion is what pinpointed the `AppData/Local` collision.)

## Why no product change

The index's `MAIN_SEPARATOR` handling is correct — real OS paths use the native separator on each platform. And excluding `AppData/Local` is intended; production watches user-configured roots (Documents, projects, …), never the OS temp dir. Both bugs are in the test fixtures.

## Verification

- Windows 11: `cargo test file_index` fully green (126 tests), including the 11 previously-failing and the two real-FS watcher e2e tests (run repeatedly, stable).
- Linux (WSL): full `cargo test` green (known `fs_watcher` inotify env failure aside); `cargo clippy --all-targets -- -D warnings` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
