### PR TITLE
fix(ai): sanitize inline emoji fallback output and accept empty rpc payload

### DIFF
--- a/asyar-launcher/src-tauri/src/agents/lifecycle.rs
+++ b/asyar-launcher/src-tauri/src/agents/lifecycle.rs
@@ -187,6 +187,25 @@ pub fn find_shortcode_miss_agent(conn: &Connection) -> Result<Option<AgentRow>, 
         .find(|agent| agent.input_source == SilentInputSource::ShortcodeMiss))
 }
 
+/// Reduces a `ShortcodeMiss` agent's raw reply to a single emoji, or an empty
+/// string if the model ignored its instructions and answered conversationally
+/// instead of calling `emoji_find`. Only a reply that trims to exactly one
+/// non-ASCII grapheme is trusted — anything else (prose, punctuation, plain
+/// ASCII) is treated the same as "no match" rather than pasted verbatim.
+pub fn sanitize_emoji_fallback_output(text: &str) -> String {
+    use unicode_segmentation::UnicodeSegmentation;
+
+    let trimmed = text.trim();
+    let is_single_non_ascii_grapheme = UnicodeSegmentation::graphemes(trimmed, true).count() == 1
+        && trimmed.chars().next().is_some_and(|c| !c.is_ascii());
+
+    if is_single_non_ascii_grapheme {
+        trimmed.to_string()
+    } else {
+        String::new()
+    }
+}
+
 /// Resolve a stored silent-agent target to its `AgentRow`.
 pub fn resolve_silent_agent_target(
     conn: &Connection,
@@ -363,6 +382,38 @@ mod tests {
             found.as_ref().map(|a| a.id.as_str()),
             Some(seeded.id.as_str())
         );
+    }
+
+    #[test]
+    fn sanitize_emoji_fallback_output_passes_through_a_single_emoji() {
+        assert_eq!(sanitize_emoji_fallback_output("🎉"), "🎉");
+    }
+
+    #[test]
+    fn sanitize_emoji_fallback_output_trims_surrounding_whitespace() {
+        assert_eq!(sanitize_emoji_fallback_output("  🎉\n"), "🎉");
+    }
+
+    #[test]
+    fn sanitize_emoji_fallback_output_rejects_prose() {
+        assert_eq!(
+            sanitize_emoji_fallback_output(
+                "# Party Suggestions\n\nHere are some ideas for \"party\":"
+            ),
+            ""
+        );
+    }
+
+    #[test]
+    fn sanitize_emoji_fallback_output_rejects_empty_or_whitespace_only() {
+        assert_eq!(sanitize_emoji_fallback_output(""), "");
+        assert_eq!(sanitize_emoji_fallback_output("   \n  "), "");
+    }
+
+    #[test]
+    fn sanitize_emoji_fallback_output_rejects_a_single_ascii_character() {
+        assert_eq!(sanitize_emoji_fallback_output("x"), "");
+        assert_eq!(sanitize_emoji_fallback_output(":"), "");
     }
 
     #[test]

