### PR TITLE
fix: surface real error text to extensions instead of "[object Object]"

### DIFF
--- a/asyar-launcher/src/lib/ipc/invokeSafe.ts
+++ b/asyar-launcher/src/lib/ipc/invokeSafe.ts
@@ -8,7 +8,7 @@ interface InvokeSafeOpts {
   retry?: () => Promise<void>;
 }
 
-function isFeedbackShape(raw: unknown): raw is Feedback {
+export function isFeedbackShape(raw: unknown): raw is Feedback {
   return (
     typeof raw === 'object' && raw !== null && 'kind' in raw && 'severity' in raw && 'source' in raw
   );

--- a/asyar-launcher/src/services/extension/ExtensionIpcRouter.test.ts
+++ b/asyar-launcher/src/services/extension/ExtensionIpcRouter.test.ts
@@ -582,3 +582,64 @@ describe('ExtensionIpcRouter — identity spoofing prevention', () => {
     unknownIframe.remove();
   });
 });
+
+describe('ExtensionIpcRouter — AppError-shaped rejection messages', () => {
+  // Regression: files:glob/read/thumbnail call Tauri's `invoke()` directly
+  // (not invokeSafe) so scope/validation failures reject instead of
+  // collapsing to null. Those rejections carry the raw serialized AppError
+  // object (`{ source, kind, severity, retryable, context, developerDetail }`),
+  // not an Error instance. The catch block's `String(error)` fallback turned
+  // that into the useless literal "[object Object]" instead of surfacing
+  // developerDetail, which is what a caller actually needs to see.
+  beforeEach(() => vi.clearAllMocks());
+
+  it('surfaces developerDetail instead of "[object Object]" for a plain AppError-shaped throw', async () => {
+    const postMessage = vi.spyOn(window, 'postMessage').mockImplementation(() => {});
+    const glob = vi.fn(async () => {
+      throw {
+        source: 'rust',
+        kind: 'validation_failure',
+        severity: 'warning',
+        retryable: false,
+        context: {},
+        developerDetail:
+          "files:glob pattern must begin with an absolute literal prefix to enumerate from (e.g. 'C:/Steam/appcache/**'), got: 'bad'",
+      };
+    });
+    const registry = { files: { glob } } as unknown as ServiceRegistry;
+    const router = new ExtensionIpcRouter(registry, vi.fn(), vi.fn(), vi.fn());
+    router.setup();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: window,
+        data: {
+          type: 'asyar:api:files:glob',
+          extensionId: 'org.asyar.demo',
+          payload: { pattern: 'bad' },
+          messageId: 'glob-1',
+        },
+      }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // Other test cases in this file each construct their own
+    // ExtensionIpcRouter and call setup(), which registers a
+    // window-level `message` listener that is never torn down. All of
+    // them receive this dispatch too, but only this test's router has a
+    // `files` service registered, so its reply is the only one with a
+    // populated `error` field — filter for that rather than assuming
+    // position.
+    const response = postMessage.mock.calls
+      .map((call) => call[0] as { type?: string; messageId?: string; error?: string })
+      .find((msg) => msg?.messageId === 'glob-1' && msg?.error);
+
+    expect(response?.error).not.toBe('[object Object]');
+    expect(response?.error).toContain(
+      'files:glob pattern must begin with an absolute literal prefix',
+    );
+
+    postMessage.mockRestore();
+  });
+});

--- a/asyar-launcher/src/services/extension/ExtensionIpcRouter.ts
+++ b/asyar-launcher/src/services/extension/ExtensionIpcRouter.ts
@@ -10,6 +10,7 @@ import type { ExtendedManifest } from '../../types/ExtendedManifest';
 import { feedbackService } from '../feedback/feedbackService.svelte';
 import { developerSettingsService } from '../settings/developerSettingsService.svelte';
 import { isExternallyConsumedExtensionResponse } from '../../lib/ipc/extensionMessageProtocol';
+import { isFeedbackShape } from '../../lib/ipc/invokeSafe';
 
 const EXTENSION_INVOKE_DISPATCH: Record<string, (args: any) => Promise<any>> = {
   search_items: (args) => commands.searchItems(args?.query ?? ''),
@@ -333,8 +334,8 @@ export class ExtensionIpcRouter {
           '*',
         );
       } catch (error) {
-        logService.error(`[Main] IPC handling error for ${extensionId}: ${error}`);
-        const catchError = error instanceof Error ? error.message : String(error);
+        const catchError = extractErrorMessage(error);
+        logService.error(`[Main] IPC handling error for ${extensionId}: ${catchError}`);
         (event.source as Window)?.postMessage(
           {
             type: 'asyar:response',
@@ -473,6 +474,20 @@ export class ExtensionIpcRouter {
     }
     return await (method as (...a: unknown[]) => unknown).apply(service, args);
   }
+}
+
+/**
+ * Rust commands that reject via raw `invoke()` (files:read/glob/thumbnail,
+ * invokeRaw callers) surface a serialized `AppError` — a plain object shaped
+ * like `Feedback` (`{ source, kind, severity, retryable, context,
+ * developerDetail }`), not an `Error` instance. `String()` on that object
+ * yields the useless "[object Object]"; `developerDetail` carries the actual
+ * message.
+ */
+function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (isFeedbackShape(error)) return error.developerDetail ?? String(error);
+  return String(error);
 }
 
 function classifyProxyError(


### PR DESCRIPTION
Rust's AppError serializes to a diagnostic object, not a JS Error, so
raw invoke() rejections (files:glob, files:read, files:thumbnail, and
other invokeRaw-based calls) lost their message when the IPC router
stringified them. Extract developerDetail before falling back to
String().