### PR TITLE
fix: make factory reset actually erase everything

### DIFF
--- a/asyar-launcher/src-tauri/src/commands/factory_reset.rs
+++ b/asyar-launcher/src-tauri/src/commands/factory_reset.rs
@@ -1,7 +1,14 @@
 //! Factory-reset command.
 //!
 //! Wipes everything Asyar persists (SQLite DB, settings store, installed
-//! extensions, OAuth/auth tokens, onboarding state, alias data, ...).
+//! extensions, OAuth/auth tokens, onboarding state, alias data, ...) plus
+//! the OS-keychain secrets that live outside `app_data_dir` entirely: the
+//! at-rest encryption master key, the cached E2EE sync seed, and any paired
+//! browser-bridge tokens. The frontend is responsible for clearing
+//! `localStorage` before invoking this command — see the `factory_reset`
+//! action in `actionService.svelte.ts` — since `lib/persistence/extensionStore.ts`
+//! mirrors some Tauri-store data into localStorage and would otherwise
+//! resurrect it into the freshly wiped store on next load.
 //!
 //! Implementation note: the actual wipe runs at boot, not at command time.
 //! `factory_reset` writes a sentinel file into `app_data_dir` and exits the
@@ -18,6 +25,8 @@
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager};
 
+use crate::browser::bridge::token_store::TokenStore;
+use crate::crypto::keystore::KeyStore;
 use crate::error::AppError;
 
 const SENTINEL_FILE_NAME: &str = "pending_factory_reset";
@@ -80,6 +89,35 @@ pub async fn factory_reset(app: AppHandle) -> Result<(), AppError> {
     Ok(())
 }
 
+/// Best-effort deletion of every OS-keychain secret Asyar owns. These live
+/// outside `app_data_dir` (Keychain Services / Credential Manager / Secret
+/// Service), so `wipe_dir_contents` can never reach them. `keyring` has no
+/// "delete everything for this service" call, so each known account is
+/// cleared individually. Failures are logged and swallowed: a keychain
+/// glitch must never block the rest of the wipe, and the sentinel itself
+/// lives inside `app_data_dir` so it's already gone regardless.
+fn clear_keychain_secrets(key_store: &dyn KeyStore, token_store: &dyn TokenStore) {
+    for account in [
+        crate::crypto::keystore::KEYCHAIN_ACCOUNT,
+        crate::sync::e2ee::service::KEYCHAIN_SLOT,
+    ] {
+        if let Err(e) = key_store.delete_slot(account) {
+            log::warn!("[factory_reset] failed to clear keychain slot {account:?}: {e}");
+        }
+    }
+
+    match token_store.list_paired() {
+        Ok(paired) => {
+            for key in paired {
+                if let Err(e) = token_store.delete(&key) {
+                    log::warn!("[factory_reset] failed to clear browser bridge token {key:?}: {e}");
+                }
+            }
+        }
+        Err(e) => log::warn!("[factory_reset] failed to list paired browser bridge tokens: {e}"),
+    }
+}
+
 /// Boot-time hook. If the sentinel file exists, wipe `app_data_dir` (and
 /// `app_local_data_dir` when distinct) entirely, then continue boot. The wipe
 /// removes the sentinel as a side effect. Returns `true` when a wipe was
@@ -113,6 +151,11 @@ pub fn perform_pending_factory_reset_if_marked(app: &AppHandle) -> bool {
             }
         }
     }
+
+    let os_keystore = crate::crypto::keystore::OsKeyStore::new();
+    let bridge_token_store = crate::browser::bridge::token_store::KeyringTokenStore::new();
+    bridge_token_store.load_paired_from_backend();
+    clear_keychain_secrets(&os_keystore, &bridge_token_store);
 
     log::warn!("[factory_reset] wipe complete");
     true
@@ -207,6 +250,61 @@ mod tests {
         }
     }
 