--- a/asyar-launcher/src-tauri/src/agents/runner.rs
+++ b/asyar-launcher/src-tauri/src/agents/runner.rs
@@ -5,7 +5,7 @@ use crate::ai::types::{
 use crate::error::AppError;
 use crate::storage::agents::{
     get_agent, get_thread, insert_message, list_messages_for_thread, update_thread_title, AgentRow,
-    MessageRole, MessageRow,
+    MessageRole, MessageRow, SilentInputSource,
 };
 use crate::storage::DataStore;
 use serde::{Deserialize, Serialize};
@@ -895,6 +895,11 @@ where
     match result {
         Some(result) => {
             on_event(AgentStreamEvent::Completed);
+            let result = if agent.input_source == SilentInputSource::ShortcodeMiss {
+                crate::agents::lifecycle::sanitize_emoji_fallback_output(&result)
+            } else {
+                result
+            };
             Ok(result)
         }
         None => {

--- a/asyar-launcher/src-tauri/src/agents/runner_test.rs
+++ b/asyar-launcher/src-tauri/src/agents/runner_test.rs
@@ -217,6 +217,86 @@ async fn test_silent_runner_rejects_non_silent_agent() {
         .contains("is not configured for silent execution"));
 }
 
+fn shortcode_miss_agent() -> AgentRow {
+    AgentRow {
+        id: "agent-emoji-fallback".to_string(),
+        name: "Inline Emoji Fallback".to_string(),
+        description: None,
+        system_prompt: "resolve emoji".to_string(),
+        provider_id: "openai".to_string(),
+        model_id: "gpt-4o".to_string(),
+        tool_selection: vec![],
+        silent: true,
+        input_source: crate::storage::agents::SilentInputSource::ShortcodeMiss,
+        output_action: crate::storage::agents::SilentOutputAction::Paste,
+        cache_responses: true,
+        shortcode_trigger: ":".to_string(),
+        created_at: None,
+        updated_at: None,
+    }
+}
+
+async fn run_shortcode_miss_with_mocked_reply(reply_chunks: &[&str]) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let body = reply_chunks
+        .iter()
+        .map(|chunk| format!("data: {{\"choices\":[{{\"delta\":{{\"content\":{chunk}}}}}]}}\n\n"))
+        .collect::<String>();
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = [0; 4096];
+        let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut buf)
+            .await
+            .unwrap();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n{body}data: [DONE]\n\n"
+        );
+        socket.write_all(response.as_bytes()).await.unwrap();
+    });
+
+    let provider = crate::ai::types::ProviderConfig {
+        enabled: true,
+        api_key: Some("test-key".to_string()),
+        base_url: Some(format!("http://127.0.0.1:{port}")),
+        last_model_id: None,
+        open_ai_api_mode: None,
+        hosted_web_search: None,
+        reasoning_effort: None,
+    };
+
+    run_silent_agent_loop_impl(
+        &shortcode_miss_agent(),
+        &ToolRegistry::new(),
+        "party".to_string(),
+        run_config(provider, 0.7, 2048),
+        |_| {},
+        |_| async { Err(AppError::Other("unexpected tool dispatch".to_string())) },
+        None,
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn test_silent_runner_sanitizes_shortcode_miss_prose_to_empty() {
+    let result =
+        run_shortcode_miss_with_mocked_reply(&["\"Here are some \"", "\"party ideas!\""]).await;
+
+    assert_eq!(
+        result, "",
+        "prose from a ShortcodeMiss agent must be sanitized to empty, not pasted verbatim"
+    );
+}
+
+#[tokio::test]
+async fn test_silent_runner_passes_through_a_single_emoji_for_shortcode_miss() {
+    let result = run_shortcode_miss_with_mocked_reply(&["\"🎉\""]).await;
+
+    assert_eq!(result, "🎉");
+}
+
 #[tokio::test]
 async fn test_thread_runner_rejects_thread_owned_by_another_agent() {
     let conn = make_conn();

--- a/asyar-launcher/src-tauri/src/commands/extension_state.rs
+++ b/asyar-launcher/src-tauri/src/commands/extension_state.rs
@@ -282,7 +282,7 @@ pub fn state_rpc_request(
     extension_id: String,
     id: String,
     correlation_id: String,
-    payload: Value,
+    payload: Option<Value>,
     mgr: State<'_, Arc<ExtensionRuntimeManager>>,
 ) -> Result<IpcDispatchOutcome, AppError> {
     let emitter = TauriEventEmitter { app };
@@ -292,7 +292,7 @@ pub fn state_rpc_request(
         &extension_id,
         id,
         correlation_id,
-        payload,
+        payload.unwrap_or(Value::Null),
         Instant::now(),
     )
 }

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -2021,20 +2021,6 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         app.manage(bridge_state);
     }
 
-    {
-        let db = app.state::<crate::storage::DataStore>();
-        if let Ok(conn) = db.conn() {
-            if let Ok(Some(template_agent)) = crate::agents::lifecycle::first_agent(&conn) {
-                if let Err(e) = crate::agents::lifecycle::seed_emoji_fallback_agent(
-                    &conn,
-                    &template_agent.provider_id,
-                    &template_agent.model_id,
-                ) {
-                    log::error!("Failed to seed emoji fallback agent: {e}");
-                }
-            }
-        };
-    }
     Ok(())
 }
 

--- a/asyar-launcher/src-tauri/src/permissions.rs
+++ b/asyar-launcher/src-tauri/src/permissions.rs
@@ -229,7 +229,6 @@ fn get_required_permission(call_type: &str) -> Option<&'static str> {
         "asyar:api:snippets:promoteLearnedShortcode" => Some("snippets:contribute"),
         "asyar:api:snippets:forgetLearnedShortcode" => Some("snippets:contribute"),
         "asyar:api:snippets:clearLearnedShortcodes" => Some("snippets:contribute"),
-        "asyar:api:snippets:setInlineFallbackEnabled" => Some("snippets:contribute"),
         // Browser bridge — tabs (read = list/inspect, write = act/open/search).
         "asyar:api:browser:listTabs" => Some("browser:tabs.read"),
         "asyar:api:browser:getActiveTab" => Some("browser:tabs.read"),
@@ -1019,7 +1018,6 @@ mod tests {
             "asyar:api:snippets:promoteLearnedShortcode",
             "asyar:api:snippets:forgetLearnedShortcode",
             "asyar:api:snippets:clearLearnedShortcodes",
-            "asyar:api:snippets:setInlineFallbackEnabled",
         ] {
             assert_eq!(get_required_permission(method), Some("snippets:contribute"));
         }

--- a/asyar-launcher/src/lib/ipc/shortcodeCommands.ts
+++ b/asyar-launcher/src/lib/ipc/shortcodeCommands.ts
@@ -1,8 +1,7 @@
 import { invokeSafe, invokeSafeVoid } from './invokeSafe';
 
