### PR TITLE
fix(ai): let any configured provider become the default

### DIFF
--- a/asyar-launcher/src-tauri/src/agents/lifecycle.rs
+++ b/asyar-launcher/src-tauri/src/agents/lifecycle.rs
@@ -49,15 +49,29 @@ fn default_agent(provider_id: &str, model_id: &str) -> AgentRow {
     }
 }
 
+/// Resolve the user's chosen default agent by id.
+///
+/// Returns `None` when no id is stored or the stored id no longer points at a
+/// live agent. It deliberately does NOT fall back to "the first agent in the
+/// DB" — that fallback made a provider the user never picked appear as the ★
+/// default (e.g. a leftover Anthropic agent from onboarding). A default is
+/// shown only when it was explicitly chosen.
 pub fn resolve_default_agent(
     conn: &Connection,
     default_agent_id: Option<&str>,
 ) -> Result<Option<AgentRow>, AppError> {
-    if let Some(id) = default_agent_id.filter(|id| !id.trim().is_empty()) {
-        if let Some(agent) = get_agent(conn, id)? {
-            return Ok(Some(agent));
-        }
+    match default_agent_id.filter(|id| !id.trim().is_empty()) {
+        Some(id) => get_agent(conn, id),
+        None => Ok(None),
     }
+}
+
+/// The earliest-inserted agent, or `None` when there are no agents.
+///
+/// Used only where "any existing agent" is a sensible template (e.g. seeding
+/// the emoji fallback agent's provider/model at startup) — never for resolving
+/// the user-facing default.
+pub fn first_agent(conn: &Connection) -> Result<Option<AgentRow>, AppError> {
     Ok(list_agents(conn)?.into_iter().next())
 }
 
@@ -281,21 +295,36 @@ mod tests {
     }
 
     #[test]
-    fn resolve_default_uses_registered_id_then_database_order_fallback() {
+    fn resolve_default_returns_the_registered_agent_or_none() {
         let conn = conn();
         let first = existing_agent("a", "First");
         let second = existing_agent("b", "Second");
         insert_agent(&conn, &first).unwrap();
         insert_agent(&conn, &second).unwrap();
 
+        // A valid id resolves to that exact agent.
         assert_eq!(
             resolve_default_agent(&conn, Some("b")).unwrap(),
             Some(second)
         );
-        assert_eq!(
-            resolve_default_agent(&conn, Some("missing")).unwrap(),
-            Some(first)
-        );
+        // A dangling id resolves to None — never a silent fall back to another
+        // agent, so the UI only shows a ★ default the user actually chose.
+        assert_eq!(resolve_default_agent(&conn, Some("missing")).unwrap(), None);
+        // No id at all means no default has been chosen yet.
+        assert_eq!(resolve_default_agent(&conn, None).unwrap(), None);
+    }
+
+    #[test]
+    fn first_agent_returns_earliest_by_db_order_or_none_when_empty() {
+        let conn = conn();
+        assert_eq!(first_agent(&conn).unwrap(), None);
+
+        let first = existing_agent("a", "First");
+        let second = existing_agent("b", "Second");
+        insert_agent(&conn, &first).unwrap();
+        insert_agent(&conn, &second).unwrap();
+
+        assert_eq!(first_agent(&conn).unwrap(), Some(first));
     }
 
     #[test]

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -2024,13 +2024,11 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     {
         let db = app.state::<crate::storage::DataStore>();
         if let Ok(conn) = db.conn() {
-            if let Ok(Some(default_agent)) =
-                crate::agents::lifecycle::resolve_default_agent(&conn, None)
-            {
+            if let Ok(Some(template_agent)) = crate::agents::lifecycle::first_agent(&conn) {
                 let _ = crate::agents::lifecycle::seed_emoji_fallback_agent(
                     &conn,
-                    &default_agent.provider_id,
-                    &default_agent.model_id,
+                    &template_agent.provider_id,
+                    &template_agent.model_id,
                 );
             }
         };

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -2025,11 +2025,13 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         let db = app.state::<crate::storage::DataStore>();
         if let Ok(conn) = db.conn() {
             if let Ok(Some(template_agent)) = crate::agents::lifecycle::first_agent(&conn) {
-                let _ = crate::agents::lifecycle::seed_emoji_fallback_agent(
+                if let Err(e) = crate::agents::lifecycle::seed_emoji_fallback_agent(
                     &conn,
                     &template_agent.provider_id,
                     &template_agent.model_id,
-                );
+                ) {
+                    log::error!("Failed to seed emoji fallback agent: {e}");
+                }
             }
         };
     }

--- a/asyar-launcher/src/routes/settings/tabs/AiTab.helpers.test.ts
+++ b/asyar-launcher/src/routes/settings/tabs/AiTab.helpers.test.ts
@@ -3,6 +3,7 @@ import {
   availableProvidersForNewRow,
   canTestAndFetch,
   configForNewProvider,
+  modelSelectionAfterFetch,
   reasoningEffortAfterModelChange,
   reasoningEffortsForModel,
 } from './AiTab.helpers';
@@ -143,5 +144,49 @@ describe('reasoningEffortsForModel', () => {
         'low',
       ),
     ).toBe('low');
+  });
+});
+
+// ── modelSelectionAfterFetch ───────────────────────────────────────────────────
+
+describe('modelSelectionAfterFetch', () => {
+  const plugin = makePlugin('ollama');
+  const models = [
+    { id: 'llama3.2', label: 'Llama 3.2' },
+    { id: 'qwen2.5', label: 'Qwen 2.5' },
+  ];
+
+  it('adopts the first fetched model when none is selected yet', () => {
+    // The <select> only shows the first model — it never fires onchange, so the
+    // config must be seeded here or the ★ default button stays disabled.
+    const result = modelSelectionAfterFetch(plugin, models, { enabled: true });
+    expect(result.configPatch.lastModelId).toBe('llama3.2');
+    expect(result.newlySelectedModelId).toBe('llama3.2');
+  });
+
+  it('keeps the user-chosen model and does not re-trigger auto-default', () => {
+    const result = modelSelectionAfterFetch(plugin, models, {
+      enabled: true,
+      lastModelId: 'qwen2.5',
+    });
+    expect(result.configPatch.lastModelId).toBeUndefined();
+    expect(result.newlySelectedModelId).toBeUndefined();
+  });
+
+  it('makes no selection when the provider returns no models', () => {
+    const result = modelSelectionAfterFetch(plugin, [], { enabled: true });
+    expect(result.configPatch.lastModelId).toBeUndefined();
+    expect(result.newlySelectedModelId).toBeUndefined();
+  });
+
+  it('clears a reasoning effort the auto-selected model does not support', () => {
+    const reasoningPlugin = makePlugin('ollama', { reasoningEfforts: ['low', 'high'] });
+    const result = modelSelectionAfterFetch(
+      reasoningPlugin,
+      [{ id: 'plain', label: 'Plain', reasoningEfforts: [] }],
+      { enabled: true, reasoningEffort: 'high' },
+    );
+    expect(result.configPatch.reasoningEffort).toBeUndefined();
+    expect('reasoningEffort' in result.configPatch).toBe(true);
   });
 });

