### PR TITLE
fix(shell): restore consent dialog and trust manager

### DIFF
--- a/asyar-launcher/src/components/settings/ShellTrustManager.svelte
+++ b/asyar-launcher/src/components/settings/ShellTrustManager.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
   import SettingsSection from './SettingsSection.svelte';
   import { onMount } from 'svelte';
-  import { extensionManager } from '../../services/extension/extensionManager.svelte';
-  import { shellListTrusted, shellRevokeTrust, type TrustedBinary } from '../../lib/ipc/commands';
+  import {
+    shellListTrusted,
+    shellRevokeTrust,
+    discoverExtensions,
+    type TrustedBinary,
+  } from '../../lib/ipc/commands';
   import { feedbackService } from '../../services/feedback/feedbackService.svelte';
   import { logService } from '../../services/log/logService';
 
@@ -18,7 +22,12 @@
 
   async function loadTrustData() {
     isLoading = true;
-    const recordsWithShell = extensionManager.extensionRecords.filter((r) =>
+    // Source the list via IPC (`discover_extensions`), not
+    // `extensionManager.extensionRecords` — that in-memory array is only
+    // populated in the main launcher window, so it's empty in this settings
+    // webview and the panel would always render as empty.
+    const allRecords = (await discoverExtensions()) ?? [];
+    const recordsWithShell = allRecords.filter((r) =>
       r.manifest.permissions?.includes('shell:spawn'),
     );
 
@@ -104,9 +113,11 @@
   });
 </script>
 
