### PR TITLE
feat(ci): upload and publish .deb packages for Linux

### DIFF
--- a/.github/workflows/release-launcher.yml
+++ b/.github/workflows/release-launcher.yml
@@ -279,6 +279,7 @@ jobs:
           path: |
             asyar-launcher/src-tauri/target/${{ matrix.rust-target }}/release/bundle/appimage/*.AppImage
             asyar-launcher/src-tauri/target/${{ matrix.rust-target }}/release/bundle/appimage/*.AppImage.sig
+            asyar-launcher/src-tauri/target/${{ matrix.rust-target }}/release/bundle/deb/*.deb
 
   publish:
     needs: [build-macos, build-windows, build-linux]
@@ -324,6 +325,7 @@ jobs:
             artifacts/**/*.msi.sig
             artifacts/**/*.AppImage
             artifacts/**/*.AppImage.sig
+            artifacts/**/*.deb
           draft: false
           prerelease: ${{ contains(github.event.inputs.tag || github.ref_name, '-') }}
           generate_release_notes: true


### PR DESCRIPTION
Collect and upload .deb packages generated during the Linux build stage,
and attach them to the GitHub release. This resolves #491.