--- a/asyar-launcher/src/routes/settings/tabs/AiTab.helpers.ts
+++ b/asyar-launcher/src/routes/settings/tabs/AiTab.helpers.ts
@@ -71,7 +71,7 @@ export function modelSelectionAfterFetch(
     effectiveModelId,
     config.reasoningEffort,
   );
-  const isNewSelection = !config.lastModelId && effectiveModelId !== undefined;
+  const isNewSelection = !config.lastModelId && effectiveModelId != null;
 
   const configPatch: Partial<ProviderConfig> = {};
   if (isNewSelection) configPatch.lastModelId = effectiveModelId;

--- a/asyar-launcher/src/routes/settings/tabs/AiTab.helpers.ts
+++ b/asyar-launcher/src/routes/settings/tabs/AiTab.helpers.ts
@@ -43,6 +43,46 @@ export function configForNewProvider(
   };
 }
 
+export interface FetchModelsOutcome {
+  /** Config fields to persist after a fetch (may be empty). */
+  configPatch: Partial<ProviderConfig>;
+  /** The model id to auto-adopt as default, set only on a first-time selection. */
+  newlySelectedModelId: string | undefined;
+}
+
+/**
+ * Decides what to persist after models are fetched for a provider.
+ *
+ * The model <select> shows `config.lastModelId ?? models[0].id`, so an
+ * untouched dropdown displays the first model but fires no onchange — the id
+ * would never persist, leaving `lastModelId` unset and the ★ default button
+ * disabled. This seeds the effective model so the button works and the first
+ * provider can auto-default.
+ */
+export function modelSelectionAfterFetch(
+  plugin: IProviderPlugin | null | undefined,
+  models: ModelInfo[],
+  config: ProviderConfig,
+): FetchModelsOutcome {
+  const effectiveModelId = config.lastModelId ?? models[0]?.id;
+  const reasoningEffort = reasoningEffortAfterModelChange(
+    plugin,
+    models,
+    effectiveModelId,
+    config.reasoningEffort,
+  );
+  const isNewSelection = !config.lastModelId && effectiveModelId !== undefined;
+
+  const configPatch: Partial<ProviderConfig> = {};
+  if (isNewSelection) configPatch.lastModelId = effectiveModelId;
+  if (reasoningEffort !== config.reasoningEffort) configPatch.reasoningEffort = reasoningEffort;
+
+  return {
+    configPatch,
+    newlySelectedModelId: isNewSelection ? effectiveModelId : undefined,
+  };
+}
+
 export function reasoningEffortsForModel(
   plugin: IProviderPlugin | null | undefined,
   models: ModelInfo[],

--- a/asyar-launcher/src/routes/settings/tabs/AiTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/AiTab.svelte
@@ -8,6 +8,7 @@
     availableProvidersForNewRow,
     canTestAndFetch,
     configForNewProvider,
+    modelSelectionAfterFetch,
     reasoningEffortAfterModelChange,
     reasoningEffortsForModel,
   } from './AiTab.helpers';
