### PR TITLE
fix(settings): refresh extensions list without restarting the launcher

### DIFF
--- a/asyar-launcher/src/routes/settings/settingsHandlers.svelte.ts
+++ b/asyar-launcher/src/routes/settings/settingsHandlers.svelte.ts
@@ -1,4 +1,5 @@
 import { onMount } from 'svelte';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import { updateShortcut } from '../../utils/shortcutManager';
 import { goto } from '$app/navigation';
 import {
@@ -130,6 +131,8 @@ export class SettingsHandler {
 
   private unsubscribe: (() => void) | null = null;
   private unlistenPreferencesChanged: (() => void) | null = null;
+  private unlistenExtensionsUpdated: (() => void) | null = null;
+  private unlistenWindowFocus: (() => void) | null = null;
   /**
    * Bumped whenever an `asyar:preferences-changed` Tauri event arrives.
    * The ExtensionDetailPanel consumes this as a reactive dependency in
@@ -201,6 +204,34 @@ export class SettingsHandler {
       } catch (err) {
         logService.warn(`Failed to subscribe to asyar:preferences-changed: ${err}`);
       }
+
+      // Cross-webview install/uninstall/update notifications. The Rust side
+      // emits this after every extension install/uninstall/update, but it
+      // only reaches windows that are actually listening for it.
+      try {
+        const { listen } = await import('@tauri-apps/api/event');
+        this.unlistenExtensionsUpdated = await listen('extensions_updated', () => {
+          void this.loadExtensions();
+        });
+      } catch (err) {
+        logService.warn(`Failed to subscribe to extensions_updated: ${err}`);
+      }
+
+      // The settings window is a persistent hidden webview — it's shown/
+      // hidden rather than destroyed/recreated on close, so `onMount` (and
+      // its one-shot `loadExtensions()` call above) never runs again after
+      // the first open. Extensions installed via `asyar link` bypass the
+      // running app entirely (no Tauri event at all), so the only reliable
+      // way to pick those up is a fresh rescan whenever this window regains
+      // focus, i.e. whenever the user reopens Settings.
+      try {
+        const unlisten = await getCurrentWindow().onFocusChanged(({ payload: focused }) => {
+          if (focused) void this.loadExtensions();
+        });
+        this.unlistenWindowFocus = unlisten;
+      } catch (err) {
+        logService.warn(`Failed to subscribe to settings window focus: ${err}`);
+      }
     }
   }
 
@@ -220,6 +251,10 @@ export class SettingsHandler {
     }
     this.unlistenPreferencesChanged?.();
     this.unlistenPreferencesChanged = null;
+    this.unlistenExtensionsUpdated?.();
+    this.unlistenExtensionsUpdated = null;
+    this.unlistenWindowFocus?.();
+    this.unlistenWindowFocus = null;
   }
 
   async loadExtensions() {

--- a/asyar-launcher/src/routes/settings/settingsHandlers.svelte.ts
+++ b/asyar-launcher/src/routes/settings/settingsHandlers.svelte.ts
@@ -258,6 +258,12 @@ export class SettingsHandler {
   }
 
   async loadExtensions() {
+    // extensions_updated and window-focus can fire close together (e.g.
+    // installing from the store while Settings is visible, then refocusing
+    // it) — skip a redundant overlapping rescan rather than racing two
+    // invoke() calls against each other.
+    if (this.isLoadingExtensions) return;
+
     this.isLoadingExtensions = true;
     this.extensionError = '';
 

--- a/asyar-launcher/src/routes/settings/settingsHandlers.test.ts
+++ b/asyar-launcher/src/routes/settings/settingsHandlers.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SettingsHandler, DEFAULT_SETTINGS } from './settingsHandlers.svelte';
 
@@ -6,6 +7,16 @@ const { mockGetAll } = vi.hoisted(() => ({ mockGetAll: vi.fn() }));
 vi.mock('../../services/extension/extensionManager.svelte', () => ({
   default: { getAllExtensionsWithState: mockGetAll },
 }));
+const { listenMock, onFocusChangedMock, getCurrentWindowMock } = vi.hoisted(() => {
+  const onFocusChangedMock = vi.fn();
+  return {
+    listenMock: vi.fn(),
+    onFocusChangedMock,
+    getCurrentWindowMock: vi.fn(() => ({ onFocusChanged: onFocusChangedMock })),
+  };
+});
+vi.mock('@tauri-apps/api/event', () => ({ listen: listenMock }));
+vi.mock('@tauri-apps/api/window', () => ({ getCurrentWindow: getCurrentWindowMock }));
 const { mockUpdateSettings } = vi.hoisted(() => ({
   mockUpdateSettings: vi.fn().mockResolvedValue(true),
 }));
@@ -94,6 +105,78 @@ describe('SettingsHandler.loadExtensions', () => {
     await handler.loadExtensions();
 
     expect(handler.extensions).toHaveLength(1);
+  });
+});
+
+describe('SettingsHandler.init — extension list freshness', () => {
+  beforeEach(() => {
+    mockGetAll.mockReset().mockResolvedValue([]);
+    listenMock.mockClear().mockImplementation(() => Promise.resolve(() => {}));
+    onFocusChangedMock.mockClear().mockImplementation(() => Promise.resolve(() => {}));
+  });
+
+  it('reloads extensions when an extensions_updated event fires', async () => {
+    let onExtensionsUpdated: (() => void) | undefined;
+    listenMock.mockImplementation((eventName: string, cb: () => void) => {
+      if (eventName === 'extensions_updated') onExtensionsUpdated = cb;
+      return Promise.resolve(() => {});
+    });
+
+    const handler = new SettingsHandler();
+    await handler.init();
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
+
+    onExtensionsUpdated?.();
+    await vi.waitFor(() => expect(mockGetAll).toHaveBeenCalledTimes(2));
+  });
+
+  it('reloads extensions when the settings window regains focus', async () => {
+    let onFocusChanged: ((e: { payload: boolean }) => void) | undefined;
+    onFocusChangedMock.mockImplementation((cb: (e: { payload: boolean }) => void) => {
+      onFocusChanged = cb;
+      return Promise.resolve(() => {});
+    });
+
+    const handler = new SettingsHandler();
+    await handler.init();
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
+
+    onFocusChanged?.({ payload: true });
+    await vi.waitFor(() => expect(mockGetAll).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not reload extensions when the settings window loses focus', async () => {
+    let onFocusChanged: ((e: { payload: boolean }) => void) | undefined;
+    onFocusChangedMock.mockImplementation((cb: (e: { payload: boolean }) => void) => {
+      onFocusChanged = cb;
+      return Promise.resolve(() => {});
+    });
+
+    const handler = new SettingsHandler();
+    await handler.init();
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
+
+    onFocusChanged?.({ payload: false });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroy() unsubscribes the extensions_updated and window-focus listeners', async () => {
+    const unlistenExtensionsUpdated = vi.fn();
+    const unlistenFocus = vi.fn();
+    listenMock.mockImplementation((eventName: string) =>
+      eventName === 'extensions_updated'
+        ? Promise.resolve(unlistenExtensionsUpdated)
+        : Promise.resolve(() => {}),
+    );
+    onFocusChangedMock.mockResolvedValue(unlistenFocus);
+
+    const handler = new SettingsHandler();
+    await handler.init();
+    handler.destroy();
+
+    expect(unlistenExtensionsUpdated).toHaveBeenCalledOnce();
+    expect(unlistenFocus).toHaveBeenCalledOnce();
   });
 });
 

--- a/asyar-launcher/src/routes/settings/settingsHandlers.test.ts
+++ b/asyar-launcher/src/routes/settings/settingsHandlers.test.ts
@@ -106,6 +106,34 @@ describe('SettingsHandler.loadExtensions', () => {
 
     expect(handler.extensions).toHaveLength(1);
   });
+
+  it('ignores a call that starts while a previous call is still in flight', async () => {
+    let resolveFirst: (value: unknown[]) => void = () => {};
+    mockGetAll.mockReset().mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFirst = resolve;
+      }),
+    );
+
+    const handler = new SettingsHandler();
+    const firstCall = handler.loadExtensions();
+    const secondCall = handler.loadExtensions();
+
+    resolveFirst([]);
+    await Promise.all([firstCall, secondCall]);
+
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a new call once the previous one has finished', async () => {
+    mockGetAll.mockReset().mockResolvedValue([]);
+
+    const handler = new SettingsHandler();
+    await handler.loadExtensions();
+    await handler.loadExtensions();
+
+    expect(mockGetAll).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('SettingsHandler.init — extension list freshness', () => {


### PR DESCRIPTION
The Settings window is a persistent hidden webview that's shown/hidden
rather than recreated, so its one-time onMount load never re-ran when
reopening the Extensions tab. Listen for the extensions_updated event
(already emitted by Rust on install/uninstall/update but never consumed)
and rescan on window focus to also catch extensions installed via
`asyar link`, which bypasses the app entirely and emits no event.