+    #[test]
+    fn clear_keychain_secrets_deletes_both_crypto_slots() {
+        use crate::browser::bridge::token_store::InMemoryTokenStore;
+        use crate::crypto::keystore::{InMemoryKeyStore, KeyStore, KEYCHAIN_ACCOUNT};
+        use crate::sync::e2ee::service::KEYCHAIN_SLOT;
+
+        let key_store = InMemoryKeyStore::new();
+        key_store
+            .write_slot(KEYCHAIN_ACCOUNT, b"master-key")
+            .unwrap();
+        key_store.write_slot(KEYCHAIN_SLOT, b"e2ee-seed").unwrap();
+        let token_store = InMemoryTokenStore::new();
+
+        clear_keychain_secrets(&key_store, &token_store);
+
+        assert!(key_store.read_slot(KEYCHAIN_ACCOUNT).unwrap().is_none());
+        assert!(key_store.read_slot(KEYCHAIN_SLOT).unwrap().is_none());
+    }
+
+    #[test]
+    fn clear_keychain_secrets_deletes_every_paired_browser_token() {
+        use crate::browser::bridge::token_store::{InMemoryTokenStore, TokenStore};
+        use crate::browser::types::{BrowserFamily, BrowserKey};
+        use crate::crypto::keystore::InMemoryKeyStore;
+
+        let key_store = InMemoryKeyStore::new();
+        let token_store = InMemoryTokenStore::new();
+        let chrome = BrowserKey {
+            family: BrowserFamily::Chromium,
+            variant: "chrome".to_string(),
+        };
+        let firefox = BrowserKey {
+            family: BrowserFamily::Firefox,
+            variant: "firefox".to_string(),
+        };
+        token_store.set(&chrome, "tok-1").unwrap();
+        token_store.set(&firefox, "tok-2").unwrap();
+
+        clear_keychain_secrets(&key_store, &token_store);
+
+        assert!(token_store.list_paired().unwrap().is_empty());
+    }
+
+    #[test]
+    fn clear_keychain_secrets_is_noop_when_nothing_is_stored() {
+        use crate::browser::bridge::token_store::InMemoryTokenStore;
+        use crate::crypto::keystore::InMemoryKeyStore;
+
+        let key_store = InMemoryKeyStore::new();
+        let token_store = InMemoryTokenStore::new();
+
+        // Must not panic on empty stores.
+        clear_keychain_secrets(&key_store, &token_store);
+    }
+
     /// Mirrors the boot-time path: write a sentinel, then "perform reset" by
     /// wiping the dir. We can't drive `perform_pending_factory_reset_if_marked`
     /// without an `AppHandle`, so this test exercises the same primitives in
@@ -231,6 +329,47 @@ mod tests {
         assert!(!sentinel_exists_at_path(&sentinel));
         assert!(!app_data_dir.join("asyar_data.db").exists());
         assert!(!app_data_dir.join("extensions").exists());
+    }
+
+    /// Same boot-time mirror as above, but also proves the OS-keychain
+    /// secrets (encryption master key, e2ee seed, browser-bridge pairing
+    /// tokens) get cleared alongside the directory wipe — these live
+    /// outside `app_data_dir` so `wipe_dir_contents` alone can't reach them.
+    #[test]
+    fn boot_time_flow_also_clears_keychain_secrets() {
+        use crate::browser::bridge::token_store::{InMemoryTokenStore, TokenStore};
+        use crate::browser::types::{BrowserFamily, BrowserKey};
+        use crate::crypto::keystore::{InMemoryKeyStore, KeyStore, KEYCHAIN_ACCOUNT};
+        use crate::sync::e2ee::service::KEYCHAIN_SLOT;
+
+        let tmp = make_temp_dir();
+        let app_data_dir = tmp.path();
+        fs::write(app_data_dir.join("asyar_data.db"), b"sqlite").unwrap();
+
+        let key_store = InMemoryKeyStore::new();
+        key_store
+            .write_slot(KEYCHAIN_ACCOUNT, b"master-key")
+            .unwrap();
+        key_store.write_slot(KEYCHAIN_SLOT, b"e2ee-seed").unwrap();
+        let token_store = InMemoryTokenStore::new();
+        let paired = BrowserKey {
+            family: BrowserFamily::Chromium,
+            variant: "chrome".to_string(),
+        };
+        token_store.set(&paired, "bridge-tok").unwrap();
+
+        let sentinel = sentinel_path_for_dir(app_data_dir);
+        write_sentinel_to_path(&sentinel).unwrap();
+
+        // Next boot: wipe dir + clear keychain, same order as
+        // `perform_pending_factory_reset_if_marked`.
+        wipe_dir_contents(app_data_dir).unwrap();
+        clear_keychain_secrets(&key_store, &token_store);
+
+        assert!(!app_data_dir.join("asyar_data.db").exists());
+        assert!(key_store.read_slot(KEYCHAIN_ACCOUNT).unwrap().is_none());
+        assert!(key_store.read_slot(KEYCHAIN_SLOT).unwrap().is_none());
+        assert!(token_store.list_paired().unwrap().is_empty());
     }
 
     #[test]

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -869,6 +869,26 @@ fn register_builtin_tools(
 }
 
 fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+    // Honor any pending factory-reset request from the previous session
+    // FIRST, before literally anything else touches `app_data_dir` —
+    // including the crash-marker check and `read_appearance_theme` /
+    // `read_launch_view` / `read_onboarding_completed` further down, all of
+    // which call `tauri_plugin_store::StoreExt::store("settings.dat")`.
+    // That plugin caches the loaded `Store` in its own `StoreCollection`
+    // Tauri-managed state, keyed by path. If any of those run before the
+    // wipe, they load the pre-wipe file into that cache; the wipe then
+    // deletes the file on disk but the in-memory cache is untouched, so
+    // every later read (including the frontend's `load("settings.dat")`)
+    // reuses the stale cached copy instead of the fresh empty file —
+    // silently resurrecting old settings (AI providers, the
+    // onboarding-completed flag, ...). Running this before any `app.store`
+    // call is the only way to guarantee the cache starts clean. The
+    // sentinel is dropped as part of the wipe, so this is naturally
+    // one-shot.
+    if commands::perform_pending_factory_reset_if_marked(app.handle()) {
+        log::warn!("[setup_app] factory reset performed; continuing fresh boot");
+    }
+
     // Must run before any window/webview is created — WKWebView reads this
     // default when it builds its NSTextInputContext.
     #[cfg(target_os = "macos")]
