### PR TITLE
fix(agents): stop silent-agent freeze and add cancel-by-retrigger

### DIFF
--- a/asyar-launcher/src-tauri/src/notifications/commands.rs
+++ b/asyar-launcher/src-tauri/src/notifications/commands.rs
@@ -27,9 +27,16 @@ pub struct ActionInput {
 ///
 /// Returns the generated notification id back to the caller so they can
 /// `dismiss()` it later.
+///
+/// `async` + `spawn_blocking`: synchronous Tauri commands execute on the
+/// main thread (see the identical fix in `commands/process.rs`), and
+/// `NotificationBackend::send` can call into native OS notification APIs —
+/// on macOS, `mac_notification_sys::set_application` runs its one-time
+/// process-wide registration inline. Left on the main thread, a slow or
+/// wedged first call there freezes the entire app, not just the caller.
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
-pub fn send_notification<R: Runtime>(
+pub async fn send_notification<R: Runtime>(
     app: tauri::AppHandle<R>,
     title: String,
     #[allow(non_snake_case)] body: Option<String>,
@@ -58,7 +65,14 @@ pub fn send_notification<R: Runtime>(
         extension_id,
     };
 
-    populate_registry_and_send(registry.inner(), backend.inner().as_ref(), request)?;
+    let registry = registry.inner().clone();
+    let backend = backend.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        populate_registry_and_send(&registry, backend.as_ref(), request)
+    })
+    .await
+    .map_err(|e| AppError::Other(format!("notification send task failed: {e}")))??;
+
     Ok(notification_id)
 }
 

--- a/asyar-launcher/src/built-in-features/agents/silentDispatch.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/silentDispatch.test.ts
@@ -264,6 +264,33 @@ describe('dispatchSilentAgentCommand', () => {
     expect(feedbackService.report).not.toHaveBeenCalled();
   });
 
+  it('cancels an in-flight run instead of starting a second one for a repeat trigger', async () => {
+    let releaseFirstRun = () => {};
+    let markStarted = () => {};
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const blocked = new Promise<void>((resolve) => {
+      releaseFirstRun = resolve;
+    });
+    vi.mocked(commands.agentsRunSilent).mockImplementation(async () => {
+      markStarted();
+      await blocked;
+      throw new Error('agent run cancelled');
+    });
+
+    const firstDispatch = dispatchSilentAgentCommand({ agentId: 'agent-1', userText: 'hello' });
+    await started;
+
+    await dispatchSilentAgentCommand({ agentId: 'agent-1', userText: 'hello again' });
+
+    expect(commands.agentsCancelRun).toHaveBeenCalledWith(bridgeMock.options?.streamId);
+    expect(commands.agentsRunSilent).toHaveBeenCalledTimes(1);
+
+    releaseFirstRun();
+    await firstDispatch;
+  });
+
   it('reports Rust command failures without throwing into the hotkey caller', async () => {
     vi.mocked(commands.agentsRunSilent).mockRejectedValue(new Error('provider unavailable'));
 

--- a/asyar-launcher/src/built-in-features/agents/silentDispatch.ts
+++ b/asyar-launcher/src/built-in-features/agents/silentDispatch.ts
@@ -40,12 +40,42 @@ export interface SilentDispatchInput extends SilentDispatchOptions {
   agentId: string;
 }
 
+/** Agent id -> the controller driving its currently in-flight silent run. */
+const activeRuns = new Map<string, AbortController>();
+
 /**
  * Runs a silent command without creating a thread or a tracked Run. Failures
  * are surfaced through diagnostics because hotkey callers cannot render a
  * rejected promise.
+ *
+ * A repeat trigger for the same agent (hotkey pressed again, shortcode
+ * retyped) while a run is still in flight cancels that run instead of
+ * stacking a second one — otherwise a slow or stuck call had no way to be
+ * interrupted short of force-quitting the app.
  */
 export async function dispatchSilentAgentCommand(input: SilentDispatchInput): Promise<void> {
+  const inFlight = activeRuns.get(input.agentId);
+  if (inFlight) {
+    inFlight.abort();
+    return;
+  }
+
+  const controller = new AbortController();
+  if (input.abortSignal) {
+    if (input.abortSignal.aborted) controller.abort();
+    else input.abortSignal.addEventListener('abort', () => controller.abort(), { once: true });
+  }
+  activeRuns.set(input.agentId, controller);
+  try {
+    await runSilentAgentCommand({ ...input, abortSignal: controller.signal });
+  } finally {
+    if (activeRuns.get(input.agentId) === controller) {
+      activeRuns.delete(input.agentId);
+    }
+  }
+}
+
+async function runSilentAgentCommand(input: SilentDispatchInput): Promise<void> {
   if (input.abortSignal?.aborted) return;
 
   let resolvedAgent: AgentDef | null = null;
@@ -162,7 +192,7 @@ async function callFinalText(input: SilentDispatchInput, text: string): Promise<
       developerDetail: String(cause),
       context: {
         message: text.length === 0 ? 'onFinalText threw on empty result' : 'onFinalText threw',
-        agentId: input.agentId ?? input.builtinProfile,
+        agentId: input.agentId,
       },
     });
   }

--- a/asyar-launcher/src/routes/onboarding/steps/HiddenCommands.svelte
+++ b/asyar-launcher/src/routes/onboarding/steps/HiddenCommands.svelte
@@ -80,7 +80,7 @@
         prefill="i has a apple and it are very tasty"
         multiline
         enabled={ready}
-        enabledHint={`Select the text and press ${modifier}+${key} — also works in any other app`}
+        enabledHint={`Select the text and press ${modifier}+${key} — also works in any other app. Taking too long? Press it again to cancel.`}
         disabledHint="Finish the 3 setup steps to try it here"
       />
     {/if}


### PR DESCRIPTION
send_notification did native OS setup synchronously on the main thread,
freezing Asyar when a silent agent's failure path fired it. Repeat
hotkey/shortcode triggers now cancel an in-flight silent run instead of
stacking a second one; onboarding documents the new cancel gesture.