### PR TITLE
fix(browser): restore paired browser companions on startup

### DIFF
--- a/asyar-launcher/src-tauri/src/browser/bridge/token_store.rs
+++ b/asyar-launcher/src-tauri/src/browser/bridge/token_store.rs
@@ -80,6 +80,41 @@ impl KeyringTokenStore {
     pub fn seed_index(&self, known: Vec<BrowserKey>) {
         *self.index.write().unwrap() = known;
     }
+
+    pub fn load_paired_from_backend(&self) {
+        let mut known_keys = Vec::new();
+
+        // 1. Chromium variants
+        for variant in crate::browser::paths::chromium_variants() {
+            known_keys.push(BrowserKey {
+                family: BrowserFamily::Chromium,
+                variant: variant.id.to_string(),
+            });
+        }
+
+        // 2. Firefox variants
+        for variant in crate::browser::paths::firefox_variants() {
+            known_keys.push(BrowserKey {
+                family: BrowserFamily::Firefox,
+                variant: variant.id.to_string(),
+            });
+        }
+
+        // 3. Safari
+        known_keys.push(BrowserKey {
+            family: BrowserFamily::Safari,
+            variant: "safari".to_string(),
+        });
+
+        let mut paired = Vec::new();
+        for key in known_keys {
+            if let Ok(Some(_)) = self.backend.read(&account_for(&key)) {
+                paired.push(key);
+            }
+        }
+
+        *self.index.write().unwrap() = paired;
+    }
 }
 
 impl Default for KeyringTokenStore {
@@ -111,6 +146,12 @@ impl TokenStore for KeyringTokenStore {
             .write()
             .unwrap()
             .insert(key.clone(), value.clone());
+        if value.is_some() {
+            let mut idx = self.index.write().unwrap();
+            if !idx.contains(key) {
+                idx.push(key.clone());
+            }
+        }
         Ok(value)
     }
 
@@ -333,5 +374,21 @@ mod tests {
         assert!(token
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'));
+    }
+
+    #[test]
+    fn load_paired_from_backend_populates_index() {
+        let backend = Arc::new(CountingBackend::default());
+        let key = BrowserKey {
+            family: BrowserFamily::Chromium,
+            variant: "chrome".to_string(),
+        };
+        backend.write(&account_for(&key), "tok").unwrap();
+
+        let store = KeyringTokenStore::with_backend(backend);
+        assert!(store.list_paired().unwrap().is_empty());
+
+        store.load_paired_from_backend();
+        assert_eq!(store.list_paired().unwrap(), vec![key]);
     }
 }

--- a/asyar-launcher/src-tauri/src/browser/bridge/token_store.rs
+++ b/asyar-launcher/src-tauri/src/browser/bridge/token_store.rs
@@ -107,9 +107,18 @@ impl KeyringTokenStore {
         });
 
         let mut paired = Vec::new();
+        let mut cache_updates = Vec::new();
         for key in known_keys {
-            if let Ok(Some(_)) = self.backend.read(&account_for(&key)) {
+            if let Ok(Some(token)) = self.backend.read(&account_for(&key)) {
+                cache_updates.push((key.clone(), Some(token)));
                 paired.push(key);
+            }
+        }
+
+        if !cache_updates.is_empty() {
+            let mut cache = self.cache.write().unwrap();
+            for (key, val) in cache_updates {
+                cache.insert(key, val);
             }
         }
 

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -1920,8 +1920,11 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         use std::sync::Arc;
         use tauri::Emitter;
 
+        let token_store = Arc::new(KeyringTokenStore::new());
+        token_store.load_paired_from_backend();
+
         let bridge_state = BridgeState {
-            tokens: Arc::new(KeyringTokenStore::new()),
+            tokens: token_store,
             pairing: Arc::new(PairingRegistry::new()),
             connections: Arc::new(CompanionRegistry::new()),
             cache: Arc::new(TabSnapshotCache::new()),

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -1921,7 +1921,10 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         use tauri::Emitter;
 
         let token_store = Arc::new(KeyringTokenStore::new());
-        token_store.load_paired_from_backend();
+        let token_store_clone = token_store.clone();
+        std::thread::spawn(move || {
+            token_store_clone.load_paired_from_backend();
+        });
 
         let bridge_state = BridgeState {
             tokens: token_store,


### PR DESCRIPTION
Seed the list of paired browsers in `KeyringTokenStore` on startup by scanning the OS keyring for known browser variant/family combinations. Additionally, update the token store to dynamically re-index a browser key upon successful keyring lookup during runtime verification. This fixes the issue where the settings page incorrectly showed paired browsers as unpaired after an app or device restart.