### PR TITLE
feat(clipboard-history): add multi-select for merged paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Don't take our word for it: [`benchmarks/bench.sh`](benchmarks/README.md) measur
 - **Scripts** — Run shell scripts from the launcher. Add metadata headers (`@asyar.title`, `@asyar.icon`, `@asyar.argument:N`) so your script gets a name, icon, and prompted arguments. Live progress surfaces as a run row.
 - **Run Tracking** — Long-running work — agents and scripts — shows live status dots in the launcher. Failed runs stay until dismissed; succeeded agent threads stay until you close them, so you can pick a conversation back up at any time.
 - **Calculator** — Instant math evaluation with currency conversion, directly in the search bar
-- **Clipboard History** — Search and reuse anything you've copied, with rich markdown, syntax highlighting, and LaTeX rendering for text items
+- **Clipboard History** — Search and reuse anything you've copied, with rich markdown, syntax highlighting, and LaTeX rendering for text items. Cmd/Ctrl-click (or Cmd/Ctrl+↑/↓) to select several items, then Enter merges them into a single paste
 - **File Search** — Find any file across your home folder instantly; a Rust-native index keeps per-keystroke search fast regardless of how much is indexed, with real image thumbnails and (on macOS) Quick Look-style previews for documents, videos, and archives
 - **Snippets** — Text snippet expansion, including background text expansion without opening the launcher
 - **Shortcuts** — Define and run custom keyboard-triggered commands

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -494,6 +494,7 @@ pub fn run() {
             storage::commands::clipboard_list_older,
             storage::commands::clipboard_search,
             storage::commands::clipboard_get_item,
+            storage::commands::clipboard_get_merged_text,
             storage::commands::clipboard_export_for_sync,
             storage::commands::clipboard_count,
             storage::commands::clipboard_record_capture,

--- a/asyar-launcher/src-tauri/src/storage/clipboard.rs
+++ b/asyar-launcher/src-tauri/src/storage/clipboard.rs
@@ -581,6 +581,48 @@ pub fn get_item(
     }
 }
 
+/// Result of [`get_merged_text`]: the joined plain text and how many of the
+/// requested items couldn't be represented as text and were left out.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MergedText {
+    pub text: String,
+    pub skipped_count: u32,
+}
+
+/// Fetch items by id in the given order, decrypt, strip HTML/RTF markup to
+/// plain text, and join with `\n`. Image/Files items can't be represented as
+/// text — they're skipped and counted rather than erroring, so a mixed
+/// selection still merges its text-representable members. Missing ids are
+/// silently skipped without affecting `skipped_count` (they were never a
+/// text-representable item to begin with).
+pub fn get_merged_text(
+    conn: &Connection,
+    ids: &[String],
+    master_key: &[u8; 32],
+) -> Result<MergedText, AppError> {
+    let mut parts = Vec::new();
+    let mut skipped_count = 0u32;
+    for id in ids {
+        let Some(item) = get_item(conn, id, master_key)? else {
+            continue;
+        };
+        let Some(content) = item.content else {
+            continue;
+        };
+        match item.item_type.as_str() {
+            "text" => parts.push(content),
+            "html" => parts.push(crate::clipboard_markup::strip_html(&content)),
+            "rtf" => parts.push(crate::clipboard_markup::strip_rtf(&content)),
+            _ => skipped_count += 1,
+        }
+    }
+    Ok(MergedText {
+        text: parts.join("\n"),
+        skipped_count,
+    })
+}
+
 /// Total and favorites-only counts. Cheap (two `COUNT(*)` queries with
 /// indexed lookups) and used by sync provider summaries to avoid
 /// materialising the whole table.
@@ -2250,5 +2292,90 @@ mod tests {
         let res = search(&conn, &fts, "anything", 20, &key).unwrap();
         assert_eq!(res.index_state, "indexing");
         assert!(res.items.is_empty());
+    }
+
+    fn make_typed_item(id: &str, item_type: &str, content: &str) -> ClipboardItem {
+        let mut item = make_item(id, content, false);
+        item.item_type = item_type.to_string();
+        item
+    }
+
+    #[test]
+    fn get_merged_text_joins_text_items_in_given_order() {
+        let conn = setup();
+        let key = test_key();
+        add_item(&conn, &make_item("1", "first", false), &key).unwrap();
+        add_item(&conn, &make_item("2", "second", false), &key).unwrap();
+        add_item(&conn, &make_item("3", "third", false), &key).unwrap();
+
+        // Order passed in, not created_at/id order.
+        let ids = vec!["3".to_string(), "1".to_string(), "2".to_string()];
+        let result = get_merged_text(&conn, &ids, &key).unwrap();
+
+        assert_eq!(result.text, "third\nfirst\nsecond");
+        assert_eq!(result.skipped_count, 0);
+    }
+
+    #[test]
+    fn get_merged_text_strips_html_and_rtf_to_plain_text() {
+        let conn = setup();
+        let key = test_key();
+        add_item(&conn, &make_typed_item("1", "text", "plain"), &key).unwrap();
+        add_item(
+            &conn,
+            &make_typed_item("2", "html", "<b>bold</b> text"),
+            &key,
+        )
+        .unwrap();
+
+        let ids = vec!["1".to_string(), "2".to_string()];
+        let result = get_merged_text(&conn, &ids, &key).unwrap();
+
+        assert_eq!(result.text, "plain\nbold text");
+        assert_eq!(result.skipped_count, 0);
+    }
+
+    #[test]
+    fn get_merged_text_skips_image_and_files_items_and_counts_them() {
+        let conn = setup();
+        let key = test_key();
+        add_item(&conn, &make_typed_item("1", "text", "kept"), &key).unwrap();
+        add_item(&conn, &make_typed_item("2", "image", "/tmp/pic.png"), &key).unwrap();
+        add_item(
+            &conn,
+            &make_typed_item("3", "files", "[\"/tmp/a.txt\"]"),
+            &key,
+        )
+        .unwrap();
+
+        let ids = vec!["1".to_string(), "2".to_string(), "3".to_string()];
+        let result = get_merged_text(&conn, &ids, &key).unwrap();
+
+        assert_eq!(result.text, "kept");
+        assert_eq!(result.skipped_count, 2);
+    }
+
+    #[test]
+    fn get_merged_text_ignores_missing_ids() {
+        let conn = setup();
+        let key = test_key();
+        add_item(&conn, &make_item("1", "present", false), &key).unwrap();
+
+        let ids = vec!["1".to_string(), "does-not-exist".to_string()];
+        let result = get_merged_text(&conn, &ids, &key).unwrap();
+
+        assert_eq!(result.text, "present");
+        assert_eq!(result.skipped_count, 0);
+    }
+
+    #[test]
+    fn get_merged_text_empty_ids_returns_empty_result() {
+        let conn = setup();
+        let key = test_key();
+
+        let result = get_merged_text(&conn, &[], &key).unwrap();
+
+        assert_eq!(result.text, "");
+        assert_eq!(result.skipped_count, 0);
     }
 }

