### PR TITLE
fix(snippets): remove accidental delete shortcut

### DIFF
--- a/asyar-launcher/src/built-in-features/snippets/DefaultView.svelte
+++ b/asyar-launcher/src/built-in-features/snippets/DefaultView.svelte
@@ -31,17 +31,6 @@
     }
   });
 
-  // Watch pendingDeleteId from state (set by keyboard Cmd+Backspace in index.ts)
-  $effect(() => {
-    if (snippetViewState.pendingDeleteId) {
-      const id = snippetViewState.pendingDeleteId;
-      const s = snippetStore.snippets.find((s) => s.id === id);
-      // Reset eagerly so the effect doesn't re-trigger if the user dismisses then re-presses.
-      snippetViewState.pendingDeleteId = null;
-      void confirmDeleteSnippet(id, s?.name ?? null);
-    }
-  });
-
   // Inline form state
   let formName = $state('');
   let formKeyword = $state('');

--- a/asyar-launcher/src/built-in-features/snippets/index.ts
+++ b/asyar-launcher/src/built-in-features/snippets/index.ts
@@ -40,11 +40,6 @@ class SnippetsExtension implements Extension {
       snippetViewState.moveSelection(e.key === 'ArrowUp' ? 'up' : 'down');
       return;
     }
-    if ((e.metaKey || e.ctrlKey) && e.key === 'Backspace') {
-      e.preventDefault();
-      snippetViewState.triggerDelete();
-      return;
-    }
     if (e.key === 'Enter' && snippetViewState.selectedSnippet) {
       e.preventDefault();
       await snippetService.pasteSnippet(snippetViewState.selectedSnippet.expansion);

--- a/asyar-launcher/src/built-in-features/snippets/index.ts
+++ b/asyar-launcher/src/built-in-features/snippets/index.ts
@@ -111,7 +111,6 @@ class SnippetsExtension implements Extension {
       context: ActionContext.EXTENSION_VIEW,
       confirm: true,
       destructive: true,
-      shortcut: 'Super+Backspace',
       execute: async () => {
         const s = snippetViewState.selectedSnippet;
         if (s) {

--- a/asyar-launcher/src/built-in-features/snippets/snippetViewState.svelte.test.ts
+++ b/asyar-launcher/src/built-in-features/snippets/snippetViewState.svelte.test.ts
@@ -250,7 +250,6 @@ describe('snippetViewState', () => {
       snippetViewState.selectItem(2);
       snippetViewState.mode = 'edit';
       snippetViewState.editingSnippet = mockSnippets[0];
-      snippetViewState.pendingDeleteId = '123';
 
       snippetViewState.reset();
 
@@ -258,7 +257,6 @@ describe('snippetViewState', () => {
       expect(snippetViewState.selectedIndex).toBe(0);
       expect(snippetViewState.mode).toBe('view');
       expect(snippetViewState.editingSnippet).toBe(null);
-      expect(snippetViewState.pendingDeleteId).toBe(null);
       // After reset, the full list is shown again with no active search.
       expect(snippetViewState.getFilteredSnippets()).toHaveLength(3);
     });

--- a/asyar-launcher/src/built-in-features/snippets/snippetViewState.svelte.ts
+++ b/asyar-launcher/src/built-in-features/snippets/snippetViewState.svelte.ts
@@ -8,7 +8,6 @@ class SnippetViewStateClass {
   searchQuery = $state('');
   mode = $state<SnippetEditMode>('view');
   editingSnippet = $state<Snippet | null>(null);
-  pendingDeleteId = $state<string | null>(null); // set by triggerDelete(), watched by DefaultView
 
   // Ids of the current search results, best-match first, as ranked by Rust.
   // `null` means no active search (show the full list). Held as ids — not item
@@ -111,17 +110,12 @@ class SnippetViewStateClass {
     this.editingSnippet = null;
   }
 
-  triggerDelete() {
-    this.pendingDeleteId = this.selectedSnippet?.id ?? null;
-  }
-
   reset() {
     this.searchQuery = '';
     this.rankedIds = null;
     this.selection.setIndex(0);
     this.mode = 'view';
     this.editingSnippet = null;
-    this.pendingDeleteId = null;
   }
 }
 


### PR DESCRIPTION
Cmd+Delete/Backspace was too easy to trigger by mistake while typing
snippet text. Delete Snippet is still available from the actions panel.