-// `contribute_shortcodes`/`revoke_shortcodes`/`promote_learned_to_snippet`/
-// `set_inline_emoji_fallback_enabled`/`record_inline_emoji_fallback_outcome`
-// are all `Result<(), AppError>` on the Rust side — Ok(()) and invokeSafe's
+// `contribute_shortcodes`/`revoke_shortcodes`/`promote_learned_to_snippet` are
+// all `Result<(), AppError>` on the Rust side — Ok(()) and invokeSafe's
 // failure sentinel both serialize to `null`, so these use invokeSafeVoid's
 // boolean signal instead. `list_learned_shortcodes`/`forget_learned_shortcode`/
 // `clear_learned_shortcodes` are plain (non-Result) commands and keep invokeSafe.
@@ -32,8 +31,4 @@ export async function forgetLearnedShortcode(shortcode: string): Promise<void> {
 
 export async function clearLearnedShortcodes(): Promise<void> {
   await invokeSafe('clear_learned_shortcodes');
-}
-
-export async function setInlineEmojiFallbackEnabled(enabled: boolean): Promise<boolean> {
-  return invokeSafeVoid('set_inline_emoji_fallback_enabled', { enabled });
 }

--- a/asyar-launcher/src/services/extension/ExtensionIpcRouter.ts
+++ b/asyar-launcher/src/services/extension/ExtensionIpcRouter.ts
@@ -7,7 +7,6 @@ import {
   promoteLearnedToSnippet,
   forgetLearnedShortcode,
   clearLearnedShortcodes,
-  setInlineEmojiFallbackEnabled,
 } from '../../lib/ipc/shortcodeCommands';
 import { extensionIframeManager } from './extensionIframeManager.svelte';
 import { extensionPreferencesService } from './extensionPreferencesService.svelte';
@@ -472,13 +471,6 @@ export class ExtensionIpcRouter {
 
     if (type === 'asyar:api:snippets:clearLearnedShortcodes') {
       return clearLearnedShortcodes();
-    }
-
-    if (type === 'asyar:api:snippets:setInlineFallbackEnabled') {
-      const { enabled } = payload as { enabled: boolean };
-      const ok = await setInlineEmojiFallbackEnabled(enabled);
-      if (!ok) throw new HandledDispatchError('set_inline_emoji_fallback_enabled failed');
-      return undefined;
     }
 
     const ns = serviceName as Namespace;

--- a/asyar-launcher/src/services/permissionGate.ts
+++ b/asyar-launcher/src/services/permissionGate.ts
@@ -114,7 +114,6 @@ export const PERMISSION_MAP: Record<string, string> = {
   'asyar:api:snippets:promoteLearnedShortcode': 'snippets:contribute',
   'asyar:api:snippets:forgetLearnedShortcode': 'snippets:contribute',
   'asyar:api:snippets:clearLearnedShortcodes': 'snippets:contribute',
-  'asyar:api:snippets:setInlineFallbackEnabled': 'snippets:contribute',
   // Browser bridge — bookmarks and history read scopes.
   // listAvailableBrowsers and isCompanionInstalled are intentionally
   // unmapped (permission-free discovery, no security boundary).

--- a/asyar-sdk/src/contracts/snippets.ts
+++ b/asyar-sdk/src/contracts/snippets.ts
@@ -51,11 +51,4 @@ export interface ISnippetsService {
 
   /** Clear all AI-learned shortcode cache entries. */
   clearLearnedShortcodes(): Promise<void>;
-
-  /**
-   * Enable or disable the launcher's inline AI fallback for unmatched
-   * `:shortcodes:`. When disabled, the dispatcher silently no-ops on every
-   * shortcode-miss event. Requires the `snippets:contribute` permission.
-   */
-  setInlineFallbackEnabled(enabled: boolean): Promise<void>;
 }

--- a/asyar-sdk/src/services/SnippetsServiceProxy.ts
+++ b/asyar-sdk/src/services/SnippetsServiceProxy.ts
@@ -41,8 +41,4 @@ export class SnippetsServiceProxy extends BaseServiceProxy implements ISnippetsS
   async clearLearnedShortcodes(): Promise<void> {
     await this.broker.invoke('snippets:clearLearnedShortcodes', {});
   }
-
-  async setInlineFallbackEnabled(enabled: boolean): Promise<void> {
-    await this.broker.invoke('snippets:setInlineFallbackEnabled', { enabled });
-  }
 }


### PR DESCRIPTION
Reduce shortcode-miss agent replies to a single emoji (empty otherwise) so
raw AI prose no longer pastes into the launcher, and let state_rpc_request
accept an absent payload for parameterless context.request calls. Drop the
inline-fallback enable/disable toggle across launcher/SDK/emoji in favor of
the agent's existence being the single source of truth, and remove the
startup auto-seed that recreated it on every launch.