### PR TITLE
feat(linux): add fast Wayland launcher summon path

### DIFF
--- a/.github/workflows/release-launcher.yml
+++ b/.github/workflows/release-launcher.yml
@@ -229,10 +229,14 @@ jobs:
           - arch: amd64
             runner: ubuntu-latest
             rust-target: x86_64-unknown-linux-gnu
+            summon-source: asyar-summon-x86_64-unknown-linux-gnu
+            summon-asset: asyar-summon_amd64
             artifact-name: linux-amd64-artifacts
           - arch: arm64
             runner: ubuntu-24.04-arm
             rust-target: aarch64-unknown-linux-gnu
+            summon-source: asyar-summon-aarch64-unknown-linux-gnu
+            summon-asset: asyar-summon_aarch64
             artifact-name: linux-arm64-artifacts
     defaults:
       run:
@@ -304,6 +308,10 @@ jobs:
           LDAI_UPDATE_INFORMATION: 'gh-releases-zsync|Xoshbin|asyar|latest|*${{ matrix.arch }}*.AppImage.zsync'
         run: |
           pnpm tauri build -v --target ${{ matrix.rust-target }}
+          SUMMON_SOURCE="src-tauri/binaries/${{ matrix.summon-source }}"
+          SUMMON_ASSET="src-tauri/target/${{ matrix.rust-target }}/release/${{ matrix.summon-asset }}"
+          test -x "$SUMMON_SOURCE"
+          install -m 0755 "$SUMMON_SOURCE" "$SUMMON_ASSET"
           cd src-tauri/target/${{ matrix.rust-target }}/release/bundle/appimage
           for f in *.AppImage; do
             if [ -f "$f" ] && [ ! -f "$f.zsync" ]; then
@@ -321,6 +329,7 @@ jobs:
             asyar-launcher/src-tauri/target/${{ matrix.rust-target }}/release/bundle/appimage/*.AppImage.sig
             asyar-launcher/src-tauri/target/${{ matrix.rust-target }}/release/bundle/appimage/*.zsync
             asyar-launcher/src-tauri/target/${{ matrix.rust-target }}/release/bundle/deb/*.deb
+            asyar-launcher/src-tauri/target/${{ matrix.rust-target }}/release/${{ matrix.summon-asset }}
 
   publish:
     needs: [build-macos, build-windows, build-linux]
@@ -369,6 +378,7 @@ jobs:
             artifacts/**/*.zsync
             artifacts/**/*.deb
             artifacts/**/*.zip
+            artifacts/**/asyar-summon_*
           draft: false
           prerelease: ${{ contains(github.event.inputs.tag || github.ref_name, '-') }}
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ brew install --cask asyar
 
 **Linux (Wayland) Shortcut Setup:**
 
-Wayland protocol security prevents background applications from intercepting global keyboard shortcuts directly. To summon or toggle Asyar on Wayland, bind your preferred shortcut in your desktop environment or window manager to execute `asyar`. Re-executing `asyar` automatically toggles the visibility of the already-running background instance:
+The Linux installer places the AppImage at `~/.local/bin/asyar` and a lightweight summon command beside it at `~/.local/bin/asyar-summon`. Wayland protocol security prevents background applications from intercepting global keyboard shortcuts directly, so bind your preferred shortcut in your desktop environment or window manager to execute `asyar-summon`:
 
-- **GNOME:** Open **Settings** → **Keyboard** → **View and Customize Shortcuts** → **Custom Shortcuts**, click **+**, set Name to `Asyar`, Command to `asyar`, and assign your shortcut (e.g. `Ctrl+Space` or `Super+Space`).
-- **KDE Plasma:** Open **System Settings** → **Shortcuts** → **Custom Shortcuts** (or **Command/URL**), add a new global shortcut for `asyar`, and set your trigger key (e.g. `Alt+Space` or `Meta+Space`).
-- **Hyprland:** Add `bind = ALT, SPACE, exec, asyar` to `~/.config/hypr/hyprland.conf`.
-- **Sway:** Add `bindsym Mod1+space exec asyar` to `~/.config/sway/config`.
+- **GNOME:** Open **Settings** → **Keyboard** → **View and Customize Shortcuts** → **Custom Shortcuts**, click **+**, set Name to `Asyar`, Command to `asyar-summon`, and assign your shortcut (e.g. `Ctrl+Space` or `Super+Space`).
+- **KDE Plasma:** Open **System Settings** → **Shortcuts** → **Custom Shortcuts** (or **Command/URL**), add a new global shortcut for `asyar-summon`, and set your trigger key (e.g. `Alt+Space` or `Meta+Space`).
+- **Hyprland:** Add `bind = ALT, SPACE, exec, asyar-summon` to `~/.config/hypr/hyprland.conf`.
+- **Sway:** Add `bindsym Mod1+space exec asyar-summon` to `~/.config/sway/config`.
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -59,6 +59,12 @@ pnpm run release <patch|minor|major|beta>
 
 > The Rust `SUPPORTED_SDK_VERSION` is **not** set by the release script — `src-tauri/build.rs` injects it at compile time from the local `asyar-sdk/package.json`, so it can never drift.
 
+Linux builds also publish the standalone summon helpers `asyar-summon_amd64`
+and `asyar-summon_aarch64`. `install.sh` installs the matching helper beside the
+AppImage, and re-running it refreshes both files. The versioned
+`org.asyar.Launcher1` interface and `--show-on-start` argument must remain
+backward compatible because the AppImage updater does not update the helper.
+
 ### Manual step after CI
 
 The tag triggers the build from the `release/vX.Y.Z` branch, so the installers always carry the correct version even before the PR is merged. After CI is green:

--- a/asyar-launcher/scripts/build-linux.mjs
+++ b/asyar-launcher/scripts/build-linux.mjs
@@ -1,0 +1,22 @@
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { provisionSummon } from './prepare-asyar-summon.mjs';
+
+const launcherDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+export function runLinuxBuild({ run = execFileSync, provision = provisionSummon } = {}) {
+  run('pnpm', ['build'], { cwd: launcherDir, stdio: 'inherit' });
+  provision();
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : undefined;
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  try {
+    runLinuxBuild();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Linux build preparation failed: ${message}`);
+    process.exitCode = 1;
+  }
+}

--- a/asyar-launcher/scripts/external-bin-provisioning.test.mjs
+++ b/asyar-launcher/scripts/external-bin-provisioning.test.mjs
@@ -2,19 +2,120 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { planSummonProvisioning } from './prepare-asyar-summon.mjs';
+import { runLinuxBuild } from './build-linux.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TAURI_CONF = resolve(__dirname, '..', 'src-tauri', 'tauri.conf.json');
+const TAURI_LINUX_CONF = resolve(__dirname, '..', 'src-tauri', 'tauri.linux.conf.json');
 
 // Sidecars (bun/uv/claude) are no longer build-time-bundled via Tauri
 // `externalBin` — they're downloaded on demand at first use by
 // `RuntimeManager`. This guards against that regressing: a binary declared
-// in `externalBin` without being provisioned fails every platform's build at
-// bundle time with "resource path 'binaries/<name>-<triple>' doesn't exist".
+// in `externalBin` without being provisioned fails the Tauri build with
+// "resource path 'binaries/<name>-<triple>' doesn't exist".
 describe('externalBin', () => {
-  it('declares no runtime binaries', () => {
+  it('declares no external binaries globally', () => {
     const conf = JSON.parse(readFileSync(TAURI_CONF, 'utf8'));
     const externalBin = conf.bundle?.externalBin ?? [];
     expect(externalBin).toEqual([]);
+  });
+
+  it('declares only the summon helper in the Linux platform config', () => {
+    const conf = JSON.parse(readFileSync(TAURI_LINUX_CONF, 'utf8'));
+
+    expect(conf.bundle?.externalBin).toEqual(['binaries/asyar-summon']);
+    expect(conf.build?.beforeBuildCommand).toBe('node scripts/build-linux.mjs');
+    expect(conf.build?.beforeBundleCommand).toBeUndefined();
+  });
+});
+
+describe('asyar-summon provisioning', () => {
+  const launcherDir = resolve(__dirname, '..');
+
+  it.each(['x86_64-unknown-linux-gnu', 'aarch64-unknown-linux-gnu'])(
+    'plans the target-suffixed binary for %s',
+    (targetTriple) => {
+      const plan = planSummonProvisioning(
+        {
+          TAURI_ENV_PLATFORM: 'linux',
+          TAURI_ENV_TARGET_TRIPLE: targetTriple,
+        },
+        launcherDir,
+      );
+
+      expect(plan.command).toBe('cargo');
+      expect(plan.args).toEqual([
+        'build',
+        '--release',
+        '--package',
+        'asyar-summon',
+        '--target',
+        targetTriple,
+      ]);
+      expect(plan.cwd).toBe(resolve(launcherDir, 'src-tauri'));
+      expect(plan.source).toBe(
+        resolve(launcherDir, 'src-tauri', 'target', targetTriple, 'release', 'asyar-summon'),
+      );
+      expect(plan.destination).toBe(
+        resolve(launcherDir, 'src-tauri', 'binaries', `asyar-summon-${targetTriple}`),
+      );
+    },
+  );
+
+  it('fails clearly when TAURI_ENV_TARGET_TRIPLE is missing', () => {
+    expect(() => planSummonProvisioning({ TAURI_ENV_PLATFORM: 'linux' }, launcherDir)).toThrow(
+      'TAURI_ENV_TARGET_TRIPLE',
+    );
+  });
+
+  it.each(['darwin', 'windows'])('rejects the %s platform', (platform) => {
+    expect(() =>
+      planSummonProvisioning(
+        {
+          TAURI_ENV_PLATFORM: platform,
+          TAURI_ENV_TARGET_TRIPLE: 'x86_64-unknown-linux-gnu',
+        },
+        launcherDir,
+      ),
+    ).toThrow(`unsupported platform: ${platform}`);
+  });
+
+  it('rejects unsupported Linux target triples', () => {
+    expect(() =>
+      planSummonProvisioning(
+        {
+          TAURI_ENV_PLATFORM: 'linux',
+          TAURI_ENV_TARGET_TRIPLE: 'x86_64-unknown-linux-musl',
+        },
+        launcherDir,
+      ),
+    ).toThrow('unsupported Linux target triple');
+  });
+});
+
+describe('Linux build wrapper', () => {
+  it('builds the launcher frontend before provisioning the helper', () => {
+    const calls = [];
+
+    runLinuxBuild({
+      run(command, args, options) {
+        calls.push({ command, args, cwd: options.cwd });
+      },
+      provision() {
+        calls.push({ provision: 'asyar-summon' });
+      },
+    });
+
+    expect(calls).toEqual([
+      {
+        command: 'pnpm',
+        args: ['build'],
+        cwd: resolve(__dirname, '..'),
+      },
+      { provision: 'asyar-summon' },
+    ]);
+    expect(calls.flatMap((call) => call.args ?? [])).not.toContain('tauri');
+    expect(calls).not.toContainEqual(expect.objectContaining({ command: 'node' }));
   });
 });

--- a/asyar-launcher/scripts/external-bin-provisioning.test.mjs
+++ b/asyar-launcher/scripts/external-bin-provisioning.test.mjs
@@ -8,6 +8,14 @@ import { runLinuxBuild } from './build-linux.mjs';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TAURI_CONF = resolve(__dirname, '..', 'src-tauri', 'tauri.conf.json');
 const TAURI_LINUX_CONF = resolve(__dirname, '..', 'src-tauri', 'tauri.linux.conf.json');
+const RELEASE_WORKFLOW = resolve(
+  __dirname,
+  '..',
+  '..',
+  '.github',
+  'workflows',
+  'release-launcher.yml',
+);
 
 // Sidecars (bun/uv/claude) are no longer build-time-bundled via Tauri
 // `externalBin` — they're downloaded on demand at first use by
@@ -117,5 +125,20 @@ describe('Linux build wrapper', () => {
     ]);
     expect(calls.flatMap((call) => call.args ?? [])).not.toContain('tauri');
     expect(calls).not.toContainEqual(expect.objectContaining({ command: 'node' }));
+  });
+});
+
+describe('standalone summon release assets', () => {
+  it.each([
+    ['x86_64-unknown-linux-gnu', 'asyar-summon-x86_64-unknown-linux-gnu', 'asyar-summon_amd64'],
+    ['aarch64-unknown-linux-gnu', 'asyar-summon-aarch64-unknown-linux-gnu', 'asyar-summon_aarch64'],
+  ])('keeps the source and public name together for %s', (target, source, asset) => {
+    const workflow = readFileSync(RELEASE_WORKFLOW, 'utf8');
+
+    expect(workflow).toMatch(
+      new RegExp(
+        `rust-target: ${target}\\n\\s+summon-source: ${source}\\n\\s+summon-asset: ${asset}`,
+      ),
+    );
   });
 });

--- a/asyar-launcher/scripts/prepare-asyar-summon.mjs
+++ b/asyar-launcher/scripts/prepare-asyar-summon.mjs
@@ -1,0 +1,74 @@
+import { chmodSync, copyFileSync, mkdirSync, renameSync, rmSync, statSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SUPPORTED_TARGETS = new Set(['x86_64-unknown-linux-gnu', 'aarch64-unknown-linux-gnu']);
+
+export function planSummonProvisioning(env, launcherDir) {
+  const platform = env.TAURI_ENV_PLATFORM;
+  if (platform !== 'linux') {
+    throw new Error(`unsupported platform: ${platform ?? '<missing>'}`);
+  }
+
+  const targetTriple = env.TAURI_ENV_TARGET_TRIPLE;
+  if (!targetTriple) {
+    throw new Error('TAURI_ENV_TARGET_TRIPLE is required');
+  }
+  if (!SUPPORTED_TARGETS.has(targetTriple)) {
+    throw new Error(`unsupported Linux target triple: ${targetTriple}`);
+  }
+
+  const tauriDir = resolve(launcherDir, 'src-tauri');
+  return {
+    command: 'cargo',
+    args: ['build', '--release', '--package', 'asyar-summon', '--target', targetTriple],
+    cwd: tauriDir,
+    source: resolve(tauriDir, 'target', targetTriple, 'release', 'asyar-summon'),
+    destination: resolve(tauriDir, 'binaries', `asyar-summon-${targetTriple}`),
+  };
+}
+
+export function provisionSummon(env = process.env) {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const launcherDir = resolve(scriptDir, '..');
+  const plan = planSummonProvisioning(env, launcherDir);
+
+  execFileSync(plan.command, plan.args, {
+    cwd: plan.cwd,
+    stdio: 'inherit',
+  });
+
+  let sourceStat;
+  try {
+    sourceStat = statSync(plan.source);
+  } catch (error) {
+    throw new Error(`built helper is missing: ${plan.source}`, {
+      cause: error,
+    });
+  }
+  if (!sourceStat.isFile()) {
+    throw new Error(`built helper is not a regular file: ${plan.source}`);
+  }
+
+  mkdirSync(dirname(plan.destination), { recursive: true });
+  const temporaryDestination = `${plan.destination}.${process.pid}.tmp`;
+  try {
+    copyFileSync(plan.source, temporaryDestination);
+    chmodSync(temporaryDestination, 0o755);
+    renameSync(temporaryDestination, plan.destination);
+  } finally {
+    rmSync(temporaryDestination, { force: true });
+  }
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : undefined;
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  try {
+    provisionSummon();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Failed to prepare asyar-summon: ${message}`);
+    process.exitCode = 1;
+  }
+}