@@ -109,15 +110,18 @@
       modelCache = { ...modelCache, [plugin.id]: models };
       fetchErrors = { ...fetchErrors, [plugin.id]: '' };
       const config = getConfig(plugin.id);
-      const modelId = config.lastModelId ?? models[0]?.id;
-      const reasoningEffort = reasoningEffortAfterModelChange(
+      // Seed the effective model so the ★ default button is enabled even when
+      // the user keeps the pre-selected first entry (which fires no onchange).
+      const { configPatch, newlySelectedModelId } = modelSelectionAfterFetch(
         plugin,
         models,
-        modelId,
-        config.reasoningEffort,
+        config,
       );
-      if (reasoningEffort !== config.reasoningEffort) {
-        updateProviderConfig(plugin.id, { reasoningEffort });
+      if (Object.keys(configPatch).length > 0) {
+        updateProviderConfig(plugin.id, configPatch);
+      }
+      if (newlySelectedModelId) {
+        await maybeAutoSetAsDefault(plugin.id, newlySelectedModelId);
       }
     } catch (e: unknown) {
       fetchErrors = {
@@ -135,10 +139,15 @@
     return agent?.providerId === id;
   }
 
-  async function setAsDefault(id: ProviderId) {
+  // Make a provider the sole default. `fallbackModelId` is the first fetched
+  // model, used when the user hasn't explicitly picked one yet (an untouched
+  // dropdown fires no onchange). The resolved model is persisted so the row and
+  // the default agent always agree.
+  async function setAsDefault(id: ProviderId, fallbackModelId?: string) {
     const config = getConfig(id);
-    const modelId = config.lastModelId;
+    const modelId = config.lastModelId ?? fallbackModelId;
     if (!modelId) return;
+    if (!config.lastModelId) updateProviderConfig(id, { lastModelId: modelId });
     try {
       await agentService.upsertDefaultAgent(id, modelId);
     } catch (err) {
@@ -299,7 +308,7 @@
         {@const isFetching = !!fetchingModels[providerId]}
         {@const fetchError = fetchErrors[providerId] ?? ''}
         {@const defaultRow = isDefault(providerId)}
-        {@const hasModel = !!config.lastModelId}
+        {@const canBeDefault = !!config.lastModelId || cachedModels.length > 0}
         {@const useCustomInput = customModelMode[providerId] ?? false}
         {@const openAIApiMode = config.openAIApiMode ?? 'chat-completions'}
         {@const selectedModelId = config.lastModelId ?? cachedModels[0]?.id}
@@ -326,13 +335,13 @@
               <button
                 class="star-btn"
                 class:is-filled={defaultRow}
-                disabled={!hasModel}
-                title={hasModel
+                disabled={!canBeDefault}
+                title={canBeDefault
                   ? defaultRow
                     ? 'Default provider'
                     : 'Set as default'
-                  : 'Pick a model first'}
-                onclick={() => setAsDefault(providerId)}
+                  : 'Fetch a model first'}
+                onclick={() => setAsDefault(providerId, selectedModelId)}
                 aria-label={defaultRow ? 'Default provider' : 'Set as default'}
               >
                 {defaultRow ? '★' : '☆'}

--- a/asyar-launcher/src/routes/settings/tabs/AiTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/AiTab.svelte
@@ -86,7 +86,7 @@
   }
 
   function updateProviderConfig(id: ProviderId, partial: Partial<ProviderConfig>) {
-    settingsService.updateSettings('ai', {
+    return settingsService.updateSettings('ai', {
       providers: {
         ...settings.providers,
         [id]: { ...getConfig(id), ...partial },
@@ -118,7 +118,7 @@
         config,
       );
       if (Object.keys(configPatch).length > 0) {
-        updateProviderConfig(plugin.id, configPatch);
+        await updateProviderConfig(plugin.id, configPatch);
       }
       if (newlySelectedModelId) {
         await maybeAutoSetAsDefault(plugin.id, newlySelectedModelId);
@@ -147,7 +147,7 @@
     const config = getConfig(id);
     const modelId = config.lastModelId ?? fallbackModelId;
     if (!modelId) return;
-    if (!config.lastModelId) updateProviderConfig(id, { lastModelId: modelId });
+    if (!config.lastModelId) await updateProviderConfig(id, { lastModelId: modelId });
     try {
       await agentService.upsertDefaultAgent(id, modelId);
     } catch (err) {


### PR DESCRIPTION
The ★ default-provider toggle was permanently disabled for every
provider except a stale leftover Anthropic agent, because:
- resolve_default_agent fell back to "first agent in the DB" when
  no default was chosen, silently crowning whatever agent happened
  to be seeded first instead of the user's actual pick
- the star was gated on a persisted model id that never got saved
  when the user kept the pre-selected first fetched model

Now the default is only ever the one the user explicitly set, the
star enables as soon as a provider has a fetchable model, and the
first configured provider auto-defaults.

Fixes #523