@@ -1170,13 +1190,6 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 
     #[cfg(target_os = "linux")]
     let _ = crate::platform::linux::setup_spotlight_window(&window);
-
-    // Honor any pending factory-reset request from the previous session
-    // BEFORE any subsystem opens a file inside `app_data_dir`. The sentinel
-    // is dropped as part of the wipe, so this is naturally one-shot.
-    if commands::perform_pending_factory_reset_if_marked(app.handle()) {
-        log::warn!("[setup_app] factory reset performed; continuing fresh boot");
-    }
 
     // Initialize the search state when the app starts
     let state = search_engine::initialize_search_state(app.handle())?;

--- a/asyar-launcher/src/services/action/actionService.svelte.ts
+++ b/asyar-launcher/src/services/action/actionService.svelte.ts
@@ -416,6 +416,12 @@ export class ActionService implements IActionService {
           variant: 'danger',
         });
         if (!confirmed) return;
+        // Rust wipes app_data_dir + the OS keychain, but localStorage lives
+        // outside app_data_dir and lib/persistence/extensionStore.ts mirrors
+        // some Tauri-store data (portals, snippets-enabled) into it with a
+        // migrate-back-on-load fallback — clear it here or "erased" data
+        // resurrects itself on next launch.
+        localStorage.clear();
         // Rust writes a sentinel and calls app.exit(0); the wipe runs at the
         // next cold start before any DB connection is opened. The promise
         // does not resolve on this page because the process exits.

--- a/asyar-launcher/src/services/action/actionService.test.ts
+++ b/asyar-launcher/src/services/action/actionService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ActionService, type ApplicationAction } from './actionService.svelte';
 import { ActionContext } from 'asyar-sdk/contracts';
 
@@ -1044,9 +1044,17 @@ describe('uninstall_application built-in action', () => {
 // ── factory_reset action ──────────────────────────────────────────────────────
 
 describe('factory_reset built-in action', () => {
+  let localStorageClearMock: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     mockDeveloperSettingsService.isDeveloperMode = false;
     mockFeedbackService.confirmAlert.mockReset().mockResolvedValue(true);
+    localStorageClearMock = vi.fn();
+    vi.stubGlobal('localStorage', { clear: localStorageClearMock });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('is registered with the expected destructive metadata', () => {
@@ -1110,5 +1118,38 @@ describe('factory_reset built-in action', () => {
     await svc.executeAction('factory_reset');
 
     expect(invoke).not.toHaveBeenCalledWith('factory_reset');
+  });
+
+  it('execute clears localStorage before invoking the factory_reset command, so the frontend cannot resurrect wiped data (e.g. portals) on next boot', async () => {
+    mockDeveloperSettingsService.isDeveloperMode = true;
+    mockFeedbackService.confirmAlert.mockResolvedValueOnce(true);
+    const { invoke } = await import('@tauri-apps/api/core');
+    const calls: string[] = [];
+    localStorageClearMock.mockImplementation(() => calls.push('clear'));
+    vi.mocked(invoke)
+      .mockReset()
+      .mockImplementation(() => {
+        calls.push('invoke');
+        return Promise.resolve(undefined);
+      });
+    const svc = freshService();
+
+    await svc.executeAction('factory_reset');
+
+    expect(localStorageClearMock).toHaveBeenCalledOnce();
+    expect(invoke).toHaveBeenCalledWith('factory_reset', undefined);
+    expect(calls).toEqual(['clear', 'invoke']);
+  });
+
+  it('execute does not clear localStorage when the user cancels the confirm dialog', async () => {
+    mockDeveloperSettingsService.isDeveloperMode = true;
+    mockFeedbackService.confirmAlert.mockResolvedValueOnce(false);
+    const { invoke } = await import('@tauri-apps/api/core');
+    vi.mocked(invoke).mockReset();
+    const svc = freshService();
+
+    await svc.executeAction('factory_reset');
+
+    expect(localStorageClearMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Factory reset only wiped app_data_dir, leaving three OS-keychain
secrets untouched (encryption master key, cached E2EE sync seed,
browser-bridge pairing tokens) and letting the frontend's
localStorage-fallback persistence resurrect "erased" data like
portals on next launch.

Clear the keychain secrets during the boot-time wipe and clear
localStorage before the app quits.