### PR TITLE
fix(help): scroll selected topic into view on keyboard nav

### DIFF
--- a/asyar-launcher/src/built-in-features/help/DefaultView.svelte
+++ b/asyar-launcher/src/built-in-features/help/DefaultView.svelte
@@ -3,9 +3,21 @@
   import { LAUNCHER_SHORTCUTS } from '../../lib/keyboard/shortcutCatalog';
   import Icon from '../../components/base/Icon.svelte';
   import { getBuiltInIconName, isBuiltInIcon } from '../../lib/iconUtils';
+  import { scrollSelectedIntoView } from '../../lib/listScroll';
+
+  let listEl = $state<HTMLDivElement | undefined>();
+
+  // Keyboard selection lives in helpViewState; keep the selected topic row visible.
+  $effect(() => {
+    const index = helpViewState.selectedIndex;
+    if (!listEl || helpViewState.filtered.length === 0) return;
+    requestAnimationFrame(() => {
+      if (listEl) scrollSelectedIntoView(listEl, index);
+    });
+  });
 </script>
 
-<div class="help-view custom-scrollbar">
+<div class="help-view custom-scrollbar" bind:this={listEl}>
   <section class="cheat-sheet">
     <h2 class="section-title">Keyboard Shortcuts</h2>
     <ul class="shortcut-list">
@@ -24,7 +36,7 @@
     <h2 class="section-title">Feature Guides</h2>
     <ul class="topic-list">
       {#each helpViewState.filtered as topic, i}
-        <li class="topic-row" class:selected={i === helpViewState.selectedIndex}>
+        <li class="topic-row" class:selected={i === helpViewState.selectedIndex} data-index={i}>
           {#if isBuiltInIcon(topic.icon)}
             <Icon name={getBuiltInIconName(topic.icon)} />
           {/if}

--- a/asyar-launcher/src/built-in-features/help/DefaultView.test.ts
+++ b/asyar-launcher/src/built-in-features/help/DefaultView.test.ts
@@ -1,0 +1,56 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+
+const { scrollMock } = vi.hoisted(() => ({
+  scrollMock: vi.fn(),
+}));
+
+vi.mock('../../lib/listScroll', () => ({
+  scrollSelectedIntoView: (...args: unknown[]) => scrollMock(...args),
+}));
+
+import DefaultView from './DefaultView.svelte';
+import { helpViewState } from './helpState.svelte';
+
+function flushFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+describe('Help DefaultView keyboard scroll', () => {
+  beforeEach(() => {
+    scrollMock.mockClear();
+    helpViewState.reset();
+  });
+
+  afterEach(() => {
+    helpViewState.reset();
+  });
+
+  it('marks topic rows with data-index for scroll targeting', () => {
+    const { container } = render(DefaultView);
+    const rows = container.querySelectorAll('.topic-row[data-index]');
+    expect(rows.length).toBe(helpViewState.filtered.length);
+    expect(rows[0]?.getAttribute('data-index')).toBe('0');
+    if (rows.length > 1) {
+      expect(rows[1]?.getAttribute('data-index')).toBe('1');
+    }
+  });
+
+  it('scrolls the selected topic into view when the selection moves', async () => {
+    render(DefaultView);
+    await tick();
+    await flushFrame();
+    scrollMock.mockClear();
+
+    helpViewState.move(1);
+    await tick();
+    await flushFrame();
+
+    expect(scrollMock).toHaveBeenCalled();
+    const lastCall = scrollMock.mock.calls.at(-1);
+    expect(lastCall?.[1]).toBe(1);
+    expect(lastCall?.[0]).toBeInstanceOf(HTMLElement);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes keyboard navigation in the Help view so the selected feature-guide row stays visible while arrowing up/down.

The Help list already tracked `selectedIndex` in `helpViewState`, but the view never scrolled to match. Other list UIs (walkthrough, runs, action popup) already use the shared `scrollSelectedIntoView` helper.

## Changes

- Bind the scrollable Help root and call `scrollSelectedIntoView` from an `$effect` when selection changes
- Add `data-index` on topic rows so the helper can locate the selected element
- Add unit tests covering `data-index` markup and scroll-on-move behavior

## Test plan

- [x] `pnpm exec vitest run src/built-in-features/help/` (11 tests passed)
- [ ] Manual: open launcher → Help → arrow down past the visible area and confirm the selection stays in view; arrow up to the top and confirm the same

Fixes #687