--- a/asyar-launcher/src-tauri/src/storage/commands.rs
+++ b/asyar-launcher/src-tauri/src/storage/commands.rs
@@ -57,6 +57,16 @@ pub fn clipboard_get_item(
 }
 
 #[tauri::command]
+pub fn clipboard_get_merged_text(
+    ids: Vec<String>,
+    store: State<'_, DataStore>,
+    keystore: State<'_, KeystoreState>,
+) -> Result<super::clipboard::MergedText, AppError> {
+    let conn = store.conn()?;
+    super::clipboard::get_merged_text(&conn, &ids, keystore.master_key())
+}
+
+#[tauri::command]
 pub fn clipboard_export_for_sync(
     cursor: Option<super::clipboard::Cursor>,
     limit: u32,

--- a/asyar-launcher/src/built-in-features/clipboard-history/DefaultView.svelte
+++ b/asyar-launcher/src/built-in-features/clipboard-history/DefaultView.svelte
@@ -289,6 +289,14 @@
     clipboardViewState.selectedItemId = id;
   }
 
+  function handleRowClick(e: MouseEvent, id: string) {
+    if (e.metaKey || e.ctrlKey) {
+      clipboardViewState.toggleMultiSelect(id);
+    } else {
+      selectItem(id);
+    }
+  }
+
   function handleListScroll(e: Event) {
     const el = e.currentTarget as HTMLElement;
     if (el.scrollTop + el.clientHeight >= el.scrollHeight - 200) {
@@ -470,7 +478,8 @@
         <LauncherListRow
           data-index={index}
           selected={selectedIndex === index}
-          onclick={() => selectItem(item.id)}
+          multiSelected={clipboardViewState.isMultiSelected(item.id)}
+          onclick={(e: MouseEvent) => handleRowClick(e, item.id)}
           ondblclick={() => pasteItemById(item.id)}
           title={getItemTitle(item)}
           subtitle={clipboardViewState.searchQuery && 'score' in item
@@ -478,7 +487,19 @@
             : undefined}
         >
           {#snippet leading()}
-            <div class="mr-1 flex-shrink-0 flex items-center justify-center opacity-60">
+            <div class="mr-1 flex-shrink-0 relative flex items-center justify-center opacity-60">
+              {#if clipboardViewState.isMultiSelected(item.id)}
+                <div class="multi-select-checkmark">
+                  <svg class="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                    ><path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="3"
+                      d="M5 13l4 4L19 7"
+                    /></svg
+                  >
+                </div>
+              {/if}
               {#if item.type === 'image'}
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"
                   ><path
@@ -716,7 +737,11 @@
           <ActionFooter>
             {#snippet left()}
               <div class="flex items-center space-x-3">
-                {#if selectedFullItem}
+                {#if clipboardViewState.selectedIds.length > 1}
+                  <span class="text-caption"
+                    >{clipboardViewState.selectedIds.length} items selected · Enter to merge &amp; paste</span
+                  >
+                {:else if selectedFullItem}
                   <Badge text={selectedFullItem.type} variant="default" mono />
                   <span class="flex items-center gap-1 text-caption">
                     <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"
@@ -802,6 +827,21 @@
     flex-direction: column;
     height: 100%;
     min-height: 0;
+  }
+
+  .multi-select-checkmark {
+    position: absolute;
+    top: -3px;
+    left: -3px;
+    width: 12px;
+    height: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--accent-primary);
+    color: #fff;
+    z-index: 1;
   }
 
   .indexing-hint {

--- a/asyar-launcher/src/built-in-features/clipboard-history/index.test.ts
+++ b/asyar-launcher/src/built-in-features/clipboard-history/index.test.ts
@@ -67,7 +67,11 @@ vi.mock('./state.svelte', () => ({
     filteredItems: [],
     selectedItem: null,
     moveSelection: vi.fn(),
+    moveSelectionAndExtend: vi.fn(),
     handleItemAction: vi.fn(),
+    pasteMergedSelection: vi.fn().mockResolvedValue(undefined),
+    clearMultiSelect: vi.fn(),
+    selectedIds: [] as string[],
     deleteItem: vi.fn().mockResolvedValue(true),
     toggleFavorite: vi.fn().mockResolvedValue(true),
     pasteAsPlainText: vi.fn().mockResolvedValue(undefined),
@@ -187,6 +191,178 @@ describe('Keyboard shortcut: Cmd+Backspace to delete', () => {
   });
 });
 
+describe('Keyboard shortcut: Cmd+Arrow extends selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, 'addEventListener');
+    vi.spyOn(window, 'removeEventListener');
+  });
+
+  async function activateWithHandler() {
+    const mockContext = {
+      getService: vi.fn().mockImplementation((name: string) => {
+        if (name === 'extensions') {
+          return { setActiveViewActionLabel: vi.fn(), navigateToView: vi.fn() };
+        }
+        if (name === 'clipboard') {
+          return { getRecentItems: vi.fn().mockResolvedValue([]) };
+        }
+        return { info: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() };
+      }),
+    };
+    await extension.initialize(mockContext as any);
+
+    const mockState = await import('./state.svelte');
+    (mockState.clipboardViewState as any).items = [{ id: 'test-1', content: 'hello' }];
+    (mockState.clipboardViewState as any).filteredItems = [{ id: 'test-1', content: 'hello' }];
+    (mockState.clipboardViewState as any).selectedItem = { id: 'test-1', content: 'hello' };
+
+    await extension.viewActivated('some/path');
+    const handler = vi
+      .mocked(window.addEventListener)
+      .mock.calls.find((call) => call[0] === 'keydown')?.[1] as EventListener;
+    expect(handler).toBeDefined();
+    return { handler, mockState };
+  }
+
+  it('calls moveSelectionAndExtend("down") on Cmd+ArrowDown, not the plain moveSelection', async () => {
+    const { handler, mockState } = await activateWithHandler();
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      metaKey: true,
+      bubbles: true,
+    });
+    Object.defineProperty(event, 'preventDefault', { value: vi.fn() });
+    Object.defineProperty(event, 'stopPropagation', { value: vi.fn() });
+    handler(event);
+
+    expect(mockState.clipboardViewState.moveSelectionAndExtend).toHaveBeenCalledWith('down');
+    expect(mockState.clipboardViewState.moveSelection).not.toHaveBeenCalled();
+  });
+
+  it('calls moveSelectionAndExtend("up") on Ctrl+ArrowUp', async () => {
+    const { handler, mockState } = await activateWithHandler();
+
+    const event = new KeyboardEvent('keydown', { key: 'ArrowUp', ctrlKey: true, bubbles: true });
+    Object.defineProperty(event, 'preventDefault', { value: vi.fn() });
+    Object.defineProperty(event, 'stopPropagation', { value: vi.fn() });
+    handler(event);
+
+    expect(mockState.clipboardViewState.moveSelectionAndExtend).toHaveBeenCalledWith('up');
+  });
+
+  it('plain ArrowDown (no modifier) still calls moveSelection, not moveSelectionAndExtend', async () => {
+    const { handler, mockState } = await activateWithHandler();
+
+    const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+    Object.defineProperty(event, 'preventDefault', { value: vi.fn() });
+    Object.defineProperty(event, 'stopPropagation', { value: vi.fn() });
+    handler(event);
+
+    expect(mockState.clipboardViewState.moveSelection).toHaveBeenCalledWith('down');
+    expect(mockState.clipboardViewState.moveSelectionAndExtend).not.toHaveBeenCalled();
+  });
+});
+
+describe('Keyboard shortcut: Enter routes to merge-paste when multi-selected', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, 'addEventListener');
+    vi.spyOn(window, 'removeEventListener');
+  });
+
+  async function activateWithSelection(selectedIds: string[]) {
+    const mockContext = {
+      getService: vi.fn().mockImplementation((name: string) => {
+        if (name === 'extensions') {
+          return { setActiveViewActionLabel: vi.fn(), navigateToView: vi.fn() };
+        }
+        if (name === 'clipboard') {
+          return { getRecentItems: vi.fn().mockResolvedValue([]) };
+        }
+        return { info: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() };
+      }),
+    };
+    await extension.initialize(mockContext as any);
+
+    const mockState = await import('./state.svelte');
+    (mockState.clipboardViewState as any).items = [{ id: 'test-1', content: 'hello' }];
+    (mockState.clipboardViewState as any).filteredItems = [{ id: 'test-1', content: 'hello' }];
+    (mockState.clipboardViewState as any).selectedItem = { id: 'test-1', content: 'hello' };
+    (mockState.clipboardViewState as any).selectedIds = selectedIds;
+
+    await extension.viewActivated('some/path');
+    const handler = vi
+      .mocked(window.addEventListener)
+      .mock.calls.find((call) => call[0] === 'keydown')?.[1] as EventListener;
+    return { handler, mockState };
+  }
+
+  it('calls pasteMergedSelection when 2+ items are selected', async () => {
+    const { handler, mockState } = await activateWithSelection(['a', 'b']);
+
+    const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+    Object.defineProperty(event, 'preventDefault', { value: vi.fn() });
+    Object.defineProperty(event, 'stopPropagation', { value: vi.fn() });
+    handler(event);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockState.clipboardViewState.pasteMergedSelection).toHaveBeenCalled();
+    expect(mockState.clipboardViewState.handleItemAction).not.toHaveBeenCalled();
+  });
+
+  it('calls handleItemAction (normal paste) when only 1 item is toggled selected', async () => {
+    const { handler, mockState } = await activateWithSelection(['test-1']);
+
+    const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+    Object.defineProperty(event, 'preventDefault', { value: vi.fn() });
+    Object.defineProperty(event, 'stopPropagation', { value: vi.fn() });
+    handler(event);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockState.clipboardViewState.handleItemAction).toHaveBeenCalledWith(
+      { id: 'test-1', content: 'hello' },
+      'paste',
+    );
+    expect(mockState.clipboardViewState.pasteMergedSelection).not.toHaveBeenCalled();
+  });
+
+  it('calls handleItemAction (normal paste) when nothing is multi-selected', async () => {
+    const { handler, mockState } = await activateWithSelection([]);
+
+    const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+    Object.defineProperty(event, 'preventDefault', { value: vi.fn() });
+    Object.defineProperty(event, 'stopPropagation', { value: vi.fn() });
+    handler(event);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockState.clipboardViewState.handleItemAction).toHaveBeenCalled();
+    expect(mockState.clipboardViewState.pasteMergedSelection).not.toHaveBeenCalled();
+  });
+});
+
+describe('viewActivated clears any stale multi-selection', () => {
+  it('calls clipboardViewState.clearMultiSelect() on view activation', async () => {
+    const mockContext = {
+      getService: vi.fn().mockImplementation((name: string) => {
+        if (name === 'extensions') {
+          return { setActiveViewActionLabel: vi.fn(), navigateToView: vi.fn() };
+        }
+        if (name === 'clipboard') {
+          return { getRecentItems: vi.fn().mockResolvedValue([]) };
+        }
+        return { info: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() };
+      }),
+    };
+    await extension.initialize(mockContext as any);
+    await extension.viewActivated('some/path');
+
+    const mockState = await import('./state.svelte');
+    expect(mockState.clipboardViewState.clearMultiSelect).toHaveBeenCalled();
+  });
+});
+
 describe('Action registration', () => {
   it('registers view actions on view activation', async () => {
     const mockContext = {
@@ -221,6 +397,61 @@ describe('Action registration', () => {
     expect(actionIds).toContain('clipboard-history:toggle-html-view');
     expect(actionIds).toContain('clipboard-history:toggle-favorite');
     expect(actionIds).toContain('clipboard-history:paste-as-plain-text');
+    expect(actionIds).toContain('clipboard-history:clear-multi-selection');
+  });
+
+  it('clear-multi-selection action is only visible when a selection exists, and clears it on execute', async () => {
+    const mockContext = {
+      getService: vi.fn().mockImplementation((name: string) => {
+        if (name === 'extensions') {
+          return { setActiveViewActionLabel: vi.fn(), navigateToView: vi.fn() };
+        }
+        if (name === 'clipboard') {
+          return { getRecentItems: vi.fn().mockResolvedValue([]) };
+        }
+        return { info: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() };
+      }),
+    };
+    await extension.initialize(mockContext as any);
+    await extension.executeCommand('show-clipboard');
+
+    const { actionService } = await import('../../services/action/actionService.svelte');
+    const clearAction = vi
+      .mocked(actionService.registerAction)
+      .mock.calls.find((c) => c[0].id === 'clipboard-history:clear-multi-selection')?.[0];
+    expect(clearAction).toBeDefined();
+
+    const mockState = await import('./state.svelte');
+    (mockState.clipboardViewState as any).selectedIds = [];
+    expect((clearAction as any).visible?.()).toBe(false);
+
+    (mockState.clipboardViewState as any).selectedIds = ['a', 'b'];
+    expect((clearAction as any).visible?.()).toBe(true);
+
+    await clearAction!.execute();
+    expect(mockState.clipboardViewState.clearMultiSelect).toHaveBeenCalled();
+  });
+
+  it('clear-multi-selection action is unregistered on view deactivation', async () => {
+    const mockContext = {
+      getService: vi.fn().mockImplementation((name: string) => {
+        if (name === 'extensions') {
+          return { setActiveViewActionLabel: vi.fn(), navigateToView: vi.fn() };
+        }
+        if (name === 'clipboard') {
+          return { getRecentItems: vi.fn().mockResolvedValue([]) };
+        }
+        return { info: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() };
+      }),
+    };
+    await extension.initialize(mockContext as any);
+    await extension.executeCommand('show-clipboard');
+    await extension.viewDeactivated('clipboard-history/DefaultView');
+
+    const { actionService } = await import('../../services/action/actionService.svelte');
+    expect(actionService.unregisterAction).toHaveBeenCalledWith(
+      'clipboard-history:clear-multi-selection',
+    );
   });
 });
 

--- a/asyar-launcher/src/built-in-features/clipboard-history/index.ts
+++ b/asyar-launcher/src/built-in-features/clipboard-history/index.ts
@@ -146,6 +146,10 @@ class ClipboardHistoryExtension implements Extension {
     this.inView = true;
     this.logService?.debug(`Clipboard History view activated: ${viewPath}`);
 
+    // Fresh entry into the view should not carry over a stale multi-selection
+    // from a previous visit.
+    clipboardViewState.clearMultiSelect();
+
     // Add global key listener
     window.addEventListener('keydown', this.handleKeydownBound);
 
@@ -178,6 +182,16 @@ class ClipboardHistoryExtension implements Extension {
       return;
     }
 
+    if (
+      (event.metaKey || event.ctrlKey) &&
+      (event.key === 'ArrowUp' || event.key === 'ArrowDown')
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      clipboardViewState.moveSelectionAndExtend(event.key === 'ArrowUp' ? 'up' : 'down');
+      return;
+    }
+
     if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
       event.preventDefault();
       event.stopPropagation();
@@ -189,7 +203,11 @@ class ClipboardHistoryExtension implements Extension {
     } else if (event.key === 'Enter' && state.selectedItem) {
       event.preventDefault();
       event.stopPropagation();
-      clipboardViewState.handleItemAction(state.selectedItem, 'paste');
+      if (state.selectedIds.length > 1) {
+        clipboardViewState.pasteMergedSelection();
+      } else {
+        clipboardViewState.handleItemAction(state.selectedItem, 'paste');
+      }
     }
   }
 
@@ -304,6 +322,20 @@ class ClipboardHistoryExtension implements Extension {
     });
 
     actionService.registerAction({
+      id: 'clipboard-history:clear-multi-selection',
+      title: 'Clear Selection',
+      description: 'Deselect all multi-selected clipboard items',
+      icon: 'icon:x',
+      category: 'clipboard-action',
+      extensionId: 'clipboard-history',
+      context: ActionContext.EXTENSION_VIEW,
+      visible: () => clipboardViewState.selectedIds.length > 0,
+      execute: () => {
+        clipboardViewState.clearMultiSelect();
+      },
+    });
+
+    actionService.registerAction({
       id: 'clipboard-history:ask-ai-about-this',
       title: 'Ask AI about this',
       description: 'Open AI Chat with this clipboard text pre-filled',
@@ -355,6 +387,7 @@ class ClipboardHistoryExtension implements Extension {
     actionService.unregisterAction('clipboard-history:open-in-browser');
     actionService.unregisterAction('clipboard-history:save-as-snippet');
     actionService.unregisterAction('clipboard-history:delete');
+    actionService.unregisterAction('clipboard-history:clear-multi-selection');
     actionService.unregisterAction('clipboard-history:ask-ai-about-this');
   }
 

--- a/asyar-launcher/src/built-in-features/clipboard-history/state.svelte.test.ts
+++ b/asyar-launcher/src/built-in-features/clipboard-history/state.svelte.test.ts
@@ -33,8 +33,16 @@ vi.mock('../../services/log/logService', () => ({
   },
 }));
 
+vi.mock('../../lib/ipc/commands', () => ({
+  checkAccessibilityPermission: vi.fn().mockResolvedValue(true),
+  openAccessibilityPreferences: vi.fn().mockResolvedValue(undefined),
+  clipboardGetMergedText: vi.fn().mockResolvedValue({ text: '', skippedCount: 0 }),
+}));
+
 import { ClipboardViewStateClass } from './state.svelte';
 import { clipboardHistoryStore } from '../../services/clipboard/stores/clipboardHistoryStore.svelte';
+import * as commands from '../../lib/ipc/commands';
+import { feedbackService } from '../../services/feedback/feedbackService.svelte';
 
 describe('ClipboardViewStateClass paste action proxy issue', () => {
   let state: ClipboardViewStateClass;
@@ -569,5 +577,175 @@ describe('type filter (applied on top of store-mirrored items)', () => {
   it('filter "files" returns only file rows', () => {
     state.setTypeFilter('files');
     expect(state.filteredItems.map((i) => i.id)).toEqual(['4']);
+  });
+});
+
+describe('toggleMultiSelect', () => {
+  let state: ClipboardViewStateClass;
+
+  beforeEach(() => {
+    state = new ClipboardViewStateClass();
+  });
+
+  it('adds an id not yet selected and moves the cursor to it', () => {
+    state.toggleMultiSelect('a');
+    expect(state.selectedIds).toEqual(['a']);
+    expect(state.selectedItemId).toBe('a');
+  });
+
+  it('removes an id already selected', () => {
+    state.toggleMultiSelect('a');
+    state.toggleMultiSelect('b');
+    state.toggleMultiSelect('a');
+    expect(state.selectedIds).toEqual(['b']);
+  });
+
+  it('preserves add-order across toggles', () => {
+    state.toggleMultiSelect('c');
+    state.toggleMultiSelect('a');
+    state.toggleMultiSelect('b');
+    expect(state.selectedIds).toEqual(['c', 'a', 'b']);
+  });
+
+  it('isMultiSelected reflects current membership', () => {
+    state.toggleMultiSelect('a');
+    expect(state.isMultiSelected('a')).toBe(true);
+    expect(state.isMultiSelected('b')).toBe(false);
+  });
+
+  it('clearMultiSelect empties the selection', () => {
+    state.toggleMultiSelect('a');
+    state.toggleMultiSelect('b');
+    state.clearMultiSelect();
+    expect(state.selectedIds).toEqual([]);
+  });
+});
+
+describe('moveSelectionAndExtend', () => {
+  let state: ClipboardViewStateClass;
+
+  beforeEach(() => {
+    state = new ClipboardViewStateClass();
+    state.setItems([
+      { id: '1', content: 'a', type: 'text' as any, createdAt: 1, favorite: false },
+      { id: '2', content: 'b', type: 'text' as any, createdAt: 2, favorite: false },
+      { id: '3', content: 'c', type: 'text' as any, createdAt: 3, favorite: false },
+    ]);
+    // setItems auto-selects the first item ('1' after favorite-sort, since none are favorites — order preserved).
+  });
+
+  it('captures the starting cursor item then adds the newly-landed item', () => {
+    state.moveSelectionAndExtend('down');
+    // Started on '1', moved down to '2' — both should now be selected, in that order.
+    expect(state.selectedIds).toEqual(['1', '2']);
+    expect(state.selectedItemId).toBe('2');
+  });
+
+  it('keeps extending across repeated calls without duplicating', () => {
+    state.moveSelectionAndExtend('down');
+    state.moveSelectionAndExtend('down');
+    expect(state.selectedIds).toEqual(['1', '2', '3']);
+  });
+
+  it('is add-only: moving back over an already-selected item does not remove it', () => {
+    state.moveSelectionAndExtend('down'); // selects 1, 2 — cursor on 2
+    state.moveSelectionAndExtend('down'); // selects 3 — cursor on 3
+    state.moveSelectionAndExtend('up'); // cursor back to 2, already selected
+    expect(state.selectedIds).toEqual(['1', '2', '3']);
+    expect(state.selectedItemId).toBe('2');
+  });
+});
+
+describe('pasteMergedSelection', () => {
+  let state: ClipboardViewStateClass;
+  let mockClipboardService: any;
+  let mockLogService: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(commands.checkAccessibilityPermission).mockResolvedValue(true);
+    vi.mocked(commands.clipboardGetMergedText).mockResolvedValue({
+      text: 'first\nsecond',
+      skippedCount: 0,
+    });
+
+    state = new ClipboardViewStateClass();
+    mockClipboardService = {
+      pasteItem: vi.fn().mockResolvedValue(undefined),
+      hideWindow: vi.fn(),
+      getRecentItems: vi.fn().mockResolvedValue([]),
+    };
+    mockLogService = { error: vi.fn(), debug: vi.fn(), warn: vi.fn() };
+    state.initializeServices({
+      getService: (name: string) => {
+        if (name === 'clipboard') return mockClipboardService;
+        if (name === 'log') return mockLogService;
+        return null;
+      },
+    } as any);
+
+    state.toggleMultiSelect('1');
+    state.toggleMultiSelect('2');
+  });
+
+  it('does nothing when fewer than 2 items are selected', async () => {
+    state.clearMultiSelect();
+    state.toggleMultiSelect('1');
+
+    await state.pasteMergedSelection();
+
+    expect(commands.clipboardGetMergedText).not.toHaveBeenCalled();
+    expect(mockClipboardService.pasteItem).not.toHaveBeenCalled();
+  });
+
+  it('fetches merged text in selection order and pastes it as a single text item', async () => {
+    await state.pasteMergedSelection();
+
+    expect(commands.clipboardGetMergedText).toHaveBeenCalledWith(['1', '2']);
+    expect(mockClipboardService.pasteItem).toHaveBeenCalledTimes(1);
+    const arg = mockClipboardService.pasteItem.mock.calls[0][0];
+    expect(arg.type).toBe('text');
+    expect(arg.content).toBe('first\nsecond');
+  });
+
+  it('clears the selection after a successful merge paste', async () => {
+    await state.pasteMergedSelection();
+    expect(state.selectedIds).toEqual([]);
+  });
+
+  it('does not clear the selection when accessibility permission is denied', async () => {
+    vi.mocked(commands.checkAccessibilityPermission).mockResolvedValue(false);
+
+    await state.pasteMergedSelection();
+
+    expect(commands.openAccessibilityPreferences).toHaveBeenCalled();
+    expect(commands.clipboardGetMergedText).not.toHaveBeenCalled();
+    expect(mockClipboardService.pasteItem).not.toHaveBeenCalled();
+    expect(state.selectedIds).toEqual(['1', '2']);
+  });
+
+  it('reports skipped items via feedbackService without blocking the paste', async () => {
+    vi.mocked(commands.clipboardGetMergedText).mockResolvedValue({
+      text: 'first',
+      skippedCount: 1,
+    });
+
+    await state.pasteMergedSelection();
+
+    expect(mockClipboardService.pasteItem).toHaveBeenCalledTimes(1);
+    expect(feedbackService.report).toHaveBeenCalled();
+  });
+
+  it('does not paste and preserves the selection when merged text is empty', async () => {
+    vi.mocked(commands.clipboardGetMergedText).mockResolvedValue({
+      text: '',
+      skippedCount: 2,
+    });
+
+    await state.pasteMergedSelection();
+
+    expect(mockClipboardService.pasteItem).not.toHaveBeenCalled();
+    expect(state.selectedIds).toEqual(['1', '2']);
+    expect(feedbackService.report).toHaveBeenCalled();
   });
 });

--- a/asyar-launcher/src/built-in-features/clipboard-history/state.svelte.ts
+++ b/asyar-launcher/src/built-in-features/clipboard-history/state.svelte.ts
@@ -11,12 +11,17 @@ import {
 import { shiftIndex } from '../../lib/listSelection.svelte';
 import { clipboardHistoryStore } from '../../services/clipboard/stores/clipboardHistoryStore.svelte';
 import { feedbackService } from '../../services/feedback/feedbackService.svelte';
+import * as commands from '../../lib/ipc/commands';
 
 export class ClipboardViewStateClass {
   searchQuery = $state('');
   lastSearch = $state(Date.now());
   items = $state<ClipboardHistoryItem[]>([]);
   selectedItemId = $state<string | null>(null);
+  /** Ordered multi-selection (Cmd/Ctrl+Click, Cmd/Ctrl+Arrow) — append-on-add,
+   *  independent of the single `selectedItemId` cursor above. Used by
+   *  `pasteMergedSelection` to merge-paste in selection order. */
+  selectedIds = $state<string[]>([]);
 
   // Search is now Rust-FTS-backed in the store; `this.items` is mirrored
   // from the store (favorites + recent when not searching, searchResults
@@ -43,6 +48,15 @@ export class ClipboardViewStateClass {
   });
 
   selectedItem = $derived(this.filteredItems[this.selectedIndex] ?? null);
+
+  /** `selectedIds` resolved against the current `filteredItems`, in
+   *  selection order. Ids that scrolled out of the loaded window or were
+   *  filtered out simply drop — no extra sync effect needed. */
+  multiSelectedItems = $derived.by(() => {
+    return this.selectedIds
+      .map((id) => this.filteredItems.find((i) => i.id === id))
+      .filter((i): i is ClipboardHistoryItem => i != null);
+  });
   isLoading = $state(true);
   loadError = $state(false);
   errorMessage = $state('');
@@ -106,6 +120,7 @@ export class ClipboardViewStateClass {
     this.searchQuery = '';
     this.lastSearch = Date.now();
     this.selectedItemId = null;
+    this.selectedIds = [];
     this.isLoading = true;
     this.loadError = false;
     this.errorMessage = '';
@@ -138,6 +153,41 @@ export class ClipboardViewStateClass {
     if (!items.length) return;
     const next = shiftIndex(this.selectedIndex, items.length, direction);
     this.selectedItemId = items[next].id;
+  }
+
+  /** Toggle a row into/out of the multi-selection (Cmd/Ctrl+Click) and move
+   *  the cursor/detail pane to it. */
+  toggleMultiSelect(id: string) {
+    if (this.selectedIds.includes(id)) {
+      this.selectedIds = this.selectedIds.filter((x) => x !== id);
+    } else {
+      this.selectedIds = [...this.selectedIds, id];
+    }
+    this.selectedItemId = id;
+  }
+
+  isMultiSelected(id: string): boolean {
+    return this.selectedIds.includes(id);
+  }
+
+  clearMultiSelect() {
+    this.selectedIds = [];
+  }
+
+  /** Cmd/Ctrl+ArrowUp/Down: move the cursor and extend the multi-selection to
+   *  cover both the starting row and the newly-landed row. Add-only — moving
+   *  back over an already-selected row is a no-op, not a toggle-off, so
+   *  "selection order" stays well-defined for a Cmd+Arrow run. */
+  moveSelectionAndExtend(direction: 'up' | 'down') {
+    const items = this.filteredItems;
+    if (!items.length) return;
+    if (this.selectedItemId && !this.selectedIds.includes(this.selectedItemId)) {
+      this.selectedIds = [...this.selectedIds, this.selectedItemId];
+    }
+    this.moveSelection(direction);
+    if (this.selectedItemId && !this.selectedIds.includes(this.selectedItemId)) {
+      this.selectedIds = [...this.selectedIds, this.selectedItemId];
+    }
   }
 
   setLoading(isLoading: boolean) {
@@ -237,6 +287,90 @@ export class ClipboardViewStateClass {
       }
     } catch (error) {
       this.logService?.error(`Failed to paste as plain text: ${error}`);
+      feedbackService.report({
+        source: 'frontend',
+        kind: 'clipboard/paste-failed',
+        severity: 'error',
+        retryable: false,
+        developerDetail: String(error),
+      });
+    }
+  }
+
+  /** Merge-paste every multi-selected item's plain text, in selection order,
+   *  as a single clipboard write + single simulated paste. The
+   *  fetch/decrypt/strip/join transformation runs server-side in Rust
+   *  (`clipboardGetMergedText`) — this method only orchestrates the ordered
+   *  id list and the final write+paste step. */
+  async pasteMergedSelection() {
+    if (!this.clipboardService) {
+      this.logService?.error('Clipboard service not initialized in pasteMergedSelection');
+      return;
+    }
+    if (this.selectedIds.length < 2) return;
+
+    try {
+      // Checked up front (mirrors the internal check in
+      // clipboardHistoryService.pasteItem): a permission-denied no-op must
+      // not clear the selection the user just built.
+      if (!(await commands.checkAccessibilityPermission())) {
+        await commands.openAccessibilityPreferences();
+        feedbackService.report({
+          source: 'frontend',
+          kind: 'manual',
+          severity: 'warning',
+          retryable: false,
+          context: {
+            message:
+              'Asyar needs macOS Accessibility permission to paste. Enable Asyar under ' +
+              'System Settings → Privacy & Security → Accessibility, then try again.',
+          },
+        });
+        return;
+      }
+
+      const merged = await commands.clipboardGetMergedText(this.selectedIds);
+      const text = merged?.text ?? '';
+      const skippedCount = merged?.skippedCount ?? 0;
+
+      if (!text.trim()) {
+        if (skippedCount > 0) {
+          feedbackService.report({
+            source: 'frontend',
+            kind: 'manual',
+            severity: 'warning',
+            retryable: false,
+            context: {
+              message: `Nothing to paste — ${skippedCount} selected item(s) can't be merged as text.`,
+            },
+          });
+        }
+        return;
+      }
+
+      await this.clipboardService.pasteItem({
+        id: 'merged-selection',
+        type: ClipboardItemType.Text as any,
+        content: text,
+        createdAt: Date.now(),
+        favorite: false,
+      } as ClipboardHistoryItem);
+
+      this.clearMultiSelect();
+
+      if (skippedCount > 0) {
+        feedbackService.report({
+          source: 'frontend',
+          kind: 'manual',
+          severity: 'warning',
+          retryable: false,
+          context: {
+            message: `${skippedCount} item(s) skipped — only text/HTML/RTF can be merged.`,
+          },
+        });
+      }
+    } catch (error) {
+      this.logService?.error(`Failed to paste merged selection: ${error}`);
       feedbackService.report({
         source: 'frontend',
         kind: 'clipboard/paste-failed',

--- a/asyar-launcher/src/components/list/LauncherListRow.svelte
+++ b/asyar-launcher/src/components/list/LauncherListRow.svelte
@@ -9,6 +9,7 @@
 
   let {
     selected = false,
+    multiSelected = false,
     onclick,
     ondblclick,
     icon,
@@ -24,6 +25,9 @@
     ...rest
   }: {
     selected?: boolean;
+    /** Independent of `selected` (the keyboard cursor) — marks this row as
+     *  part of a multi-item selection (e.g. clipboard-history's merge-paste). */
+    multiSelected?: boolean;
     onclick?: (e: MouseEvent) => void;
     ondblclick?: (e: MouseEvent) => void;
     icon?: string;
@@ -50,6 +54,7 @@
   type="button"
   class="result-item"
   class:selected-result={selected}
+  class:multi-selected-result={multiSelected}
   {onclick}
   {ondblclick}
   {...rest}

--- a/asyar-launcher/src/lib/ipc/commands.ts
+++ b/asyar-launcher/src/lib/ipc/commands.ts
@@ -885,6 +885,18 @@ export async function clipboardGetItem(id: string): Promise<StoredClipboardItem 
   return invokeSafe<StoredClipboardItem | null>('clipboard_get_item', { id });
 }
 
+export interface MergedClipboardText {
+  text: string;
+  skippedCount: number;
+}
+
+/** Fetch, decrypt, strip HTML/RTF, and join multiple items' text server-side
+ *  (in the given order). Image/Files items are skipped and counted. Used by
+ *  the clipboard-history multi-select merge-paste flow. */
+export async function clipboardGetMergedText(ids: string[]): Promise<MergedClipboardText | null> {
+  return invokeSafe<MergedClipboardText>('clipboard_get_merged_text', { ids });
+}
+
 export async function clipboardExportForSync(
   cursor: ClipboardCursor | undefined,
   limit: number,

--- a/asyar-launcher/src/resources/styles/style.css
+++ b/asyar-launcher/src/resources/styles/style.css
@@ -527,6 +527,14 @@ html[data-platform='macos'] .app-root {
     box-shadow: inset 0 0 2px 0.5px var(--kbd-rim);
   }
 
+  /* Multi-item selection (e.g. clipboard-history merge-paste) — independent
+     of .selected-result (the single keyboard cursor); a row can carry either
+     or both classes at once. */
+  .multi-selected-result {
+    background-color: var(--bg-tertiary);
+    box-shadow: inset 3px 0 0 0 var(--accent-primary);
+  }
+
   .btn {
     @apply inline-flex items-center justify-center px-4 py-1.5 text-sm font-medium outline-none;
     font-family: var(--font-ui);

--- a/asyar-launcher/src/routes/onboarding/steps/Clipboard.svelte
+++ b/asyar-launcher/src/routes/onboarding/steps/Clipboard.svelte
@@ -21,5 +21,9 @@
     <LauncherHint
       steps={[`Press ${mod}+${key}`, 'Type clip and press Enter', 'Pick any past item to paste it']}
     />
+    <p>
+      Need several at once? Cmd/Ctrl-click (or Cmd/Ctrl+↑/↓) to select multiple items, then press
+      Enter to <span class="onb-hl">merge them into a single paste</span>.
+    </p>
   {/snippet}
 </GuidanceStep>

--- a/docs/guide/features/clipboard-history.md
+++ b/docs/guide/features/clipboard-history.md
@@ -21,15 +21,19 @@ Asyar also records which app each item came from, so you can see the source appl
 4. To narrow by content type, click the dropdown in the search bar (or press `⌘P`) and choose **All Types**, **Text**, **Images**, or **Files**.
 5. Press `Enter` to paste the selected item into the app that was in focus before you opened Asyar.
 6. Press `⇧Enter` to paste as plain text, stripping any formatting.
+7. To paste several items at once, `⌘Click` (or `Ctrl+Click` on Windows/Linux) each item you want, or hold `⌘`/`Ctrl` and press `↑`/`↓` to sweep through a range — then press `Enter` to merge them into a single paste.
 
 ## Shortcuts & actions
 
-| Action              | How      |
-| ------------------- | -------- |
-| Paste               | `Enter`  |
-| Paste as Plain Text | `⇧Enter` |
-| Delete item         | `⌘⌫`     |
-| Open action panel   | `⌘K`     |
+| Action                          | How         |
+| ------------------------------- | ----------- |
+| Paste                           | `Enter`     |
+| Paste as Plain Text             | `⇧Enter`    |
+| Toggle an item in the selection | `⌘Click`    |
+| Extend the selection            | `⌘↑` / `⌘↓` |
+| Merge & paste the selection     | `Enter`     |
+| Delete item                     | `⌘⌫`        |
+| Open action panel               | `⌘K`        |
 
 **Action panel (⌘K) entries while the list is open:**
 
@@ -39,6 +43,7 @@ Asyar also records which app each item came from, so you can see the source appl
 - **Open in Browser** — opens a selected URL item in your default browser.
 - **Save as Snippet** — sends the selected text item directly to the Snippets editor so you can give it a keyword.
 - **Delete** — removes the selected item permanently (`⌘⌫`).
+- **Clear Selection** — deselects all multi-selected items, without leaving the view. Only appears while a selection is active.
 - **Ask AI about this** — opens AI Chat with the selected text pre-filled.
 - **Clear Clipboard History** — removes all non-favourited items (available from the root search bar too, without opening the view).
 
@@ -48,6 +53,7 @@ Asyar also records which app each item came from, so you can see the source appl
 - **Double-click to paste** — clicking an item selects it; double-clicking pastes it immediately.
 - **RTF items** — Asyar stores the rich format but "Paste as Plain Text" strips it, which is handy for pasting into apps that don't accept rich text.
 - **Large text is truncated in the preview** — the full content is always pasted correctly; the preview just caps at 50,000 characters to keep the UI fast.
+- **Merged paste is plain text, in selection order** — `⌘Click`/`⌘↑`/`⌘↓` build an ordered multi-selection independent of the normal cursor, so browsing around with plain clicks or arrow keys never loses it. Pressing `Enter` joins every selected item's text with a newline and pastes it as one block, in the order you selected them. Images and files can't be merged as text and are skipped (you'll see a toast if any were).
 
 ## Related
 


### PR DESCRIPTION
Cmd/Ctrl-click or Cmd/Ctrl+arrow selects multiple history items;
Enter merges their text (joined server-side in Rust) into one
clipboard write + paste. Docs, onboarding, and README updated.