### PR TITLE
chore(snippets): remove dead learned-shortcodes IPC surface

### DIFF
--- a/asyar-launcher/src-tauri/src/permissions.rs
+++ b/asyar-launcher/src-tauri/src/permissions.rs
@@ -225,10 +225,6 @@ fn get_required_permission(call_type: &str) -> Option<&'static str> {
         // Snippets — extension contributes shortcodes to the snippets service
         "asyar:api:snippets:registerShortcodes" => Some("snippets:contribute"),
         "asyar:api:snippets:unregisterShortcodes" => Some("snippets:contribute"),
-        "asyar:api:snippets:listLearnedShortcodes" => Some("snippets:contribute"),
-        "asyar:api:snippets:promoteLearnedShortcode" => Some("snippets:contribute"),
-        "asyar:api:snippets:forgetLearnedShortcode" => Some("snippets:contribute"),
-        "asyar:api:snippets:clearLearnedShortcodes" => Some("snippets:contribute"),
         // Browser bridge — tabs (read = list/inspect, write = act/open/search).
         "asyar:api:browser:listTabs" => Some("browser:tabs.read"),
         "asyar:api:browser:getActiveTab" => Some("browser:tabs.read"),
@@ -1009,18 +1005,6 @@ mod tests {
             get_required_permission("asyar:api:snippets:unregisterShortcodes"),
             Some("snippets:contribute"),
         );
-    }
-
-    #[test]
-    fn learned_shortcode_methods_require_contribute_permission() {
-        for method in &[
-            "asyar:api:snippets:listLearnedShortcodes",
-            "asyar:api:snippets:promoteLearnedShortcode",
-            "asyar:api:snippets:forgetLearnedShortcode",
-            "asyar:api:snippets:clearLearnedShortcodes",
-        ] {
-            assert_eq!(get_required_permission(method), Some("snippets:contribute"));
-        }
     }
 
     #[test]

--- a/asyar-launcher/src/lib/ipc/shortcodeCommands.ts
+++ b/asyar-launcher/src/lib/ipc/shortcodeCommands.ts
@@ -1,10 +1,8 @@
-import { invokeSafe, invokeSafeVoid } from './invokeSafe';
+import { invokeSafeVoid } from './invokeSafe';
 
-// `contribute_shortcodes`/`revoke_shortcodes`/`promote_learned_to_snippet` are
-// all `Result<(), AppError>` on the Rust side — Ok(()) and invokeSafe's
-// failure sentinel both serialize to `null`, so these use invokeSafeVoid's
-// boolean signal instead. `list_learned_shortcodes`/`forget_learned_shortcode`/
-// `clear_learned_shortcodes` are plain (non-Result) commands and keep invokeSafe.
+// `contribute_shortcodes`/`revoke_shortcodes` are `Result<(), AppError>` on
+// the Rust side — Ok(()) and invokeSafe's failure sentinel both serialize to
+// `null`, so these use invokeSafeVoid's boolean signal instead.
 
 export async function contributeShortcodes(
   extensionId: string | undefined,
@@ -15,20 +13,4 @@ export async function contributeShortcodes(
 
 export async function revokeShortcodes(extensionId: string | undefined): Promise<boolean> {
   return invokeSafeVoid('revoke_shortcodes', { extensionId });
-}
-
-export async function listLearnedShortcodes(): Promise<[string, string][] | null> {
-  return invokeSafe<[string, string][]>('list_learned_shortcodes');
-}
-
-export async function promoteLearnedToSnippet(shortcode: string): Promise<boolean> {
-  return invokeSafeVoid('promote_learned_to_snippet', { shortcode });
-}
-
-export async function forgetLearnedShortcode(shortcode: string): Promise<void> {
-  await invokeSafe('forget_learned_shortcode', { shortcode });
-}
-
-export async function clearLearnedShortcodes(): Promise<void> {
-  await invokeSafe('clear_learned_shortcodes');
 }

--- a/asyar-launcher/src/services/extension/ExtensionIpcRouter.ts
+++ b/asyar-launcher/src/services/extension/ExtensionIpcRouter.ts
@@ -1,13 +1,6 @@
 import { logService } from '../log/logService';
 import * as commands from '../../lib/ipc/commands';
-import {
-  contributeShortcodes,
-  revokeShortcodes,
-  listLearnedShortcodes,
-  promoteLearnedToSnippet,
-  forgetLearnedShortcode,
-  clearLearnedShortcodes,
-} from '../../lib/ipc/shortcodeCommands';
+import { contributeShortcodes, revokeShortcodes } from '../../lib/ipc/shortcodeCommands';
 import { extensionIframeManager } from './extensionIframeManager.svelte';
 import { extensionPreferencesService } from './extensionPreferencesService.svelte';
 import { streamDispatcher } from './streamDispatcher.svelte';
@@ -449,28 +442,6 @@ export class ExtensionIpcRouter {
       const ok = await revokeShortcodes(extensionId);
       if (!ok) throw new HandledDispatchError('revoke_shortcodes failed');
       return undefined;
-    }
-
-    if (type === 'asyar:api:snippets:listLearnedShortcodes') {
-      const result = await listLearnedShortcodes();
-      if (result === null) throw new HandledDispatchError('list_learned_shortcodes failed');
-      return result;
-    }
-
-    if (type === 'asyar:api:snippets:promoteLearnedShortcode') {
-      const { shortcode } = payload as { shortcode: string };
-      const ok = await promoteLearnedToSnippet(shortcode);
-      if (!ok) throw new HandledDispatchError('promote_learned_to_snippet failed');
-      return undefined;
-    }
-
-    if (type === 'asyar:api:snippets:forgetLearnedShortcode') {
-      const { shortcode } = payload as { shortcode: string };
-      return forgetLearnedShortcode(shortcode);
-    }
-
-    if (type === 'asyar:api:snippets:clearLearnedShortcodes') {
-      return clearLearnedShortcodes();
     }
 
     const ns = serviceName as Namespace;

--- a/asyar-launcher/src/services/permissionGate.test.ts
+++ b/asyar-launcher/src/services/permissionGate.test.ts
@@ -837,22 +837,5 @@ describe('checkPermission', () => {
       );
       expect(allowed.allowed).toBe(true);
     });
-
-    it('requires snippets:contribute for the 4 learned-shortcode methods', () => {
-      for (const method of [
-        'listLearnedShortcodes',
-        'promoteLearnedShortcode',
-        'forgetLearnedShortcode',
-        'clearLearnedShortcodes',
-      ]) {
-        const denied = checkPermission('any.ext', `asyar:api:snippets:${method}`, []);
-        expect(denied.allowed).toBe(false);
-        expect(denied.requiredPermission).toBe('snippets:contribute');
-        const allowed = checkPermission('org.asyar.emoji', `asyar:api:snippets:${method}`, [
-          'snippets:contribute',
-        ]);
-        expect(allowed.allowed).toBe(true);
-      }
-    });
   });
 });