-{#if !isLoading && groupedTrusts.length > 0}
-  <SettingsSection title="Terminal Trust Store">
-    <div class="px-6 pb-6 space-y-6">
+<SettingsSection title="Terminal Trust Store">
+  <div class="px-6 pb-6 space-y-6">
+    {#if isLoading}
+      <p class="text-xs text-[var(--text-tertiary)] leading-relaxed">Loading trusted programs…</p>
+    {:else if groupedTrusts.length > 0}
       <p class="text-xs text-[var(--text-secondary)] leading-relaxed">
         The following programs have been explicitly trusted for execution by specific extensions.
         Revoking trust will cause the extension to prompt for permission again on next use.
@@ -162,6 +173,11 @@
           </div>
         {/each}
       </div>
-    </div>
-  </SettingsSection>
-{/if}
+    {:else}
+      <p class="text-xs text-[var(--text-tertiary)] leading-relaxed">
+        No programs are trusted yet. When an extension runs a binary — or you approve its declared
+        binaries at install — they’ll appear here to review or revoke.
+      </p>
+    {/if}
+  </div>
+</SettingsSection>

--- a/asyar-launcher/src/routes/settings/tabs/ExtensionsTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/ExtensionsTab.svelte
@@ -11,7 +11,6 @@
   import { extensionStateManager } from '../../../services/extension/extensionStateManager.svelte';
   import { extensionUpdateService } from '../../../services/extension/extensionUpdateService.svelte';
   import { showOpenExtensionDialog, installExtensionFromFile } from '../../../lib/ipc/commands';
-  import ShellTrustManager from '../../../components/settings/ShellTrustManager.svelte';
   import { filterExtensions, type ExtensionFilter } from './extensionFilters';
   import type { ExtensionCommand } from 'asyar-sdk/contracts';
   import { onMount } from 'svelte';
@@ -622,8 +621,6 @@
     </button>
   </div>
 {/if}
-
-<ShellTrustManager />
 
 {#if editingAliasTarget}
   <AliasCapture

--- a/asyar-launcher/src/routes/settings/tabs/PrivacyTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/PrivacyTab.svelte
@@ -5,6 +5,7 @@
   import EncryptionStatusSection from '../../../components/settings/EncryptionStatusSection.svelte';
   import CrashReportSection from '../../../components/settings/CrashReportSection.svelte';
   import UsageShareSection from '../../../components/settings/UsageShareSection.svelte';
+  import ShellTrustManager from '../../../components/settings/ShellTrustManager.svelte';
   import { clipboardPrivacyService } from '../../../services/privacy/clipboardPrivacyService.svelte';
   import { secretRedactionService } from '../../../services/privacy/secretRedactionService.svelte';
   import { encryptionService } from '../../../services/privacy/encryptionService.svelte';
@@ -26,6 +27,7 @@
   <UsageShareSection />
   <ClipboardPrivacySection />
   <SecretRedactionSection />
+  <ShellTrustManager />
 </div>
 
 <style>

--- a/asyar-launcher/src/services/shell/shellConsentService.svelte.ts
+++ b/asyar-launcher/src/services/shell/shellConsentService.svelte.ts
@@ -1,4 +1,5 @@
 import { shellCheckTrust, shellGrantTrust } from '../../lib/ipc/shellCommands';
+import { showWindow, setFocusLock } from '../../lib/ipc/commands';
 
 interface ConsentRequest {
   extensionId: string;
@@ -74,12 +75,25 @@ class ShellConsentService {
   private pump(): void {
     if (this.activeRequest !== null) return;
     this.activeRequest = this.queue.shift() ?? null;
+    if (this.activeRequest !== null) {
+      // A trust dialog is opening. A background command (e.g. a worker shell
+      // spawn) hides the launcher just before this async request lands, so
+      // re-show it and hold it open — otherwise the dialog is stranded in a
+      // hidden window, or auto-hides on blur while the user reads it.
+      void showWindow();
+      void setFocusLock(true);
+    }
   }
 
   private settle(request: ConsentRequest, allowed: boolean): void {
     this.activeRequest = null;
     request.resolve(allowed);
     this.pump();
+    // Release the focus lock once the queue is fully drained so the launcher
+    // can auto-hide normally again.
+    if (this.activeRequest === null) {
+      void setFocusLock(false);
+    }
   }
 }
 

--- a/asyar-launcher/src/services/shell/shellConsentService.test.ts
+++ b/asyar-launcher/src/services/shell/shellConsentService.test.ts
@@ -5,8 +5,13 @@ vi.mock('../../lib/ipc/shellCommands', () => ({
   shellCheckTrust: vi.fn().mockResolvedValue(false),
   shellGrantTrust: vi.fn().mockResolvedValue(true),
 }));
+vi.mock('../../lib/ipc/commands', () => ({
+  showWindow: vi.fn().mockResolvedValue(undefined),
+  setFocusLock: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { shellCheckTrust, shellGrantTrust } from '../../lib/ipc/shellCommands';
+import { showWindow, setFocusLock } from '../../lib/ipc/commands';
 import { shellConsentService } from './shellConsentService.svelte';
 
 const checkTrust = vi.mocked(shellCheckTrust);
@@ -28,6 +33,27 @@ describe('shellConsentService', () => {
       true,
     );
     expect(shellConsentService.activeRequest).toBeNull();
+  });
+
+  it('does not reveal or focus-lock the launcher on the already-trusted hot path', async () => {
+    checkTrust.mockResolvedValue(true);
+    await shellConsentService.requestConsent('ext.a', 'jq', '/usr/bin/jq');
+    expect(showWindow).not.toHaveBeenCalled();
+    expect(setFocusLock).not.toHaveBeenCalled();
+  });
+
+  it('reveals and focus-locks the launcher when a dialog opens, releasing on settle', async () => {
+    const promise = shellConsentService.requestConsent('ext.a', 'jq', '/usr/bin/jq');
+    await settleMicrotasks();
+    // Dialog is up: a background command may have hidden the launcher, so it
+    // is re-shown and held open.
+    expect(showWindow).toHaveBeenCalledTimes(1);
+    expect(setFocusLock).toHaveBeenLastCalledWith(true);
+
+    await shellConsentService.denyCurrent();
+    await expect(promise).resolves.toBe(false);
+    // Queue drained → the hold is released.
+    expect(setFocusLock).toHaveBeenLastCalledWith(false);
   });
 
   it('approve grants trust and resolves true', async () => {


### PR DESCRIPTION
Accepting the brief launcher flash because it only affects fallback consent.
Removing it would either delay every background command or require a larger architectural change. The dialog is now reliably usable, and declaring binaries avoids both the prompt and flash.

### UI/UX trade-offs

| UX area | Current behavior | Consent-aware architecture |
| --- | --- | --- |
| Normal background commands | Launcher disappears immediately | Launcher may linger briefly while the worker acknowledges execution |
| Undeclared binary consent | Launcher flashes away and returns | Launcher remains stable and shows the dialog directly |
| Perceived speed | Consistently snappy | Slightly slower or variable, especially during worker cold starts |
| Predictability | Always hides immediately | Hide timing depends on what the command does |
| Focus | Brief flash/focus interruption on the fallback path | Focus remains stable, but the launcher may hold focus longer |
| Failure cases | Consent dialog can cause a flash | A failed acknowledgement could make the launcher appear temporarily stuck |
| Accessibility | Sudden disappearance and reappearance can be disorienting | More continuous and easier for keyboard or assistive-technology users |

The main trade-off is:

> Better UX for the rare consent fallback, but slightly less immediate and less consistent hiding for every background command.
