### PR TITLE
chore: release 0.1.1-43

### DIFF
--- a/asyar-launcher/package.json
+++ b/asyar-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asyar",
-  "version": "0.1.1-42",
+  "version": "0.1.1-43",
   "description": "A fast, open-source launcher for macOS, Windows, and Linux.",
   "type": "module",
   "scripts": {
@@ -39,7 +39,7 @@
     "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-store": "~2.4.2",
     "@tauri-apps/plugin-updater": "~2.10.0",
-    "asyar-sdk": "^4.7.0",
+    "asyar-sdk": "^4.8.0",
     "date-fns": "^4.1.0",
     "katex": "^0.16.45",
     "marked": "^17.0.5",

--- a/asyar-launcher/src-tauri/Cargo.lock
+++ b/asyar-launcher/src-tauri/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "asyar"
-version = "0.1.1-42"
+version = "0.1.1-43"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/asyar-launcher/src-tauri/Cargo.toml
+++ b/asyar-launcher/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asyar"
-version = "0.1.1-42"
+version = "0.1.1-43"
 description = "A fast, open-source launcher for macOS, Windows, and Linux."
 authors = ["Khoshbin Ali <xoshbin@gmail.com>"]
 license = "GPL-3.0-only"

--- a/asyar-launcher/src/built-in-features/create-extension/scaffoldService.ts
+++ b/asyar-launcher/src/built-in-features/create-extension/scaffoldService.ts
@@ -38,7 +38,7 @@ async function getLatestSdkVersion(): Promise<string> {
       return `^${output.stdout.trim()}`;
     }
   } catch {}
-  return '^4.7.0'; // Offline fallback
+  return '^4.8.0'; // Offline fallback
 }
 
 // ── Shared templates (all non-theme types) ──────────────────────────────────


### PR DESCRIPTION
Launcher release 0.1.1-43 (SDK 4.8.0). The tag already triggered the build; merge to land the bump on main.