--- a/asyar-launcher/src/services/permissionGate.ts
+++ b/asyar-launcher/src/services/permissionGate.ts
@@ -110,10 +110,6 @@ export const PERMISSION_MAP: Record<string, string> = {
   // Snippet shortcodes contributed by extensions.
   'asyar:api:snippets:registerShortcodes': 'snippets:contribute',
   'asyar:api:snippets:unregisterShortcodes': 'snippets:contribute',
-  'asyar:api:snippets:listLearnedShortcodes': 'snippets:contribute',
-  'asyar:api:snippets:promoteLearnedShortcode': 'snippets:contribute',
-  'asyar:api:snippets:forgetLearnedShortcode': 'snippets:contribute',
-  'asyar:api:snippets:clearLearnedShortcodes': 'snippets:contribute',
   // Browser bridge — bookmarks and history read scopes.
   // listAvailableBrowsers and isCompanionInstalled are intentionally
   // unmapped (permission-free discovery, no security boundary).

--- a/asyar-sdk/src/contracts/snippets.ts
+++ b/asyar-sdk/src/contracts/snippets.ts
@@ -31,24 +31,4 @@ export interface ISnippetsService {
 
   /** Remove the calling extension's entire contribution. Idempotent. */
   unregisterShortcodes(): Promise<void>;
-
-  /**
-   * Return all AI-learned shortcode → emoji pairs that are currently cached
-   * (i.e. shortcodes the inline emoji fallback resolved at least once).
-   * Requires the `snippets:contribute` permission.
-   */
-  listLearnedShortcodes(): Promise<Array<[string, string]>>;
-
-  /**
-   * Promote an AI-learned shortcode to a permanent user snippet and remove it
-   * from the learned cache. The launcher emits `snippet:promote-from-cache` and
-   * the main window persists the entry via the existing snippets storage path.
-   */
-  promoteLearnedShortcode(shortcode: string): Promise<void>;
-
-  /** Remove a single cached AI-learned shortcode entry. */
-  forgetLearnedShortcode(shortcode: string): Promise<void>;
-
-  /** Clear all AI-learned shortcode cache entries. */
-  clearLearnedShortcodes(): Promise<void>;
 }

--- a/asyar-sdk/src/services/SnippetsServiceProxy.ts
+++ b/asyar-sdk/src/services/SnippetsServiceProxy.ts
@@ -25,20 +25,4 @@ export class SnippetsServiceProxy extends BaseServiceProxy implements ISnippetsS
     const broker = this.broker;
     await broker.invoke('snippets:unregisterShortcodes', {});
   }
-
-  async listLearnedShortcodes(): Promise<Array<[string, string]>> {
-    return this.broker.invoke<Array<[string, string]>>('snippets:listLearnedShortcodes', {});
-  }
-
-  async promoteLearnedShortcode(shortcode: string): Promise<void> {
-    await this.broker.invoke('snippets:promoteLearnedShortcode', { shortcode });
-  }
-
-  async forgetLearnedShortcode(shortcode: string): Promise<void> {
-    await this.broker.invoke('snippets:forgetLearnedShortcode', { shortcode });
-  }
-
-  async clearLearnedShortcodes(): Promise<void> {
-    await this.broker.invoke('snippets:clearLearnedShortcodes', {});
-  }
 }


### PR DESCRIPTION
list_learned_shortcodes/forget_learned_shortcode/clear_learned_shortcodes/
promote_learned_to_snippet were deleted from the Rust backend in #515 when
the AI shortcode fallback moved onto the general agent runtime's cache
(agents_list_cached etc.), but the SDK contract, ExtensionIpcRouter routes,
and permission-gate entries pointing at them were never cleaned up.