--- a/asyar-launcher/src-tauri/Cargo.lock
+++ b/asyar-launcher/src-tauri/Cargo.lock
@@ -297,6 +297,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "asyar-summon"
+version = "0.1.0"
+dependencies = [
+ "zbus 4.4.0",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/asyar-launcher/src-tauri/Cargo.toml
+++ b/asyar-launcher/src-tauri/Cargo.toml
@@ -6,6 +6,11 @@ authors = ["Khoshbin Ali <xoshbin@gmail.com>"]
 license = "GPL-3.0-only"
 edition = "2021"
 
+[workspace]
+members = [".", "asyar-summon"]
+default-members = ["."]
+resolver = "2"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]

--- a/asyar-launcher/src-tauri/Cargo.toml
+++ b/asyar-launcher/src-tauri/Cargo.toml
@@ -11,6 +11,9 @@ members = [".", "asyar-summon"]
 default-members = ["."]
 resolver = "2"
 
+[profile.release.package.asyar-summon]
+strip = "symbols"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
@@ -23,6 +26,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 semver = "1"
+serde_json = "1"
 
 [dependencies]
 percent-encoding = "2.3"

--- a/asyar-launcher/src-tauri/asyar-summon/Cargo.toml
+++ b/asyar-launcher/src-tauri/asyar-summon/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "asyar-summon"
+version = "0.1.0"
+edition = "2021"
+license = "GPL-3.0-only"
+publish = false
+
+[target.'cfg(target_os = "linux")'.dependencies]
+zbus = { version = "=4.4.0", default-features = false, features = ["async-io"] }

