### PR TITLE
test(windows): fix secret_scan + uninstall path assertions on Windows

### DIFF
--- a/asyar-launcher/src-tauri/src/application/uninstall.rs
+++ b/asyar-launcher/src-tauri/src/application/uninstall.rs
@@ -1012,9 +1012,12 @@ mod tests {
         #[test]
         fn validate_data_path_rejects_missing() {
             let tmp = fake_home();
+            // Absolute (on every platform, unlike a bare "/tmp/..." which is
+            // not absolute on Windows) but nonexistent — so the missing-path
+            // check fires, not the absolute-path one.
+            let missing = tmp.path().join("__asyar_nonexistent_data_path__");
             let err =
-                validate_data_path_under_home("/tmp/__asyar_nonexistent_data_path__", tmp.path())
-                    .unwrap_err();
+                validate_data_path_under_home(&missing.to_string_lossy(), tmp.path()).unwrap_err();
             assert!(matches!(err, AppError::NotFound(_)), "got: {err:?}");
         }
 

--- a/asyar-launcher/src-tauri/src/ext_builder/secret_scan.rs
+++ b/asyar-launcher/src-tauri/src/ext_builder/secret_scan.rs
@@ -112,7 +112,12 @@ mod tests {
         let hit = scan_dir_for_secret(&dir, "secret-ABC-123").unwrap();
         assert_eq!(
             hit,
-            Some(dir.join("src/config.ts").to_string_lossy().into_owned())
+            Some(
+                dir.join("src")
+                    .join("config.ts")
+                    .to_string_lossy()
+                    .into_owned()
+            )
         );
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -160,7 +165,12 @@ mod tests {
         write(&dir, "src/config.ts", "KEY=secret-ABC-123;");
         assert_eq!(
             scan_dir_for_secret(&dir, "  secret-ABC-123  ").unwrap(),
-            Some(dir.join("src/config.ts").to_string_lossy().into_owned())
+            Some(
+                dir.join("src")
+                    .join("config.ts")
+                    .to_string_lossy()
+                    .into_owned()
+            )
         );
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
Final slice of the 38 Windows test failures surfaced once #499 made `cargo test` loadable on Windows (context in #498). **Test-only** — no product change.

## The failures

- **`ext_builder::secret_scan`** (2 tests) — the expected offending path was built with `dir.join("src/config.ts")`. On Windows the forward-slash suffix stays literal (backslash root + `/config.ts`), while the scanner walks the tree and returns a native all-backslash path, so the equality assertion differed only by separator. Build the expected with sequential `.join("src").join("config.ts")` so it uses the native separator.
- **`application::uninstall::…::validate_data_path_rejects_missing`** (1 test) — it passed `"/tmp/__asyar_nonexistent_data_path__"`, which is not absolute on Windows, so `validate_data_path_under_home` returned its `Validation("must be absolute")` error *before* reaching the missing-path (`NotFound`) branch the test asserts. Derive an absolute-but-missing path from the fake home's temp dir instead, so the missing-path check is what fires on every platform.

## Verification

- Windows 11: `cargo test secret_scan` and `cargo test uninstall` green, including the three previously-failing tests.
- Linux (WSL): full `cargo test` green (known `fs_watcher` inotify env failure aside); `cargo clippy --all-targets -- -D warnings` and `cargo fmt` clean.

## Context

This is the last of the Windows test-portability fixes. With #503–#506 and this PR, `cargo test` passes on Windows except for the 6 `agents::builtin_tools::shell_test` cases, which are intentionally left alone because a separate in-flight PR reworks that area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