--- a/asyar-launcher/src-tauri/asyar-summon/src/lib.rs
+++ b/asyar-launcher/src-tauri/asyar-summon/src/lib.rs
@@ -1,0 +1,376 @@
+use std::ffi::OsStr;
+use std::fmt;
+#[cfg(target_os = "linux")]
+use std::sync::mpsc;
+#[cfg(target_os = "linux")]
+use std::thread;
+#[cfg(target_os = "linux")]
+use std::time::Duration;
+
+#[cfg(target_os = "linux")]
+const CALL_TIMEOUT: Duration = Duration::from_millis(500);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Flavor {
+    Production,
+    Development,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Identity {
+    bus_name: &'static str,
+    object_path: &'static str,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SummonError {
+    InvalidArguments,
+    UnsupportedPlatform,
+    // Stage 4 may cold-start only for this variant. Bus, call, and timeout
+    // failures do not establish that another Asyar process is safe to spawn.
+    ServiceUnavailable,
+    BusUnavailable(String),
+    CallFailed(String),
+    TimedOut,
+}
+
+impl fmt::Display for SummonError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidArguments => write!(formatter, "usage: asyar-summon [--dev]"),
+            Self::UnsupportedPlatform => {
+                write!(formatter, "asyar-summon is only supported on Linux")
+            }
+            Self::ServiceUnavailable => write!(formatter, "Asyar launcher service is unavailable"),
+            Self::BusUnavailable(error) => {
+                write!(formatter, "session bus is unavailable: {error}")
+            }
+            Self::CallFailed(error) => write!(formatter, "launcher request failed: {error}"),
+            Self::TimedOut => write!(formatter, "launcher request timed out"),
+        }
+    }
+}
+
+fn parse_args<I, S>(args: I) -> Result<Flavor, SummonError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let arguments = args.into_iter().collect::<Vec<_>>();
+    match arguments.as_slice() {
+        [] => Ok(Flavor::Production),
+        [argument] if argument.as_ref() == OsStr::new("--dev") => Ok(Flavor::Development),
+        _ => Err(SummonError::InvalidArguments),
+    }
+}
+
+fn identity(flavor: Flavor) -> Identity {
+    match flavor {
+        Flavor::Production => Identity {
+            bus_name: "org.asyar.app.Launcher",
+            object_path: "/org/asyar/app/Launcher",
+        },
+        Flavor::Development => Identity {
+            bus_name: "org.asyar.dev.Launcher",
+            object_path: "/org/asyar/dev/Launcher",
+        },
+    }
+}
+
+pub fn run<I, S>(args: I) -> Result<(), SummonError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    summon(parse_args(args)?)
+}
+
+fn summon(flavor: Flavor) -> Result<(), SummonError> {
+    #[cfg(target_os = "linux")]
+    {
+        summon_linux(flavor)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let selected_identity = identity(flavor);
+        let _ = (selected_identity.bus_name, selected_identity.object_path);
+        Err(SummonError::UnsupportedPlatform)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn summon_linux(flavor: Flavor) -> Result<(), SummonError> {
+    let (sender, receiver) = mpsc::sync_channel(1);
+    thread::Builder::new()
+        .name("asyar-summon-dbus".to_string())
+        .spawn(move || {
+            let _ = sender.send(call_launcher(flavor));
+        })
+        .map_err(|error| SummonError::CallFailed(error.to_string()))?;
+
+    match receiver.recv_timeout(CALL_TIMEOUT) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(SummonError::TimedOut),
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(SummonError::CallFailed(
+            "launcher request worker stopped unexpectedly".to_string(),
+        )),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn call_launcher(flavor: Flavor) -> Result<(), SummonError> {
+    let identity = identity(flavor);
+    let connection = zbus::blocking::Connection::session()
+        .map_err(|error| SummonError::BusUnavailable(error.to_string()))?;
+    let proxy = zbus::blocking::Proxy::new(
+        &connection,
+        identity.bus_name,
+        identity.object_path,
+        "org.asyar.Launcher1",
+    )
+    .map_err(|error| SummonError::CallFailed(error.to_string()))?;
+
+    proxy
+        .call::<_, _, ()>("Toggle", &())
+        .map_err(classify_call_error)
+}
+
+#[cfg(target_os = "linux")]
+fn classify_call_error(error: zbus::Error) -> SummonError {
+    let service_unavailable = match &error {
+        zbus::Error::MethodError(name, _, _) => matches!(
+            name.as_str(),
+            "org.freedesktop.DBus.Error.ServiceUnknown"
+                | "org.freedesktop.DBus.Error.NameHasNoOwner"
+        ),
+        zbus::Error::FDO(error) => matches!(
+            error.as_ref(),
+            zbus::fdo::Error::ServiceUnknown(_) | zbus::fdo::Error::NameHasNoOwner(_)
+        ),
+        _ => false,
+    };
+
+    if service_unavailable {
+        SummonError::ServiceUnavailable
+    } else {
+        SummonError::CallFailed(error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+    #[cfg(target_os = "linux")]
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    #[cfg(target_os = "linux")]
+    use std::sync::Arc;
+    #[cfg(target_os = "linux")]
+    use std::thread;
+
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    struct FakeLauncher {
+        toggles: Arc<AtomicUsize>,
+        delay: Duration,
+    }
+
+    #[cfg(target_os = "linux")]
+    #[zbus::interface(name = "org.asyar.Launcher1")]
+    impl FakeLauncher {
+        fn toggle(&self) {
+            thread::sleep(self.delay);
+            self.toggles.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    struct FailingLauncher;
+
+    #[cfg(target_os = "linux")]
+    #[zbus::interface(name = "org.asyar.Launcher1")]
+    impl FailingLauncher {
+        fn toggle(&self) -> zbus::fdo::Result<()> {
+            Err(zbus::fdo::Error::Failed(
+                "resident rejected launcher request".to_string(),
+            ))
+        }
+    }
+
+    #[test]
+    fn no_arguments_selects_production() {
+        assert_eq!(parse_args(Vec::<String>::new()), Ok(Flavor::Production));
+    }
+
+    #[test]
+    fn dev_argument_selects_development() {
+        assert_eq!(parse_args(["--dev"]), Ok(Flavor::Development));
+    }
+
+    #[test]
+    fn unknown_unicode_argument_is_rejected() {
+        assert_eq!(
+            parse_args([OsString::from("--développement")]),
+            Err(SummonError::InvalidArguments)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_argument_is_rejected() {
+        use std::os::unix::ffi::OsStringExt;
+
+        assert_eq!(
+            parse_args([OsString::from_vec(vec![0xff])]),
+            Err(SummonError::InvalidArguments)
+        );
+    }
+
+    #[test]
+    fn unknown_argument_is_rejected() {
+        assert_eq!(
+            parse_args(["--unknown"]),
+            Err(SummonError::InvalidArguments)
+        );
+    }
+
+    #[test]
+    fn multiple_arguments_are_rejected() {
+        assert_eq!(
+            parse_args(["--dev", "--unknown"]),
+            Err(SummonError::InvalidArguments)
+        );
+    }
+
+    #[test]
+    fn duplicate_dev_arguments_are_rejected() {
+        assert_eq!(
+            parse_args(["--dev", "--dev"]),
+            Err(SummonError::InvalidArguments)
+        );
+    }
+
+    #[test]
+    fn multiple_unsupported_arguments_are_rejected() {
+        assert_eq!(
+            parse_args(["--unknown", "value"]),
+            Err(SummonError::InvalidArguments)
+        );
+    }
+
+    #[test]
+    fn unsupported_platform_error_is_concise() {
+        assert_eq!(
+            SummonError::UnsupportedPlatform.to_string(),
+            "asyar-summon is only supported on Linux"
+        );
+    }
+
+    #[test]
+    fn identities_match_the_launcher_service() {
+        assert_eq!(
+            identity(Flavor::Production),
+            Identity {
+                bus_name: "org.asyar.app.Launcher",
+                object_path: "/org/asyar/app/Launcher",
+            }
+        );
+        assert_eq!(
+            identity(Flavor::Development),
+            Identity {
+                bus_name: "org.asyar.dev.Launcher",
+                object_path: "/org/asyar/dev/Launcher",
+            }
+        );
+    }
+
+    #[test]
+    #[ignore = "requires an isolated D-Bus session"]
+    #[cfg(target_os = "linux")]
+    fn isolated_session_routes_flavors_classifies_unavailable_and_times_out() {
+        assert_eq!(
+            run(Vec::<String>::new()),
+            Err(SummonError::ServiceUnavailable)
+        );
+
+        let (production_service, production_toggles) =
+            start_fake_service(Flavor::Production, Duration::ZERO);
+        let (development_service, development_toggles) =
+            start_fake_service(Flavor::Development, Duration::ZERO);
+
+        run(Vec::<String>::new()).unwrap();
+        assert_eq!(production_toggles.load(Ordering::SeqCst), 1);
+        assert_eq!(development_toggles.load(Ordering::SeqCst), 0);
+
+        run(["--dev"]).unwrap();
+        assert_eq!(production_toggles.load(Ordering::SeqCst), 1);
+        assert_eq!(development_toggles.load(Ordering::SeqCst), 1);
+
+        let development_identity = identity(Flavor::Development);
+        assert!(development_service
+            .release_name(development_identity.bus_name)
+            .unwrap());
+        let _failing_service = start_failing_service(Flavor::Development);
+        assert!(matches!(run(["--dev"]), Err(SummonError::CallFailed(_))));
+
+        let production_identity = identity(Flavor::Production);
+        assert!(production_service
+            .release_name(production_identity.bus_name)
+            .unwrap());
+        let (_slow_service, _) =
+            start_fake_service(Flavor::Production, CALL_TIMEOUT.saturating_mul(4));
+
+        assert_eq!(summon(Flavor::Production), Err(SummonError::TimedOut));
+    }
+
+    #[cfg(target_os = "linux")]
+    fn start_fake_service(
+        flavor: Flavor,
+        delay: Duration,
+    ) -> (zbus::blocking::Connection, Arc<AtomicUsize>) {
+        let identity = identity(flavor);
+        let toggles = Arc::new(AtomicUsize::new(0));
+        let connection = zbus::blocking::connection::Builder::session()
+            .unwrap()
+            .serve_at(
+                identity.object_path,
+                FakeLauncher {
+                    toggles: toggles.clone(),
+                    delay,
+                },
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+        let reply = connection
+            .request_name_with_flags(
+                identity.bus_name,
+                zbus::fdo::RequestNameFlags::DoNotQueue.into(),
+            )
+            .unwrap();
+        assert_eq!(reply, zbus::fdo::RequestNameReply::PrimaryOwner);
+
+        (connection, toggles)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn start_failing_service(flavor: Flavor) -> zbus::blocking::Connection {
+        let identity = identity(flavor);
+        let connection = zbus::blocking::connection::Builder::session()
+            .unwrap()
+            .serve_at(identity.object_path, FailingLauncher)
+            .unwrap()
+            .build()
+            .unwrap();
+        let reply = connection
+            .request_name_with_flags(
+                identity.bus_name,
+                zbus::fdo::RequestNameFlags::DoNotQueue.into(),
+            )
+            .unwrap();
+        assert_eq!(reply, zbus::fdo::RequestNameReply::PrimaryOwner);
+
+        connection
+    }
+}

--- a/asyar-launcher/src-tauri/asyar-summon/src/lib.rs
+++ b/asyar-launcher/src-tauri/asyar-summon/src/lib.rs
@@ -1,6 +1,14 @@
 use std::ffi::OsStr;
 use std::fmt;
 #[cfg(target_os = "linux")]
+use std::fs;
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::PermissionsExt;
+#[cfg(target_os = "linux")]
+use std::path::{Path, PathBuf};
+#[cfg(target_os = "linux")]
+use std::process::{Command, Stdio};
+#[cfg(target_os = "linux")]
 use std::sync::mpsc;
 #[cfg(target_os = "linux")]
 use std::thread;
@@ -32,6 +40,7 @@ pub enum SummonError {
     BusUnavailable(String),
     CallFailed(String),
     TimedOut,
+    LaunchFailed(String),
 }
 
 impl fmt::Display for SummonError {
@@ -47,6 +56,7 @@ impl fmt::Display for SummonError {
             }
             Self::CallFailed(error) => write!(formatter, "launcher request failed: {error}"),
             Self::TimedOut => write!(formatter, "launcher request timed out"),
+            Self::LaunchFailed(error) => write!(formatter, "failed to start Asyar: {error}"),
         }
     }
 }
@@ -82,7 +92,25 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    summon(parse_args(args)?)
+    run_with(args, summon, cold_start)
+}
+
+fn run_with<I, S, Invoke, ColdStart>(
+    args: I,
+    invoke: Invoke,
+    cold_start: ColdStart,
+) -> Result<(), SummonError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+    Invoke: FnOnce(Flavor) -> Result<(), SummonError>,
+    ColdStart: FnOnce() -> Result<(), SummonError>,
+{
+    let flavor = parse_args(args)?;
+    match invoke(flavor) {
+        Err(SummonError::ServiceUnavailable) => cold_start(),
+        result => result,
+    }
 }
 
 fn summon(flavor: Flavor) -> Result<(), SummonError> {
@@ -158,9 +186,90 @@ fn classify_call_error(error: zbus::Error) -> SummonError {
     }
 }
 
+#[cfg(target_os = "linux")]
+#[derive(Debug, PartialEq, Eq)]
+enum LaunchTarget {
+    Sibling(PathBuf),
+    Path,
+}
+
+#[cfg(target_os = "linux")]
+fn cold_start() -> Result<(), SummonError> {
+    let current_exe = std::env::current_exe().ok();
+    let target = discover_launch_target(current_exe.as_deref());
+    spawn_cold_start(&target)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn cold_start() -> Result<(), SummonError> {
+    Err(SummonError::UnsupportedPlatform)
+}
+
+#[cfg(target_os = "linux")]
+fn discover_launch_target(current_exe: Option<&Path>) -> LaunchTarget {
+    let sibling = current_exe
+        .and_then(Path::parent)
+        .map(|directory| directory.join("asyar"));
+
+    match (sibling, current_exe) {
+        (Some(candidate), Some(helper)) if is_valid_sibling(&candidate, helper) => {
+            LaunchTarget::Sibling(candidate)
+        }
+        _ => LaunchTarget::Path,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn is_valid_sibling(candidate: &Path, helper: &Path) -> bool {
+    let Ok(metadata) = fs::metadata(candidate) else {
+        return false;
+    };
+    if !metadata.is_file() || metadata.permissions().mode() & 0o111 == 0 {
+        return false;
+    }
+
+    !matches!(
+        (fs::canonicalize(candidate), fs::canonicalize(helper)),
+        (Ok(candidate), Ok(helper)) if candidate == helper
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn cold_start_command(target: &LaunchTarget) -> Command {
+    let mut command = match target {
+        LaunchTarget::Sibling(path) => Command::new(path),
+        LaunchTarget::Path => Command::new("asyar"),
+    };
+    command
+        .arg("--show-on-start")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    command
+}
+
+#[cfg(target_os = "linux")]
+fn spawn_cold_start(target: &LaunchTarget) -> Result<(), SummonError> {
+    cold_start_command(target)
+        .spawn()
+        .map(|_| ())
+        .map_err(|error| {
+            let target = match target {
+                LaunchTarget::Sibling(path) => path.display().to_string(),
+                LaunchTarget::Path => "asyar from PATH".to_string(),
+            };
+            SummonError::LaunchFailed(format!("{target}: {error}"))
+        })
+}
+
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
     use std::ffi::OsString;
+    #[cfg(target_os = "linux")]
+    use std::fs;
+    #[cfg(target_os = "linux")]
+    use std::path::PathBuf;
     #[cfg(target_os = "linux")]
     use std::sync::atomic::{AtomicUsize, Ordering};
     #[cfg(target_os = "linux")]
@@ -286,33 +395,270 @@ mod tests {
     }
 
     #[test]
+    fn warm_success_does_not_attempt_cold_launch() {
+        let launches = Cell::new(0);
+
+        let result = run_with(
+            Vec::<OsString>::new(),
+            |_| Ok(()),
+            || {
+                launches.set(launches.get() + 1);
+                Ok(())
+            },
+        );
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(launches.get(), 0);
+    }
+
+    #[test]
+    fn service_unavailable_attempts_cold_launch() {
+        let launches = Cell::new(0);
+
+        let result = run_with(
+            Vec::<OsString>::new(),
+            |_| Err(SummonError::ServiceUnavailable),
+            || {
+                launches.set(launches.get() + 1);
+                Ok(())
+            },
+        );
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(launches.get(), 1);
+    }
+
+    #[test]
+    fn unsafe_failures_never_attempt_cold_launch() {
+        for error in [
+            SummonError::TimedOut,
+            SummonError::CallFailed("failed".to_string()),
+            SummonError::BusUnavailable("unavailable".to_string()),
+            SummonError::UnsupportedPlatform,
+            SummonError::LaunchFailed("failed".to_string()),
+        ] {
+            let launches = Cell::new(0);
+            let result = run_with(
+                Vec::<OsString>::new(),
+                |_| Err(error),
+                || {
+                    launches.set(launches.get() + 1);
+                    Ok(())
+                },
+            );
+
+            assert!(result.is_err());
+            assert_eq!(launches.get(), 0);
+        }
+    }
+
+    #[test]
+    fn invalid_arguments_do_not_invoke_or_launch() {
+        let invokes = Cell::new(0);
+        let launches = Cell::new(0);
+
+        let result = run_with(
+            [OsString::from("--unknown")],
+            |_| {
+                invokes.set(invokes.get() + 1);
+                Ok(())
+            },
+            || {
+                launches.set(launches.get() + 1);
+                Ok(())
+            },
+        );
+
+        assert_eq!(result, Err(SummonError::InvalidArguments));
+        assert_eq!(invokes.get(), 0);
+        assert_eq!(launches.get(), 0);
+    }
+
+    #[test]
+    fn cold_launch_failure_is_returned() {
+        let result = run_with(
+            Vec::<OsString>::new(),
+            |_| Err(SummonError::ServiceUnavailable),
+            || Err(SummonError::LaunchFailed("not found".to_string())),
+        );
+
+        assert_eq!(
+            result,
+            Err(SummonError::LaunchFailed("not found".to_string()))
+        );
+    }
+
+    #[test]
+    fn two_sequential_cold_requests_may_each_request_an_idempotent_show() {
+        let launches = Cell::new(0);
+
+        for _ in 0..2 {
+            run_with(
+                Vec::<OsString>::new(),
+                |_| Err(SummonError::ServiceUnavailable),
+                || {
+                    launches.set(launches.get() + 1);
+                    Ok(())
+                },
+            )
+            .unwrap();
+        }
+
+        assert_eq!(launches.get(), 2);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn valid_sibling_executable_wins() {
+        let fixture = ExecutableFixture::new(true);
+
+        assert_eq!(
+            discover_launch_target(Some(&fixture.helper)),
+            LaunchTarget::Sibling(fixture.sibling.clone())
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn absent_sibling_selects_path_fallback() {
+        let fixture = ExecutableFixture::new(false);
+
+        assert_eq!(
+            discover_launch_target(Some(&fixture.helper)),
+            LaunchTarget::Path
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn non_executable_sibling_selects_path_fallback() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let fixture = ExecutableFixture::new(true);
+        fs::set_permissions(&fixture.sibling, fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert_eq!(
+            discover_launch_target(Some(&fixture.helper)),
+            LaunchTarget::Path
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn sibling_resolving_to_helper_selects_path_fallback() {
+        use std::os::unix::fs::symlink;
+
+        let fixture = ExecutableFixture::new(false);
+        symlink(&fixture.helper, &fixture.sibling).unwrap();
+
+        assert_eq!(
+            discover_launch_target(Some(&fixture.helper)),
+            LaunchTarget::Path
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn cold_commands_use_exact_show_argument() {
+        let fixture = ExecutableFixture::new(true);
+
+        for (target, expected_program) in [
+            (LaunchTarget::Path, OsStr::new("asyar")),
+            (
+                LaunchTarget::Sibling(fixture.sibling.clone()),
+                fixture.sibling.as_os_str(),
+            ),
+        ] {
+            let command = cold_start_command(&target);
+            assert_eq!(command.get_program(), expected_program);
+            assert_eq!(
+                command.get_args().collect::<Vec<_>>(),
+                vec![OsStr::new("--show-on-start")]
+            );
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn cold_child_standard_streams_are_detached() {
+        let fixture = ExecutableFixture::new(true);
+        fs::write(&fixture.sibling, b"#!/bin/sh\nsleep 5\n").unwrap();
+
+        let mut command = cold_start_command(&LaunchTarget::Sibling(fixture.sibling.clone()));
+        let mut child = command.spawn().unwrap();
+        let file_descriptors = (0..=2)
+            .map(|descriptor| {
+                fs::read_link(format!("/proc/{}/fd/{descriptor}", child.id())).unwrap()
+            })
+            .collect::<Vec<_>>();
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert_eq!(file_descriptors, vec![PathBuf::from("/dev/null"); 3]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn missing_explicit_launch_target_returns_launch_failed() {
+        let target =
+            LaunchTarget::Sibling(PathBuf::from("/definitely/missing/asyar-stage-four-test"));
+
+        assert!(matches!(
+            spawn_cold_start(&target),
+            Err(SummonError::LaunchFailed(_))
+        ));
+    }
+
+    #[test]
     #[ignore = "requires an isolated D-Bus session"]
     #[cfg(target_os = "linux")]
     fn isolated_session_routes_flavors_classifies_unavailable_and_times_out() {
+        let fallback_attempts = Cell::new(0);
         assert_eq!(
-            run(Vec::<String>::new()),
-            Err(SummonError::ServiceUnavailable)
+            run_with(Vec::<OsString>::new(), summon, || {
+                fallback_attempts.set(fallback_attempts.get() + 1);
+                Ok(())
+            }),
+            Ok(())
         );
+        assert_eq!(fallback_attempts.get(), 1);
 
         let (production_service, production_toggles) =
             start_fake_service(Flavor::Production, Duration::ZERO);
         let (development_service, development_toggles) =
             start_fake_service(Flavor::Development, Duration::ZERO);
 
-        run(Vec::<String>::new()).unwrap();
+        run_with(Vec::<OsString>::new(), summon, || {
+            fallback_attempts.set(fallback_attempts.get() + 1);
+            Ok(())
+        })
+        .unwrap();
         assert_eq!(production_toggles.load(Ordering::SeqCst), 1);
         assert_eq!(development_toggles.load(Ordering::SeqCst), 0);
+        assert_eq!(fallback_attempts.get(), 1);
 
-        run(["--dev"]).unwrap();
+        run_with(["--dev"], summon, || {
+            fallback_attempts.set(fallback_attempts.get() + 1);
+            Ok(())
+        })
+        .unwrap();
         assert_eq!(production_toggles.load(Ordering::SeqCst), 1);
         assert_eq!(development_toggles.load(Ordering::SeqCst), 1);
+        assert_eq!(fallback_attempts.get(), 1);
 
         let development_identity = identity(Flavor::Development);
         assert!(development_service
             .release_name(development_identity.bus_name)
             .unwrap());
         let _failing_service = start_failing_service(Flavor::Development);
-        assert!(matches!(run(["--dev"]), Err(SummonError::CallFailed(_))));
+        assert!(matches!(
+            run_with(["--dev"], summon, || {
+                fallback_attempts.set(fallback_attempts.get() + 1);
+                Ok(())
+            }),
+            Err(SummonError::CallFailed(_))
+        ));
+        assert_eq!(fallback_attempts.get(), 1);
 
         let production_identity = identity(Flavor::Production);
         assert!(production_service
@@ -321,7 +667,14 @@ mod tests {
         let (_slow_service, _) =
             start_fake_service(Flavor::Production, CALL_TIMEOUT.saturating_mul(4));
 
-        assert_eq!(summon(Flavor::Production), Err(SummonError::TimedOut));
+        assert_eq!(
+            run_with(Vec::<OsString>::new(), summon, || {
+                fallback_attempts.set(fallback_attempts.get() + 1);
+                Ok(())
+            }),
+            Err(SummonError::TimedOut)
+        );
+        assert_eq!(fallback_attempts.get(), 1);
     }
 
     #[cfg(target_os = "linux")]
@@ -373,4 +726,49 @@ mod tests {
 
         connection
     }
+
+    #[cfg(target_os = "linux")]
+    struct ExecutableFixture {
+        directory: PathBuf,
+        helper: PathBuf,
+        sibling: PathBuf,
+    }
+
+    #[cfg(target_os = "linux")]
+    impl ExecutableFixture {
+        fn new(create_sibling: bool) -> Self {
+            use std::os::unix::fs::PermissionsExt;
+
+            let directory = std::env::temp_dir().join(format!(
+                "asyar-summon-stage4-{}-{}",
+                std::process::id(),
+                TEST_FIXTURE_ID.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir(&directory).unwrap();
+            let helper = directory.join("asyar-summon");
+            fs::write(&helper, b"helper").unwrap();
+            fs::set_permissions(&helper, fs::Permissions::from_mode(0o755)).unwrap();
+            let sibling = directory.join("asyar");
+            if create_sibling {
+                fs::write(&sibling, b"asyar").unwrap();
+                fs::set_permissions(&sibling, fs::Permissions::from_mode(0o755)).unwrap();
+            }
+
+            Self {
+                directory,
+                helper,
+                sibling,
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    impl Drop for ExecutableFixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.directory);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    static TEST_FIXTURE_ID: AtomicUsize = AtomicUsize::new(0);
 }

--- a/asyar-launcher/src-tauri/asyar-summon/src/main.rs
+++ b/asyar-launcher/src-tauri/asyar-summon/src/main.rs
@@ -1,0 +1,11 @@
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    match asyar_summon::run(std::env::args_os().skip(1)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("asyar-summon: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/asyar-launcher/src-tauri/binaries/README.md
+++ b/asyar-launcher/src-tauri/binaries/README.md
@@ -1,4 +1,11 @@
-# Local dev-only runtime binaries
+# External and local-development binaries
+
+Linux release bundling automatically builds `asyar-summon` and stages it here
+with its Rust target-triple suffix. Tauri packages that generated executable as
+`asyar-summon`; the staged file remains gitignored.
+
+The runtime binaries described below remain local-development conveniences and
+are not bundled.
 
 Asyar no longer bundles `bun`, `uv`, or `claude` at build time — they're
 downloaded on demand at runtime by `RuntimeManager`
@@ -29,9 +36,8 @@ manually, named with the Rust target triple suffix:
 | Windows x86_64 | `-x86_64-pc-windows-msvc.exe`  |
 | Windows arm64  | `-aarch64-pc-windows-msvc.exe` |
 
-e.g. `bun-aarch64-apple-darwin`. This is purely a local convenience — nothing
-populates this directory automatically, and it is not part of any shipped
-build (`tauri.conf.json` no longer declares `externalBin`).
+e.g. `bun-aarch64-apple-darwin`. This is purely a local convenience. The global
+`tauri.conf.json` does not declare these runtime binaries as `externalBin`.
 
 ## Why these runtimes?
 

--- a/asyar-launcher/src-tauri/build.rs
+++ b/asyar-launcher/src-tauri/build.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 fn main() {
     let base_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
 
+    omit_missing_linux_external_binary(&base_dir);
+
     // Expose the build-time target triple to the crate so process.rs can locate
     // the `tauri dev` sidecar/binary layout (`binaries/<name>-<triple>`). Baked
     // at compile time; in a shipped binary the production resource paths match
@@ -146,6 +148,54 @@ fn main() {
             .windows_attributes(tauri_build::WindowsAttributes::new_without_app_manifest());
     }
     tauri_build::try_build(attributes).expect("failed to run tauri-build");
+}
+
+/// Direct Cargo operations do not run Tauri's before-build hook. Suppress the
+/// Linux-only sidecar when its target-specific staged file is absent; a Tauri
+/// build provisions that file first and therefore preserves the sidecar in
+/// both debug and release builds.
+fn omit_missing_linux_external_binary(base_dir: &std::path::Path) {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("linux") {
+        return;
+    }
+
+    let target = std::env::var("TARGET").expect("TARGET env var not set");
+    if !matches!(
+        target.as_str(),
+        "x86_64-unknown-linux-gnu" | "aarch64-unknown-linux-gnu"
+    ) {
+        return;
+    }
+
+    let staged_helper = base_dir
+        .join("binaries")
+        .join(format!("asyar-summon-{target}"));
+    println!("cargo:rerun-if-changed={}", staged_helper.display());
+    if staged_helper.is_file() {
+        return;
+    }
+
+    let mut overlay = std::env::var("TAURI_CONFIG")
+        .map(|value| serde_json::from_str(&value).expect("TAURI_CONFIG must be valid JSON"))
+        .unwrap_or_else(|_| serde_json::json!({}));
+    let overlay = overlay
+        .as_object_mut()
+        .expect("TAURI_CONFIG must be a JSON object");
+    let bundle = overlay
+        .entry("bundle")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .expect("TAURI_CONFIG bundle must be a JSON object");
+    // The Linux platform config currently declares only asyar-summon, enforced
+    // by external-bin-provisioning.test.mjs. JSON Merge Patch replaces arrays,
+    // so an empty overlay is the narrow simple option until another sidecar is
+    // deliberately added to that config.
+    bundle.insert("externalBin".into(), serde_json::json!([]));
+
+    std::env::set_var(
+        "TAURI_CONFIG",
+        serde_json::to_string(&overlay).expect("TAURI_CONFIG overlay must serialize"),
+    );
 }
 
 /// Recursively copy the capability spec tree, skipping dev-only `*.test.ts`

--- a/asyar-launcher/src-tauri/src/commands/shortcuts.rs
+++ b/asyar-launcher/src-tauri/src/commands/shortcuts.rs
@@ -3,6 +3,7 @@
 //! Handles registering, unregistering, pausing, and persisting shortcuts.
 
 use crate::error::AppError;
+use crate::launcher::LauncherAction;
 use crate::AppState;
 use crate::SPOTLIGHT_LABEL;
 use log::info;
@@ -501,18 +502,21 @@ pub fn toggle_launcher(app: &tauri::AppHandle) {
         // Branch on the logical flag, NOT panel.is_visible(): a parked panel
         // is ordered in (isVisible == true) even though the user perceives it
         // as hidden, so the NSWindow check would make the toggle hide-only.
-        if state.asyar_visible.load(Ordering::Relaxed) {
+        if !launcher_visibility_after(
+            LauncherAction::Toggle,
+            state.asyar_visible.load(Ordering::Relaxed),
+        ) {
             state.asyar_visible.store(false, Ordering::Relaxed);
             crate::platform::macos::park_launcher_panel(&window, &panel);
         } else {
-            state.asyar_visible.store(true, Ordering::Relaxed);
-            crate::platform::macos::reveal_launcher_panel(&window, &panel);
+            reveal_launcher(&state, &window, &panel);
         }
     }
 
     #[cfg(not(target_os = "macos"))]
     {
-        if window.is_visible().unwrap_or(false) {
+        let currently_visible = window.is_visible().unwrap_or(false);
+        if !launcher_visibility_after(LauncherAction::Toggle, currently_visible) {
             state.asyar_visible.store(false, Ordering::Relaxed);
             let _ = window.hide();
             #[cfg(target_os = "windows")]
@@ -521,21 +525,80 @@ pub fn toggle_launcher(app: &tauri::AppHandle) {
             }
         } else {
             #[cfg(target_os = "windows")]
+            if should_capture_foreground(LauncherAction::Toggle, currently_visible) {
+                if let Ok(mut hwnd) = state.previous_hwnd.lock() {
+                    *hwnd = crate::platform::windows::capture_foreground_window();
+                }
+            }
+            reveal_launcher(&state, &window);
+        }
+    }
+}
+
+/// Reveals and focuses the launcher without hiding it when it is already visible.
+pub(crate) fn show_spotlight_launcher(app: &tauri::AppHandle) {
+    let state = app.state::<AppState>();
+    let Some(window) = app.get_webview_window(SPOTLIGHT_LABEL) else {
+        log::warn!("[show_spotlight_launcher] no window labelled {SPOTLIGHT_LABEL}");
+        return;
+    };
+
+    #[cfg(target_os = "macos")]
+    {
+        use tauri_nspanel::ManagerExt;
+        let Ok(panel) = app.get_webview_panel(SPOTLIGHT_LABEL) else {
+            log::warn!("[show_spotlight_launcher] no panel labelled {SPOTLIGHT_LABEL}");
+            return;
+        };
+        reveal_launcher(&state, &window, &panel);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        #[cfg(target_os = "windows")]
+        if should_capture_foreground(LauncherAction::Show, window.is_visible().unwrap_or(false)) {
             if let Ok(mut hwnd) = state.previous_hwnd.lock() {
                 *hwnd = crate::platform::windows::capture_foreground_window();
             }
-            state.asyar_visible.store(true, Ordering::Relaxed);
-            #[cfg(target_os = "windows")]
-            let _ = crate::platform::windows::setup_spotlight_window(&window);
-            #[cfg(target_os = "linux")]
-            let _ = crate::platform::linux::setup_spotlight_window(&window);
-
-            let _ = window.show();
-            let _ = window.set_focus();
-            #[cfg(target_os = "linux")]
-            crate::mark_launcher_shown(&state);
         }
+        reveal_launcher(&state, &window);
     }
+}
+
+#[cfg(target_os = "macos")]
+fn reveal_launcher(
+    state: &tauri::State<'_, AppState>,
+    window: &tauri::WebviewWindow,
+    panel: &tauri_nspanel::Panel,
+) {
+    state.asyar_visible.store(true, Ordering::Relaxed);
+    crate::platform::macos::reveal_launcher_panel(window, panel);
+}
+
+#[cfg(not(target_os = "macos"))]
+fn reveal_launcher(state: &tauri::State<'_, AppState>, window: &tauri::WebviewWindow) {
+    state.asyar_visible.store(true, Ordering::Relaxed);
+    #[cfg(target_os = "windows")]
+    let _ = crate::platform::windows::setup_spotlight_window(window);
+    #[cfg(target_os = "linux")]
+    let _ = crate::platform::linux::setup_spotlight_window(window);
+
+    let _ = window.show();
+    let _ = window.set_focus();
+    #[cfg(target_os = "linux")]
+    crate::mark_launcher_shown(state);
+}
+
+fn launcher_visibility_after(action: LauncherAction, currently_visible: bool) -> bool {
+    match action {
+        LauncherAction::Show => true,
+        LauncherAction::Toggle => !currently_visible,
+    }
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn should_capture_foreground(action: LauncherAction, currently_visible: bool) -> bool {
+    matches!(action, LauncherAction::Toggle | LauncherAction::Show) && !currently_visible
 }
 
 /// Returns the currently persisted global shortcut configuration from disk.
@@ -695,6 +758,36 @@ pub(crate) fn canonicalize_shortcut(shortcut_str: &str) -> Result<String, AppErr
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn show_hidden_becomes_visible() {
+        assert!(launcher_visibility_after(LauncherAction::Show, false));
+    }
+
+    #[test]
+    fn show_visible_remains_visible() {
+        assert!(launcher_visibility_after(LauncherAction::Show, true));
+    }
+
+    #[test]
+    fn toggle_hidden_becomes_visible() {
+        assert!(launcher_visibility_after(LauncherAction::Toggle, false));
+    }
+
+    #[test]
+    fn toggle_visible_becomes_hidden() {
+        assert!(!launcher_visibility_after(LauncherAction::Toggle, true));
+    }
+
+    #[test]
+    fn hidden_show_captures_previous_foreground_window() {
+        assert!(should_capture_foreground(LauncherAction::Show, false));
+    }
+
+    #[test]
+    fn visible_show_does_not_replace_previous_foreground_window() {
+        assert!(!should_capture_foreground(LauncherAction::Show, true));
+    }
     use tauri_plugin_global_shortcut::Code;
 
     // --- get_code_from_string ---

--- a/asyar-launcher/src-tauri/src/launcher/coordinator.rs
+++ b/asyar-launcher/src-tauri/src/launcher/coordinator.rs
@@ -181,6 +181,11 @@ impl LauncherCoordinator {
             .lock()
             .expect("launcher coordinator state mutex poisoned")
     }
+
+    #[cfg(test)]
+    pub(crate) fn pending_actions(&self) -> Vec<LauncherAction> {
+        self.lock_state().pending.iter().copied().collect()
+    }
 }
 
 #[cfg(test)]

--- a/asyar-launcher/src-tauri/src/launcher/coordinator.rs
+++ b/asyar-launcher/src-tauri/src/launcher/coordinator.rs
@@ -1,0 +1,399 @@
+use std::collections::VecDeque;
+use std::fmt;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+const MAX_PENDING_ACTIONS: usize = 64;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LauncherAction {
+    Toggle,
+    Show,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum CoordinatorError {
+    AlreadyAttached,
+    NotAttached,
+    QueueFull,
+    Schedule(String),
+}
+
+impl fmt::Display for CoordinatorError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AlreadyAttached => write!(formatter, "launcher coordinator already attached"),
+            Self::NotAttached => write!(formatter, "launcher coordinator is not attached"),
+            Self::QueueFull => write!(formatter, "launcher coordinator queue is full"),
+            Self::Schedule(error) => {
+                write!(formatter, "failed to schedule launcher action: {error}")
+            }
+        }
+    }
+}
+
+trait LauncherBackend: Send + Sync + 'static {
+    fn schedule(&self, task: Box<dyn FnOnce() + Send>) -> Result<(), String>;
+    fn execute(&self, action: LauncherAction);
+}
+
+struct TauriLauncherBackend {
+    app: tauri::AppHandle,
+}
+
+impl LauncherBackend for TauriLauncherBackend {
+    fn schedule(&self, task: Box<dyn FnOnce() + Send>) -> Result<(), String> {
+        self.app
+            .run_on_main_thread(task)
+            .map_err(|error| error.to_string())
+    }
+
+    fn execute(&self, action: LauncherAction) {
+        match action {
+            LauncherAction::Toggle => crate::commands::toggle_launcher(&self.app),
+            LauncherAction::Show => crate::commands::shortcuts::show_spotlight_launcher(&self.app),
+        }
+    }
+}
+
+#[derive(Default)]
+struct CoordinatorState {
+    backend: Option<Arc<dyn LauncherBackend>>,
+    ready: bool,
+    drain_scheduled: bool,
+    pending: VecDeque<LauncherAction>,
+}
+
+pub(crate) struct LauncherCoordinator {
+    state: Mutex<CoordinatorState>,
+}
+
+impl Default for LauncherCoordinator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LauncherCoordinator {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Mutex::new(CoordinatorState::default()),
+        }
+    }
+
+    pub(crate) fn attach_app(
+        self: &Arc<Self>,
+        app: tauri::AppHandle,
+    ) -> Result<(), CoordinatorError> {
+        self.attach_backend(Arc::new(TauriLauncherBackend { app }))
+    }
+
+    pub(crate) fn request(
+        self: &Arc<Self>,
+        action: LauncherAction,
+    ) -> Result<(), CoordinatorError> {
+        {
+            let mut state = self.lock_state();
+            if state.pending.len() >= MAX_PENDING_ACTIONS {
+                log::warn!("[launcher] dropping {action:?}: coordinator queue is full");
+                return Err(CoordinatorError::QueueFull);
+            }
+            state.pending.push_back(action);
+        }
+
+        self.schedule_drain_if_needed()
+    }
+
+    pub(crate) fn mark_ready(self: &Arc<Self>) -> Result<(), CoordinatorError> {
+        {
+            let mut state = self.lock_state();
+            state.ready = true;
+        }
+        self.schedule_drain_if_needed()
+    }
+
+    fn attach_backend(
+        self: &Arc<Self>,
+        backend: Arc<dyn LauncherBackend>,
+    ) -> Result<(), CoordinatorError> {
+        {
+            let mut state = self.lock_state();
+            if state.backend.is_some() {
+                return Err(CoordinatorError::AlreadyAttached);
+            }
+            state.backend = Some(backend);
+        }
+        self.schedule_drain_if_needed()
+    }
+
+    fn schedule_drain_if_needed(self: &Arc<Self>) -> Result<(), CoordinatorError> {
+        let backend = {
+            let mut state = self.lock_state();
+            if !state.ready || state.pending.is_empty() || state.drain_scheduled {
+                return Ok(());
+            }
+            let backend = state.backend.clone().ok_or(CoordinatorError::NotAttached)?;
+            state.drain_scheduled = true;
+            backend
+        };
+
+        let coordinator = self.clone();
+        if let Err(error) = backend.schedule(Box::new(move || coordinator.drain())) {
+            self.clear_scheduled_flag();
+            log::warn!("[launcher] failed to schedule coordinator drain: {error}");
+            return Err(CoordinatorError::Schedule(error));
+        }
+
+        Ok(())
+    }
+
+    fn clear_scheduled_flag(&self) {
+        let mut state = self.lock_state();
+        state.drain_scheduled = false;
+    }
+
+    fn drain(self: &Arc<Self>) {
+        let backend = {
+            let state = self.lock_state();
+            state
+                .backend
+                .clone()
+                .expect("scheduled launcher drain must have an attached backend")
+        };
+
+        loop {
+            let action = {
+                let mut state = self.lock_state();
+                match state.pending.pop_front() {
+                    Some(action) => action,
+                    None => {
+                        state.drain_scheduled = false;
+                        return;
+                    }
+                }
+            };
+
+            backend.execute(action);
+        }
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, CoordinatorState> {
+        self.state
+            .lock()
+            .expect("launcher coordinator state mutex poisoned")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct FakeBackend {
+        executed: Mutex<Vec<LauncherAction>>,
+        scheduled: Mutex<Vec<Box<dyn FnOnce() + Send>>>,
+        during_execute: Mutex<Option<Box<dyn FnOnce() + Send>>>,
+        schedule_failures: Mutex<usize>,
+    }
+
+    impl FakeBackend {
+        fn run_next(&self) {
+            let task = self.scheduled.lock().unwrap().remove(0);
+            task();
+        }
+
+        fn scheduled_count(&self) -> usize {
+            self.scheduled.lock().unwrap().len()
+        }
+
+        fn executed(&self) -> Vec<LauncherAction> {
+            self.executed.lock().unwrap().clone()
+        }
+
+        fn fail_next_schedule(&self) {
+            *self.schedule_failures.lock().unwrap() += 1;
+        }
+    }
+
+    impl LauncherBackend for FakeBackend {
+        fn schedule(&self, task: Box<dyn FnOnce() + Send>) -> Result<(), String> {
+            let mut failures = self.schedule_failures.lock().unwrap();
+            if *failures > 0 {
+                *failures -= 1;
+                return Err("test scheduling failure".to_string());
+            }
+            drop(failures);
+            self.scheduled.lock().unwrap().push(task);
+            Ok(())
+        }
+
+        fn execute(&self, action: LauncherAction) {
+            self.executed.lock().unwrap().push(action);
+            if let Some(callback) = self.during_execute.lock().unwrap().take() {
+                callback();
+            }
+        }
+    }
+
+    fn attached() -> (Arc<LauncherCoordinator>, Arc<FakeBackend>) {
+        let coordinator = Arc::new(LauncherCoordinator::new());
+        let backend = Arc::new(FakeBackend::default());
+        coordinator.attach_backend(backend.clone()).unwrap();
+        (coordinator, backend)
+    }
+
+    #[test]
+    fn toggle_before_readiness_is_queued_and_mark_ready_drains_it() {
+        let (coordinator, backend) = attached();
+        coordinator.request(LauncherAction::Toggle).unwrap();
+        assert_eq!(backend.scheduled_count(), 0);
+
+        coordinator.mark_ready().unwrap();
+        assert_eq!(backend.scheduled_count(), 1);
+        backend.run_next();
+        assert_eq!(backend.executed(), vec![LauncherAction::Toggle]);
+    }
+
+    #[test]
+    fn ready_toggle_is_scheduled() {
+        let (coordinator, backend) = attached();
+        coordinator.mark_ready().unwrap();
+        coordinator.request(LauncherAction::Toggle).unwrap();
+        assert_eq!(backend.scheduled_count(), 1);
+        backend.run_next();
+        assert_eq!(backend.executed(), vec![LauncherAction::Toggle]);
+    }
+
+    #[test]
+    fn actions_preserve_fifo_order() {
+        let (coordinator, backend) = attached();
+        coordinator.request(LauncherAction::Show).unwrap();
+        coordinator.request(LauncherAction::Toggle).unwrap();
+        coordinator.request(LauncherAction::Show).unwrap();
+        coordinator.mark_ready().unwrap();
+        backend.run_next();
+        assert_eq!(
+            backend.executed(),
+            vec![
+                LauncherAction::Show,
+                LauncherAction::Toggle,
+                LauncherAction::Show
+            ]
+        );
+    }
+
+    #[test]
+    fn repeated_show_requests_preserve_order() {
+        let (coordinator, backend) = attached();
+        coordinator.request(LauncherAction::Show).unwrap();
+        coordinator.request(LauncherAction::Show).unwrap();
+        coordinator.mark_ready().unwrap();
+        backend.run_next();
+        assert_eq!(
+            backend.executed(),
+            vec![LauncherAction::Show, LauncherAction::Show]
+        );
+    }
+
+    #[test]
+    fn show_then_toggle_preserves_order() {
+        let (coordinator, backend) = attached();
+        coordinator.request(LauncherAction::Show).unwrap();
+        coordinator.request(LauncherAction::Toggle).unwrap();
+        coordinator.mark_ready().unwrap();
+        backend.run_next();
+        assert_eq!(
+            backend.executed(),
+            vec![LauncherAction::Show, LauncherAction::Toggle]
+        );
+    }
+
+    #[test]
+    fn action_added_during_drain_is_not_lost() {
+        let (coordinator, backend) = attached();
+        let during_drain = coordinator.clone();
+        *backend.during_execute.lock().unwrap() = Some(Box::new(move || {
+            during_drain.request(LauncherAction::Show).unwrap();
+        }));
+
+        coordinator.mark_ready().unwrap();
+        coordinator.request(LauncherAction::Toggle).unwrap();
+        backend.run_next();
+        assert_eq!(
+            backend.executed(),
+            vec![LauncherAction::Toggle, LauncherAction::Show]
+        );
+    }
+
+    #[test]
+    fn one_drain_is_scheduled_for_multiple_ready_requests() {
+        let (coordinator, backend) = attached();
+        coordinator.mark_ready().unwrap();
+        coordinator.request(LauncherAction::Toggle).unwrap();
+        coordinator.request(LauncherAction::Show).unwrap();
+        assert_eq!(backend.scheduled_count(), 1);
+        backend.run_next();
+        assert_eq!(
+            backend.executed(),
+            vec![LauncherAction::Toggle, LauncherAction::Show]
+        );
+    }
+
+    #[test]
+    fn ready_pending_work_is_scheduled_when_backend_attaches() {
+        let coordinator = Arc::new(LauncherCoordinator::new());
+        coordinator.mark_ready().unwrap();
+        assert_eq!(
+            coordinator.request(LauncherAction::Toggle),
+            Err(CoordinatorError::NotAttached)
+        );
+
+        let backend = Arc::new(FakeBackend::default());
+        coordinator.attach_backend(backend.clone()).unwrap();
+        assert_eq!(backend.scheduled_count(), 1);
+        backend.run_next();
+        assert_eq!(backend.executed(), vec![LauncherAction::Toggle]);
+    }
+
+    #[test]
+    fn scheduling_failure_keeps_actions_queued_for_a_later_request() {
+        let (coordinator, backend) = attached();
+        coordinator.mark_ready().unwrap();
+        backend.fail_next_schedule();
+
+        assert_eq!(
+            coordinator.request(LauncherAction::Show),
+            Err(CoordinatorError::Schedule(
+                "test scheduling failure".to_string()
+            ))
+        );
+        assert_eq!(backend.scheduled_count(), 0);
+
+        coordinator.request(LauncherAction::Toggle).unwrap();
+        assert_eq!(backend.scheduled_count(), 1);
+        backend.run_next();
+        assert_eq!(
+            backend.executed(),
+            vec![LauncherAction::Show, LauncherAction::Toggle]
+        );
+    }
+
+    #[test]
+    fn queue_overflow_preserves_existing_actions_and_remains_coherent() {
+        let (coordinator, backend) = attached();
+        for _ in 0..MAX_PENDING_ACTIONS {
+            coordinator.request(LauncherAction::Show).unwrap();
+        }
+
+        assert_eq!(
+            coordinator.request(LauncherAction::Toggle),
+            Err(CoordinatorError::QueueFull)
+        );
+        coordinator.mark_ready().unwrap();
+        backend.run_next();
+        assert_eq!(
+            backend.executed(),
+            vec![LauncherAction::Show; MAX_PENDING_ACTIONS]
+        );
+    }
+}

--- a/asyar-launcher/src-tauri/src/launcher/coordinator.rs
+++ b/asyar-launcher/src-tauri/src/launcher/coordinator.rs
@@ -182,7 +182,7 @@ impl LauncherCoordinator {
             .expect("launcher coordinator state mutex poisoned")
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, target_os = "linux"))]
     pub(crate) fn pending_actions(&self) -> Vec<LauncherAction> {
         self.lock_state().pending.iter().copied().collect()
     }

--- a/asyar-launcher/src-tauri/src/launcher/mod.rs
+++ b/asyar-launcher/src-tauri/src/launcher/mod.rs
@@ -1,0 +1,143 @@
+mod coordinator;
+
+pub(crate) use coordinator::{LauncherAction, LauncherCoordinator};
+
+pub(crate) fn classify_secondary_launch(args: &[String], scheme: &str) -> Option<LauncherAction> {
+    if carries_active_deep_link(args, scheme) {
+        None
+    } else if requests_show(args) {
+        Some(LauncherAction::Show)
+    } else {
+        Some(LauncherAction::Toggle)
+    }
+}
+
+pub(crate) fn classify_initial_launch(args: &[String], scheme: &str) -> Option<LauncherAction> {
+    if carries_active_deep_link(args, scheme) {
+        None
+    } else if requests_show(args) {
+        Some(LauncherAction::Show)
+    } else {
+        None
+    }
+}
+
+fn carries_active_deep_link(args: &[String], scheme: &str) -> bool {
+    let prefix = format!("{scheme}://");
+    args.iter().any(|arg| arg.starts_with(&prefix))
+}
+
+fn requests_show(args: &[String]) -> bool {
+    args.iter().any(|arg| arg == "--show-on-start")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_secondary_launch_toggles() {
+        let args = vec!["asyar".to_string()];
+        assert_eq!(
+            classify_secondary_launch(&args, "asyar"),
+            Some(LauncherAction::Toggle)
+        );
+    }
+
+    #[test]
+    fn explicit_cold_start_shows() {
+        let args = vec!["asyar".to_string(), "--show-on-start".to_string()];
+        assert_eq!(
+            classify_secondary_launch(&args, "asyar"),
+            Some(LauncherAction::Show)
+        );
+        assert_eq!(
+            classify_initial_launch(&args, "asyar"),
+            Some(LauncherAction::Show)
+        );
+    }
+
+    #[test]
+    fn production_deep_link_has_no_launcher_action() {
+        let args = vec![
+            "asyar".to_string(),
+            "asyar://extensions/example/run".to_string(),
+        ];
+        assert_eq!(classify_secondary_launch(&args, "asyar"), None);
+    }
+
+    #[test]
+    fn development_deep_link_has_no_launcher_action() {
+        let args = vec![
+            "asyar".to_string(),
+            "asyar-dev://extensions/example/run".to_string(),
+        ];
+        assert_eq!(classify_secondary_launch(&args, "asyar-dev"), None);
+    }
+
+    #[test]
+    fn show_before_production_deep_link_has_no_launcher_action() {
+        let args = vec![
+            "asyar".to_string(),
+            "--show-on-start".to_string(),
+            "asyar://extensions/example/run".to_string(),
+        ];
+        assert_eq!(classify_secondary_launch(&args, "asyar"), None);
+        assert_eq!(classify_initial_launch(&args, "asyar"), None);
+    }
+
+    #[test]
+    fn production_deep_link_before_show_has_no_launcher_action() {
+        let args = vec![
+            "asyar".to_string(),
+            "asyar://extensions/example/run".to_string(),
+            "--show-on-start".to_string(),
+        ];
+        assert_eq!(classify_secondary_launch(&args, "asyar"), None);
+        assert_eq!(classify_initial_launch(&args, "asyar"), None);
+    }
+
+    #[test]
+    fn development_deep_link_takes_precedence_over_show() {
+        let args = vec![
+            "asyar".to_string(),
+            "--show-on-start".to_string(),
+            "asyar-dev://extensions/example/run".to_string(),
+        ];
+        assert_eq!(classify_secondary_launch(&args, "asyar-dev"), None);
+        assert_eq!(classify_initial_launch(&args, "asyar-dev"), None);
+    }
+
+    #[test]
+    fn ordinary_primary_startup_has_no_launcher_action() {
+        let args = vec!["asyar".to_string()];
+        assert_eq!(classify_initial_launch(&args, "asyar"), None);
+    }
+
+    #[test]
+    fn unknown_secondary_argument_preserves_toggle_behavior() {
+        let args = vec!["asyar".to_string(), "--unknown".to_string()];
+        assert_eq!(
+            classify_secondary_launch(&args, "asyar"),
+            Some(LauncherAction::Toggle)
+        );
+        assert_eq!(classify_initial_launch(&args, "asyar"), None);
+    }
+
+    #[test]
+    fn show_with_unknown_argument_still_shows() {
+        let args = vec![
+            "asyar".to_string(),
+            "--show-on-start".to_string(),
+            "--unknown".to_string(),
+        ];
+        assert_eq!(
+            classify_secondary_launch(&args, "asyar"),
+            Some(LauncherAction::Show)
+        );
+        assert_eq!(
+            classify_initial_launch(&args, "asyar"),
+            Some(LauncherAction::Show)
+        );
+    }
+}

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -149,6 +149,7 @@ pub mod files_scope;
 pub mod fs_watcher;
 pub mod hud_window;
 pub mod index_events;
+mod launcher;
 pub mod launcher_placement;
 pub mod locale;
 pub mod mcp;
@@ -238,6 +239,8 @@ pub fn run() {
         mcp_factory,
         mcp::SupervisorConfig::default(),
     ));
+    let launcher_coordinator = std::sync::Arc::new(launcher::LauncherCoordinator::new());
+    let single_instance_coordinator = launcher_coordinator.clone();
 
     let builder = tauri::Builder::default()
         // Single-instance must be the FIRST plugin: it intercepts a second
@@ -245,26 +248,28 @@ pub fn run() {
         // feature) forwards that instance's asyar:// URL argv into on_open_url
         // — the only way a deep link reaches an already-running app on
         // Windows/Linux.
-        .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
-            // A bare re-exec (`asyar` with no URL argv) is a summon request:
-            // it is the only way a Wayland compositor can drive the launcher,
-            // since the X11 key grab behind tauri-plugin-global-shortcut never
-            // sees keystrokes there. Bind a compositor key to the binary and
-            // this callback toggles the already-running instance.
-            //
-            // Skip when argv carries an asyar:// URL — those instances exist to
-            // deliver a deep link, and the deep-link handler decides on its own
-            // whether to reveal the window (view commands do, background ones
-            // do not). Toggling here would fight that, and would *hide* the
-            // launcher whenever a deep link arrived while it was open.
-            let scheme = deeplink::deep_link_scheme(app);
-            let carries_deeplink = args
-                .iter()
-                .any(|arg| arg.starts_with(&format!("{scheme}://")));
-            if !carries_deeplink {
-                commands::toggle_launcher(app);
-            }
-        }))
+        .plugin(tauri_plugin_single_instance::init(
+            move |app, args, _cwd| {
+                // A bare re-exec (`asyar` with no URL argv) is a summon request:
+                // it is the only way a Wayland compositor can drive the launcher,
+                // since the X11 key grab behind tauri-plugin-global-shortcut never
+                // sees keystrokes there. Bind a compositor key to the binary and
+                // this callback toggles the already-running instance.
+                //
+                // Skip when argv carries an asyar:// URL — those instances exist to
+                // deliver a deep link, and the deep-link handler decides on its own
+                // whether to reveal the window (view commands do, background ones
+                // do not). Toggling here would fight that, and would *hide* the
+                // launcher whenever a deep link arrived while it was open.
+                if let Some(action) =
+                    launcher::classify_secondary_launch(&args, deeplink::deep_link_scheme(app))
+                {
+                    if let Err(error) = single_instance_coordinator.request(action) {
+                        log::warn!("[launcher] failed to queue secondary launch action: {error}");
+                    }
+                }
+            },
+        ))
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_clipboard_x::init())
@@ -372,6 +377,7 @@ pub fn run() {
         .manage(feedback::channel::FeedbackChannelState::default())
         .manage(feedback::PendingCrash::default())
         .manage(locale::LocaleService::new())
+        .manage(launcher_coordinator)
         .manage(crate::agents::cache::AgentResponseCache::default())
         .manage(AppState {
             focus_locked: AtomicBool::new(false),
@@ -1133,6 +1139,22 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // one-shot.
     if commands::perform_pending_factory_reset_if_marked(app.handle()) {
         log::warn!("[setup_app] factory reset performed; continuing fresh boot");
+    }
+
+    let launcher_coordinator = app
+        .state::<std::sync::Arc<launcher::LauncherCoordinator>>()
+        .inner()
+        .clone();
+    launcher_coordinator
+        .attach_app(app.handle().clone())
+        .map_err(|error| format!("failed to attach launcher coordinator: {error}"))?;
+    let initial_args = std::env::args().collect::<Vec<_>>();
+    if let Some(action) =
+        launcher::classify_initial_launch(&initial_args, deeplink::deep_link_scheme(app.handle()))
+    {
+        launcher_coordinator
+            .request(action)
+            .map_err(|error| format!("failed to queue initial launcher action: {error}"))?;
     }
 
     // Must run before any window/webview is created — WKWebView reads this
@@ -2408,6 +2430,10 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 
         app.manage(bridge_state);
     }
+
+    launcher_coordinator
+        .mark_ready()
+        .map_err(|error| format!("failed to mark launcher coordinator ready: {error}"))?;
 
     Ok(())
 }

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -1148,6 +1148,15 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     launcher_coordinator
         .attach_app(app.handle().clone())
         .map_err(|error| format!("failed to attach launcher coordinator: {error}"))?;
+    #[cfg(target_os = "linux")]
+    match platform::linux::launcher_dbus::start(&app.config().identifier, &launcher_coordinator) {
+        Ok(service) => {
+            app.manage(service);
+        }
+        Err(error) => {
+            log::warn!("[launcher-dbus] {error}");
+        }
+    }
     let initial_args = std::env::args().collect::<Vec<_>>();
     if let Some(action) =
         launcher::classify_initial_launch(&initial_args, deeplink::deep_link_scheme(app.handle()))

--- a/asyar-launcher/src-tauri/src/platform/linux.rs
+++ b/asyar-launcher/src-tauri/src/platform/linux.rs
@@ -1,4 +1,6 @@
 pub mod desktop_entry;
+#[cfg(target_os = "linux")]
+pub(crate) mod launcher_dbus;
 pub use desktop_entry::*;
 
 use std::path::{Path, PathBuf};

--- a/asyar-launcher/src-tauri/src/platform/linux/launcher_dbus.rs
+++ b/asyar-launcher/src-tauri/src/platform/linux/launcher_dbus.rs
@@ -1,0 +1,260 @@
+use std::fmt;
+use std::sync::{Arc, Weak};
+
+use crate::launcher::{LauncherAction, LauncherCoordinator};
+
+#[derive(Debug, PartialEq, Eq)]
+struct LauncherDbusIdentity {
+    bus_name: &'static str,
+    object_path: &'static str,
+}
+
+impl LauncherDbusIdentity {
+    fn resolve(identifier: &str) -> Result<Self, LauncherDbusError> {
+        match identifier {
+            "org.asyar.app" => Ok(Self {
+                bus_name: "org.asyar.app.Launcher",
+                object_path: "/org/asyar/app/Launcher",
+            }),
+            "org.asyar.dev" => Ok(Self {
+                bus_name: "org.asyar.dev.Launcher",
+                object_path: "/org/asyar/dev/Launcher",
+            }),
+            identifier => Err(LauncherDbusError::UnsupportedIdentifier(
+                identifier.to_string(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum LauncherDbusError {
+    UnsupportedIdentifier(String),
+    Registration(String),
+}
+
+impl fmt::Display for LauncherDbusError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedIdentifier(identifier) => write!(
+                formatter,
+                "unsupported Tauri application identifier for launcher D-Bus service: {identifier}"
+            ),
+            Self::Registration(error) => {
+                write!(
+                    formatter,
+                    "failed to register launcher D-Bus service: {error}"
+                )
+            }
+        }
+    }
+}
+
+struct LauncherDbusEndpoint {
+    coordinator: Weak<LauncherCoordinator>,
+}
+
+impl LauncherDbusEndpoint {
+    fn new(coordinator: &Arc<LauncherCoordinator>) -> Self {
+        Self {
+            coordinator: Arc::downgrade(coordinator),
+        }
+    }
+}
+
+#[zbus::interface(name = "org.asyar.Launcher1")]
+impl LauncherDbusEndpoint {
+    fn toggle(&self) -> zbus::fdo::Result<()> {
+        self.coordinator
+            .upgrade()
+            .ok_or_else(|| {
+                zbus::fdo::Error::Failed("launcher coordinator is unavailable".to_string())
+            })?
+            .request(LauncherAction::Toggle)
+            .map_err(|error| zbus::fdo::Error::Failed(error.to_string()))
+    }
+}
+
+/// Owns the connection so its well-known name and object remain registered
+/// until Tauri drops managed state during application shutdown.
+pub(crate) struct LauncherDbusService {
+    _connection: zbus::blocking::Connection,
+}
+
+pub(crate) fn start(
+    identifier: &str,
+    coordinator: &Arc<LauncherCoordinator>,
+) -> Result<LauncherDbusService, LauncherDbusError> {
+    let identity = LauncherDbusIdentity::resolve(identifier)?;
+    let connection = zbus::blocking::connection::Builder::session()
+        .and_then(|builder| {
+            builder.serve_at(identity.object_path, LauncherDbusEndpoint::new(coordinator))
+        })
+        .and_then(zbus::blocking::connection::Builder::build)
+        .map_err(|error| LauncherDbusError::Registration(error.to_string()))?;
+    let reply = connection
+        .request_name_with_flags(
+            identity.bus_name,
+            zbus::fdo::RequestNameFlags::DoNotQueue.into(),
+        )
+        .map_err(|error| LauncherDbusError::Registration(error.to_string()))?;
+    if reply != zbus::fdo::RequestNameReply::PrimaryOwner {
+        return Err(LauncherDbusError::Registration(format!(
+            "unexpected name request reply: {reply:?}"
+        )));
+    }
+
+    Ok(LauncherDbusService {
+        _connection: connection,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn production_identity_uses_production_bus_and_path() {
+        let identity = LauncherDbusIdentity::resolve("org.asyar.app").unwrap();
+
+        assert_eq!(identity.bus_name, "org.asyar.app.Launcher");
+        assert_eq!(identity.object_path, "/org/asyar/app/Launcher");
+    }
+
+    #[test]
+    fn development_identity_uses_development_bus_and_path() {
+        let identity = LauncherDbusIdentity::resolve("org.asyar.dev").unwrap();
+
+        assert_eq!(identity.bus_name, "org.asyar.dev.Launcher");
+        assert_eq!(identity.object_path, "/org/asyar/dev/Launcher");
+    }
+
+    #[test]
+    fn unknown_identifier_is_rejected() {
+        let error = LauncherDbusIdentity::resolve("org.example.asyar").unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "unsupported Tauri application identifier for launcher D-Bus service: org.example.asyar"
+        );
+    }
+
+    #[test]
+    fn toggle_queues_a_toggle_with_the_launcher_coordinator() {
+        let coordinator = Arc::new(LauncherCoordinator::new());
+        let endpoint = LauncherDbusEndpoint::new(&coordinator);
+
+        endpoint.toggle().unwrap();
+
+        assert_eq!(coordinator.pending_actions(), vec![LauncherAction::Toggle]);
+    }
+
+    #[test]
+    fn toggle_fails_when_the_coordinator_is_unavailable() {
+        let coordinator = Arc::new(LauncherCoordinator::new());
+        let endpoint = LauncherDbusEndpoint::new(&coordinator);
+        drop(coordinator);
+
+        let error = endpoint.toggle().unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "org.freedesktop.DBus.Error.Failed: launcher coordinator is unavailable"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires an isolated D-Bus session"]
+    #[serial_test::serial(launcher_dbus)]
+    fn isolated_session_exposes_toggle_and_keeps_flavors_separate() {
+        let production = Arc::new(LauncherCoordinator::new());
+        let development = Arc::new(LauncherCoordinator::new());
+        let _production_service = start("org.asyar.app", &production).unwrap();
+        let _development_service = start("org.asyar.dev", &development).unwrap();
+        let client = zbus::blocking::Connection::session().unwrap();
+
+        for (bus_name, object_path) in [
+            ("org.asyar.app.Launcher", "/org/asyar/app/Launcher"),
+            ("org.asyar.dev.Launcher", "/org/asyar/dev/Launcher"),
+        ] {
+            let introspection = zbus::blocking::Proxy::new(
+                &client,
+                bus_name,
+                object_path,
+                "org.freedesktop.DBus.Introspectable",
+            )
+            .unwrap();
+            let xml: String = introspection.call("Introspect", &()).unwrap();
+            assert!(xml.contains("org.asyar.Launcher1"));
+            assert!(xml.contains("<method name=\"Toggle\">"));
+        }
+
+        let production_proxy = zbus::blocking::Proxy::new(
+            &client,
+            "org.asyar.app.Launcher",
+            "/org/asyar/app/Launcher",
+            "org.asyar.Launcher1",
+        )
+        .unwrap();
+        production_proxy.call::<_, _, ()>("Toggle", &()).unwrap();
+        assert_eq!(production.pending_actions(), vec![LauncherAction::Toggle]);
+        assert!(development.pending_actions().is_empty());
+
+        let wrong_flavor_path = zbus::blocking::Proxy::new(
+            &client,
+            "org.asyar.dev.Launcher",
+            "/org/asyar/app/Launcher",
+            "org.asyar.Launcher1",
+        )
+        .unwrap();
+        assert!(wrong_flavor_path.call::<_, _, ()>("Toggle", &()).is_err());
+        assert!(development.pending_actions().is_empty());
+
+        let development_proxy = zbus::blocking::Proxy::new(
+            &client,
+            "org.asyar.dev.Launcher",
+            "/org/asyar/dev/Launcher",
+            "org.asyar.Launcher1",
+        )
+        .unwrap();
+        development_proxy.call::<_, _, ()>("Toggle", &()).unwrap();
+        assert_eq!(development.pending_actions(), vec![LauncherAction::Toggle]);
+    }
+
+    #[test]
+    #[ignore = "requires an isolated D-Bus session"]
+    #[serial_test::serial(launcher_dbus)]
+    fn normal_owner_conflict_does_not_replace_existing_owner() {
+        assert_existing_owner_is_not_replaced(zbus::fdo::RequestNameFlags::DoNotQueue);
+    }
+
+    #[test]
+    #[ignore = "requires an isolated D-Bus session"]
+    #[serial_test::serial(launcher_dbus)]
+    fn replaceable_owner_conflict_does_not_replace_existing_owner() {
+        assert_existing_owner_is_not_replaced(zbus::fdo::RequestNameFlags::AllowReplacement);
+    }
+
+    fn assert_existing_owner_is_not_replaced(owner_flags: zbus::fdo::RequestNameFlags) {
+        const BUS_NAME: &str = "org.asyar.app.Launcher";
+
+        let owner = zbus::blocking::Connection::session().unwrap();
+        let reply = owner
+            .request_name_with_flags(BUS_NAME, owner_flags.into())
+            .unwrap();
+        assert_eq!(reply, zbus::fdo::RequestNameReply::PrimaryOwner);
+        let original_owner = owner.unique_name().unwrap().to_string();
+
+        let coordinator = Arc::new(LauncherCoordinator::new());
+        assert!(start("org.asyar.app", &coordinator).is_err());
+
+        let client = zbus::blocking::Connection::session().unwrap();
+        let dbus = zbus::blocking::fdo::DBusProxy::new(&client).unwrap();
+        let current_owner = dbus
+            .get_name_owner(zbus::names::BusName::try_from(BUS_NAME).unwrap())
+            .unwrap();
+        assert_eq!(current_owner.to_string(), original_owner);
+
+        assert!(owner.release_name(BUS_NAME).unwrap());
+    }
+}

--- a/asyar-launcher/src-tauri/tauri.linux.conf.json
+++ b/asyar-launcher/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "build": {
+    "beforeBuildCommand": "node scripts/build-linux.mjs"
+  },
+  "bundle": {
+    "externalBin": ["binaries/asyar-summon"]
+  }
+}

--- a/install.sh
+++ b/install.sh
@@ -38,11 +38,15 @@ esac
 TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/asyar-install.XXXXXX")
 MOUNTED=0
 mount_point="$TMP_DIR/mnt"
+linux_app_tmp=""
+linux_helper_tmp=""
 
 cleanup() {
   if [ "$MOUNTED" = "1" ]; then
     hdiutil detach "$mount_point" -quiet >/dev/null 2>&1 || true
   fi
+  [ -z "$linux_app_tmp" ] || rm -f "$linux_app_tmp"
+  [ -z "$linux_helper_tmp" ] || rm -f "$linux_helper_tmp"
   rm -rf "$TMP_DIR"
 }
 trap cleanup EXIT INT TERM
@@ -78,14 +82,23 @@ case "$platform" in
     ;;
   linux)
     case "$arch" in
-      aarch64) asset_url=$(find_asset_url '_aarch64\.AppImage"') ;;
-      x86_64) asset_url=$(find_asset_url '_amd64\.AppImage"') ;;
+      aarch64)
+        asset_url=$(find_asset_url '_aarch64\.AppImage"')
+        helper_url=$(find_asset_url 'asyar-summon_aarch64"')
+        ;;
+      x86_64)
+        asset_url=$(find_asset_url '_amd64\.AppImage"')
+        helper_url=$(find_asset_url 'asyar-summon_amd64"')
+        ;;
       *) err "Unsupported Linux architecture: $arch" ;;
     esac
     ;;
 esac
 
 [ -n "$asset_url" ] || err "Could not find a release asset for ${platform}/${arch}"
+if [ "$platform" = "linux" ]; then
+  [ -n "$helper_url" ] || err "Could not find the summon helper for Linux/${arch}"
+fi
 
 asset_file=$(printf '%s' "$asset_url" | sed 's#.*/##')
 version=$(printf '%s' "$asset_file" | sed -E 's/^asyar_([^_]+)_.*/\1/')
@@ -120,15 +133,33 @@ case "$platform" in
     ;;
   linux)
     target="$INSTALL_DIR/asyar"
+    helper_target="$INSTALL_DIR/asyar-summon"
+    [ ! -d "$target" ] || err "Installation target is a directory: ${target}"
+    [ ! -d "$helper_target" ] || err "Summon helper target is a directory: ${helper_target}"
     if [ -e "$target" ]; then
       log "Found an existing install at ${target} — it will be replaced."
     fi
+    if [ -e "$helper_target" ]; then
+      log "Found an existing summon helper at ${helper_target} — it will be replaced."
+    fi
 
     mkdir -p "$INSTALL_DIR"
-    curl -fsSL -o "$target" "$asset_url"
-    chmod +x "$target"
+    linux_app_tmp=$(mktemp "$INSTALL_DIR/.asyar.XXXXXX")
+    linux_helper_tmp=$(mktemp "$INSTALL_DIR/.asyar-summon.XXXXXX")
 
-    log "Installed to ${target}"
+    curl -fsSL -o "$linux_app_tmp" "$asset_url"
+    curl -fsSL -o "$linux_helper_tmp" "$helper_url"
+    [ -s "$linux_app_tmp" ] || err "Downloaded AppImage is empty"
+    [ -s "$linux_helper_tmp" ] || err "Downloaded summon helper is empty"
+    chmod 0755 "$linux_app_tmp" "$linux_helper_tmp"
+
+    mv -f "$linux_app_tmp" "$target"
+    linux_app_tmp=""
+    mv -f "$linux_helper_tmp" "$helper_target"
+    linux_helper_tmp=""
+
+    log "Installed Asyar to ${target}"
+    log "Installed summon helper to ${helper_target}"
     case ":$PATH:" in
       *":$INSTALL_DIR:"*) ;;
       *)
@@ -137,5 +168,6 @@ case "$platform" in
         ;;
     esac
     log "Run it with: asyar"
+    log "Use asyar-summon for a lightweight Linux global shortcut."
     ;;
 esac

--- a/scripts/install-script.test.mjs
+++ b/scripts/install-script.test.mjs
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const installScript = join(repoRoot, 'install.sh');
+const fixtures = [];
+
+afterEach(() => {
+  for (const fixture of fixtures.splice(0)) {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+function makeFixture({ arch = 'x86_64', failDownload, omitHelper = false } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'asyar-install-test-'));
+  fixtures.push(root);
+  const binDir = join(root, 'stub-bin');
+  const installDir = join(root, 'install');
+  const curlLog = join(root, 'curl.log');
+  mkdirSync(binDir);
+  mkdirSync(installDir);
+
+  writeFileSync(
+    join(binDir, 'uname'),
+    `#!/bin/sh
+case "\${1:-}" in
+  -s) printf 'Linux\\n' ;;
+  -m) printf '%s\\n' "${arch}" ;;
+  *) exit 1 ;;
+esac
+`,
+  );
+  chmodSync(join(binDir, 'uname'), 0o755);
+
+  writeFileSync(
+    join(binDir, 'curl'),
+    `#!/bin/sh
+set -eu
+output=''
+url=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) output=$2; shift 2 ;;
+    -*) shift ;;
+    *) url=$1; shift ;;
+  esac
+done
+printf '%s\\n' "$url" >> "$STUB_CURL_LOG"
+if [ -z "$output" ]; then
+  if [ "$STUB_OMIT_HELPER" = '1' ]; then
+    printf '%s\\n' '{"assets":[{"browser_download_url":"https://example.test/asyar_1.2.3_amd64.AppImage"},{"browser_download_url":"https://example.test/asyar_1.2.3_aarch64.AppImage"}]}'
+    exit 0
+  fi
+  printf '%s\\n' '{"assets":[{"browser_download_url":"https://example.test/asyar_1.2.3_amd64.AppImage"},{"browser_download_url":"https://example.test/asyar_1.2.3_aarch64.AppImage"},{"browser_download_url":"https://example.test/asyar-summon_amd64"},{"browser_download_url":"https://example.test/asyar-summon_aarch64"}]}'
+  exit 0
+fi
+case "$url" in
+  *"$STUB_FAIL_DOWNLOAD"*) exit 22 ;;
+  *asyar-summon_*) printf 'new-helper' > "$output" ;;
+  *.AppImage) printf 'new-appimage' > "$output" ;;
+  *) exit 22 ;;
+esac
+`,
+  );
+  chmodSync(join(binDir, 'curl'), 0o755);
+
+  return {
+    root,
+    installDir,
+    curlLog,
+    env: {
+      ...process.env,
+      ASYAR_INSTALL_DIR: installDir,
+      HOME: root,
+      PATH: `${binDir}${delimiter}${process.env.PATH}`,
+      STUB_CURL_LOG: curlLog,
+      STUB_FAIL_DOWNLOAD: failDownload ?? '__never__',
+      STUB_OMIT_HELPER: omitHelper ? '1' : '0',
+    },
+  };
+}
+
+function runInstaller(fixture) {
+  return execFileSync('/bin/sh', [installScript], {
+    cwd: repoRoot,
+    env: fixture.env,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+describe('Linux installer', () => {
+  it.each([
+    ['x86_64', 'amd64'],
+    ['aarch64', 'aarch64'],
+  ])('installs matching AppImage and helper assets for %s', (arch, assetArch) => {
+    const fixture = makeFixture({ arch });
+
+    const output = runInstaller(fixture);
+
+    expect(readFileSync(join(fixture.installDir, 'asyar'), 'utf8')).toBe('new-appimage');
+    expect(readFileSync(join(fixture.installDir, 'asyar-summon'), 'utf8')).toBe('new-helper');
+    expect(statSync(join(fixture.installDir, 'asyar')).mode & 0o111).not.toBe(0);
+    expect(statSync(join(fixture.installDir, 'asyar-summon')).mode & 0o111).not.toBe(0);
+    expect(readFileSync(fixture.curlLog, 'utf8')).toContain(`_${assetArch}.AppImage`);
+    expect(readFileSync(fixture.curlLog, 'utf8')).toContain(`asyar-summon_${assetArch}`);
+    expect(output).toContain(join(fixture.installDir, 'asyar'));
+    expect(output).toContain(join(fixture.installDir, 'asyar-summon'));
+    expect(output).toContain("isn't on your PATH");
+  });
+
+  it.each([
+    ['AppImage', 'amd64.AppImage'],
+    ['helper', 'asyar-summon_amd64'],
+  ])('does not replace either installed file when the %s download fails', (_, failure) => {
+    const fixture = makeFixture({ failDownload: failure });
+    writeFileSync(join(fixture.installDir, 'asyar'), 'old-appimage');
+    writeFileSync(join(fixture.installDir, 'asyar-summon'), 'old-helper');
+
+    expect(() => runInstaller(fixture)).toThrow();
+
+    expect(readFileSync(join(fixture.installDir, 'asyar'), 'utf8')).toBe('old-appimage');
+    expect(readFileSync(join(fixture.installDir, 'asyar-summon'), 'utf8')).toBe('old-helper');
+  });
+
+  it('rejects unsupported Linux architectures', () => {
+    const fixture = makeFixture({ arch: 'riscv64' });
+
+    expect(() => runInstaller(fixture)).toThrow(/Unsupported Linux architecture/);
+  });
+
+  it.each(['asyar', 'asyar-summon'])(
+    'rejects an existing %s directory before installation downloads',
+    (directoryTarget) => {
+      const fixture = makeFixture();
+      const otherTarget = directoryTarget === 'asyar' ? 'asyar-summon' : 'asyar';
+      mkdirSync(join(fixture.installDir, directoryTarget));
+      writeFileSync(join(fixture.installDir, otherTarget), `old-${otherTarget}`);
+
+      expect(() => runInstaller(fixture)).toThrow(/directory/);
+
+      expect(readdirSync(join(fixture.installDir, directoryTarget))).toEqual([]);
+      expect(readFileSync(join(fixture.installDir, otherTarget), 'utf8')).toBe(
+        `old-${otherTarget}`,
+      );
+      expect(readFileSync(fixture.curlLog, 'utf8').trim().split('\n')).toHaveLength(1);
+    },
+  );
+
+  it('rejects a symlink-to-directory target before installation downloads', () => {
+    const fixture = makeFixture();
+    const targetDirectory = join(fixture.root, 'unexpected-target');
+    mkdirSync(targetDirectory);
+    symlinkSync(targetDirectory, join(fixture.installDir, 'asyar-summon'), 'dir');
+    writeFileSync(join(fixture.installDir, 'asyar'), 'old-appimage');
+
+    expect(() => runInstaller(fixture)).toThrow(/directory/);
+
+    expect(readdirSync(targetDirectory)).toEqual([]);
+    expect(readFileSync(join(fixture.installDir, 'asyar'), 'utf8')).toBe('old-appimage');
+    expect(readFileSync(fixture.curlLog, 'utf8').trim().split('\n')).toHaveLength(1);
+  });
+
+  it('preserves the installed pair when the release has no helper asset', () => {
+    const fixture = makeFixture({ omitHelper: true });
+    writeFileSync(join(fixture.installDir, 'asyar'), 'old-appimage');
+    writeFileSync(join(fixture.installDir, 'asyar-summon'), 'old-helper');
+
+    expect(() => runInstaller(fixture)).toThrow(/Could not find the summon helper/);
+
+    expect(readFileSync(join(fixture.installDir, 'asyar'), 'utf8')).toBe('old-appimage');
+    expect(readFileSync(join(fixture.installDir, 'asyar-summon'), 'utf8')).toBe('old-helper');
+    expect(readFileSync(fixture.curlLog, 'utf8').trim().split('\n')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a lightweight Linux summon path for Asyar, primarily targeting Wayland environments where launching the full Asyar executable for every global shortcut invocation adds substantial startup overhead.

The new path uses a small standalone `asyar-summon` client and an Asyar-owned D-Bus interface to toggle the already-running launcher directly.

## Motivation

Previously, a global shortcut such as Ctrl+Space had to invoke the full Asyar executable and rely on single-instance forwarding.

Measured client-side invocation times during development were approximately:

| Path | Time |
|---|---:|
| Full AppImage re-execution | ~400 ms |
| Extracted AppDir / full Asyar executable | ~170 ms |
| Experimental large-ELF socket client | ~50 ms |
| `gdbus` direct call | ~5.2 ms mean |
| `asyar-summon` | ~3.5 ms mean / ~3.3 ms median |

These measurements represent client completion time rather than exact compositor-visible latency.

With the new helper, the launcher feels effectively instantaneous when Asyar is already resident.

## Architecture

### Warm summon

```text
global shortcut
    ↓
asyar-summon
    ↓
org.asyar.app.Launcher
    ↓
org.asyar.Launcher1.Toggle()
    ↓
LauncherCoordinator
    ↓
existing Asyar launcher