### PR TITLE
fix(settings): repair Advanced tab state handling

### DIFF
--- a/asyar-launcher/src/built-in-features/snippets/DefaultView.svelte
+++ b/asyar-launcher/src/built-in-features/snippets/DefaultView.svelte
@@ -105,7 +105,7 @@
   onMount(async () => {
     const result = await snippetService.onViewOpen();
     permissionGranted = result.permissionGranted;
-    const currentEnabled = enabledPersistence.loadSync(true);
+    const currentEnabled = await enabledPersistence.load(true);
     await snippetService.setEnabled(currentEnabled && permissionGranted);
   });
 
@@ -180,8 +180,8 @@
   async function recheckPermission() {
     const result = await snippetService.onViewOpen();
     permissionGranted = result.permissionGranted;
-    const currentEnabled = enabledPersistence.loadSync(true);
-    if (permissionGranted && currentEnabled) await snippetService.setEnabled(true);
+    const currentEnabled = await enabledPersistence.load(true);
+    await snippetService.setEnabled(currentEnabled && permissionGranted);
   }
 
   function duplicateSnippet(snippet: Snippet) {

--- a/asyar-launcher/src/built-in-features/snippets/DefaultView.test.ts
+++ b/asyar-launcher/src/built-in-features/snippets/DefaultView.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { load, loadSync, onViewOpen, save, setEnabled } = vi.hoisted(() => ({
+  load: vi.fn(),
+  loadSync: vi.fn(),
+  onViewOpen: vi.fn(),
+  save: vi.fn(),
+  setEnabled: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+vi.mock('../../components', async () => {
+  const Stub = (await import('./DefaultViewTestStub.svelte')).default;
+  return {
+    ActionFooter: Stub,
+    Badge: Stub,
+    Button: Stub,
+    EmptyState: Stub,
+    FormField: Stub,
+    Input: Stub,
+    LauncherListRow: Stub,
+    PlaceholderPicker: Stub,
+    SplitListDetail: Stub,
+    Textarea: Stub,
+    WarningBanner: Stub,
+  };
+});
+
+vi.mock('../../services/feedback/feedbackService.svelte', () => ({
+  feedbackService: { confirmAlert: vi.fn() },
+}));
+
+vi.mock('../../services/i18n', () => ({ t: (key: string) => key }));
+
+vi.mock('./snippetService', async (importActual) => ({
+  ...(await importActual<typeof import('./snippetService')>()),
+  enabledPersistence: { load, loadSync, save },
+  snippetService: {
+    onViewOpen,
+    setEnabled,
+    syncToRust: vi.fn(),
+    openAccessibilityPreferences: vi.fn(),
+  },
+}));
+
+import DefaultView from './DefaultView.svelte';
+
+describe('DefaultView snippet runtime synchronization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadSync.mockReturnValue(true);
+  });
+
+  it('uses durable false when localStorage has no synchronous value', async () => {
+    load.mockResolvedValue(false);
+    onViewOpen.mockResolvedValue({ permissionGranted: true });
+
+    render(DefaultView);
+
+    await vi.waitFor(() => expect(setEnabled).toHaveBeenCalledWith(false));
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('does not turn a durable true preference off when permission is denied', async () => {
+    load.mockResolvedValue(true);
+    onViewOpen.mockResolvedValue({ permissionGranted: false });
+
+    render(DefaultView);
+
+    await vi.waitFor(() => expect(setEnabled).toHaveBeenCalledWith(false));
+    expect(load).toHaveBeenCalledWith(true);
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('reenables runtime when permission becomes granted without changing preference', async () => {
+    load.mockResolvedValue(true);
+    onViewOpen
+      .mockResolvedValueOnce({ permissionGranted: false })
+      .mockResolvedValueOnce({ permissionGranted: true });
+
+    render(DefaultView);
+    await vi.waitFor(() => expect(setEnabled).toHaveBeenCalledWith(false));
+    await fireEvent.click(screen.getByRole('button', { name: 'Re-check Permission' }));
+
+    await vi.waitFor(() => expect(setEnabled).toHaveBeenLastCalledWith(true));
+    expect(load).toHaveBeenCalledTimes(2);
+    expect(save).not.toHaveBeenCalled();
+  });
+});

--- a/asyar-launcher/src/built-in-features/snippets/DefaultViewTestStub.svelte
+++ b/asyar-launcher/src/built-in-features/snippets/DefaultViewTestStub.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  let { children, actions, onclick } = $props();
+</script>
+
+{#if onclick}
+  <button {onclick}>{@render children?.()}</button>
+{:else}
+  <div>
+    {@render children?.()}
+    {@render actions?.()}
+  </div>
+{/if}

--- a/asyar-launcher/src/built-in-features/snippets/snippetService.test.ts
+++ b/asyar-launcher/src/built-in-features/snippets/snippetService.test.ts
@@ -182,11 +182,18 @@ describe('setEnabled', () => {
     expect(mockInvoke).toHaveBeenCalledWith('set_snippets_enabled', { enabled: false });
   });
 
+  it.each([true, false])('does not persist runtime enabled=%s', async (enabled) => {
+    await snippetService.setEnabled(enabled);
+
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+
   it('returns { ok: false, error } when invoke rejects', async () => {
     mockInvoke.mockRejectedValueOnce(new Error('permission denied'));
     const result = await snippetService.setEnabled(true);
     expect(result.ok).toBe(false);
     expect(result.error).toContain('set_snippets_enabled failed');
+    expect(mockSave).not.toHaveBeenCalled();
   });
 });
 

--- a/asyar-launcher/src/built-in-features/snippets/snippetService.ts
+++ b/asyar-launcher/src/built-in-features/snippets/snippetService.ts
@@ -70,7 +70,8 @@ export const snippetService = {
 
   async setEnabled(enabled: boolean): Promise<{ ok: boolean; error?: string }> {
     const ok = await commands.setSnippetsEnabled(enabled);
-    return ok ? { ok: true } : { ok: false, error: 'set_snippets_enabled failed' };
+    if (!ok) return { ok: false, error: 'set_snippets_enabled failed' };
+    return { ok: true };
   },
 
   async openAccessibilityPreferences(): Promise<void> {

--- a/asyar-launcher/src/routes/onboarding/steps/Snippets.test.ts
+++ b/asyar-launcher/src/routes/onboarding/steps/Snippets.test.ts
@@ -4,6 +4,7 @@ const add = vi.hoisted(() => vi.fn());
 const snippets = vi.hoisted(() => vi.fn().mockReturnValue([]));
 const setEnabled = vi.hoisted(() => vi.fn().mockResolvedValue({ ok: true }));
 const syncToRust = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const saveEnabled = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
 vi.mock('../../../built-in-features/snippets/snippetStore.svelte', () => ({
   snippetStore: {
@@ -14,6 +15,7 @@ vi.mock('../../../built-in-features/snippets/snippetStore.svelte', () => ({
   },
 }));
 vi.mock('../../../built-in-features/snippets/snippetService', () => ({
+  enabledPersistence: { save: saveEnabled },
   snippetService: { setEnabled, syncToRust },
 }));
 
@@ -37,6 +39,7 @@ describe('Snippets setup', () => {
     const ok = await enableExpansion();
     expect(syncToRust).toHaveBeenCalled();
     expect(setEnabled).toHaveBeenCalledWith(true);
+    expect(saveEnabled).toHaveBeenCalledWith(true);
     expect(ok).toBe(true);
   });
 });

--- a/asyar-launcher/src/routes/onboarding/steps/snippetsSetup.ts
+++ b/asyar-launcher/src/routes/onboarding/steps/snippetsSetup.ts
@@ -1,5 +1,8 @@
 import { snippetStore } from '../../../built-in-features/snippets/snippetStore.svelte';
-import { snippetService } from '../../../built-in-features/snippets/snippetService';
+import {
+  enabledPersistence,
+  snippetService,
+} from '../../../built-in-features/snippets/snippetService';
 
 const SAMPLE_KEYWORD = ';email';
 
@@ -17,5 +20,6 @@ export function seedSampleSnippet(): void {
 export async function enableExpansion(): Promise<boolean> {
   await snippetService.syncToRust();
   const res = await snippetService.setEnabled(true);
+  if (res.ok) await enabledPersistence.save(true);
   return res.ok === true;
 }

--- a/asyar-launcher/src/routes/settings/tabs/AdvancedTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/AdvancedTab.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { SettingsCard, SettingsRow, Toggle, SegmentedControl } from '../../../components';
   import type { SettingsHandler } from '../settingsHandlers.svelte';
   import { settingsService } from '../../../services/settings/settingsService.svelte';
@@ -16,37 +17,42 @@
     handler: SettingsHandler;
   } = $props();
 
-  let snippetsEnabled = $state(enabledPersistence.loadSync(true));
+  let snippetsEnabled = $state(true);
   let snippetsToggleError = $state<string | null>(null);
 
-  async function toggleSnippets() {
+  onMount(async () => {
+    snippetsEnabled = await enabledPersistence.load(true);
+  });
+
+  async function toggleSnippets(event: Event) {
+    const input = event.currentTarget as HTMLInputElement;
     snippetsToggleError = null;
     const next = !snippetsEnabled;
     try {
-      await snippetService.setEnabled(next);
+      const result = await snippetService.setEnabled(next);
+      if (!result.ok) throw new Error(result.error);
+      await enabledPersistence.save(next);
       snippetsEnabled = next;
     } catch (e) {
+      input.checked = snippetsEnabled;
       snippetsToggleError = (e as Error).message || 'Failed to update snippets state';
     }
   }
 
-  let autoUpdate = $derived(
-    (settingsService.settings.extensions as Record<string, unknown> | undefined)?.autoUpdate !==
-      false,
-  );
+  let autoUpdate = $derived(handler.settings.extensions.autoUpdate !== false);
 
   async function toggleAutoUpdate() {
-    await settingsService.set('extensions.autoUpdate', !autoUpdate);
+    await settingsService.updateSettings('extensions', { autoUpdate: !autoUpdate });
   }
 
   type EscapeBehavior = 'hide-and-reset' | 'go-back' | 'close-window';
 
   let escapeValue = $state<EscapeBehavior>(
-    handler.settings.general?.escapeBehavior ?? 'hide-and-reset',
+    handler.settings.general.escapeInViewBehavior ?? 'hide-and-reset',
   );
 
   $effect(() => {
-    const current = handler.settings.general?.escapeBehavior ?? 'hide-and-reset';
+    const current = handler.settings.general.escapeInViewBehavior ?? 'hide-and-reset';
     if (escapeValue !== current) {
       handler.updateEscapeBehavior(escapeValue);
     }

--- a/asyar-launcher/src/routes/settings/tabs/AdvancedTab.test.ts
+++ b/asyar-launcher/src/routes/settings/tabs/AdvancedTab.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { invokeMock, persistedSnippetEnabled, storeGetMock, storeSetMock, updateSettingsMock } =
+  vi.hoisted(() => ({
+    invokeMock: vi.fn().mockResolvedValue(null),
+    persistedSnippetEnabled: { value: undefined as boolean | undefined },
+    storeGetMock: vi.fn(async () => undefined as boolean | undefined),
+    storeSetMock: vi.fn(async () => undefined),
+    updateSettingsMock: vi.fn().mockResolvedValue(true),
+  }));
+
+vi.mock('../../../components', async () => ({
+  SettingsCard: (await import('../../../components/settings/SettingsCard.svelte')).default,
+  SettingsRow: (await import('../../../components/settings/SettingsRow.svelte')).default,
+  Toggle: (await import('../../../components/base/Toggle.svelte')).default,
+  SegmentedControl: (await import('../../../components/base/SegmentedControl.svelte')).default,
+}));
+
+vi.mock('../../../services/settings/settingsService.svelte', () => ({
+  settingsService: {
+    updateSettings: updateSettingsMock,
+  },
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+  transformCallback: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+vi.mock('@tauri-apps/plugin-store', () => ({
+  load: vi.fn().mockResolvedValue({
+    get: storeGetMock,
+    set: storeSetMock,
+    save: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('../../../lib/ipc/commands', async (importActual) => ({
+  ...(await importActual<typeof import('../../../lib/ipc/commands')>()),
+  getScheduledTasks: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../../services/runtime/runtimeService.svelte', () => ({
+  runtimeService: {
+    list: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+import AdvancedTab from './AdvancedTab.svelte';
+
+function makeHandler(escapeInViewBehavior: 'go-back' | 'close-window' | 'hide-and-reset') {
+  return {
+    settings: {
+      general: {
+        startAtLogin: false,
+        showDockIcon: false,
+        showTrayIcon: true,
+        escapeInViewBehavior,
+      },
+      search: {
+        searchApplications: true,
+        searchSystemPreferences: true,
+        fuzzySearch: true,
+        enableExtensionSearch: false,
+        allowExtensionActions: false,
+        additionalScanPaths: [],
+        applicationEnabled: {},
+      },
+      shortcut: { modifier: 'Alt', key: 'Space' },
+      appearance: {
+        theme: 'system' as const,
+        launchView: 'default' as const,
+        windowWidth: 800,
+        windowHeight: 600,
+      },
+      extensions: { enabled: {}, autoUpdate: false },
+      onboarding: { completed: true },
+      updates: { channel: 'stable' as const, autoCheck: true },
+      ai: {
+        providers: {},
+        temperature: 0.7,
+        maxTokens: 2048,
+        defaultAgentId: null,
+        tabContinuesLastThread: false,
+      },
+      developer: {
+        enabled: false,
+        showInspector: false,
+        verboseLogging: false,
+        tracing: false,
+        allowSideloading: false,
+      },
+      privacy: { crashReportMode: 'off' as const, usageShareMode: 'off' as const },
+      fileSearch: { enabled: true, includeRoots: [], excludePatterns: [], indexHidden: false },
+    },
+    saveError: false,
+    saveMessage: '',
+    handleExtensionSearchToggle: vi.fn(),
+    handleExtensionActionsToggle: vi.fn(),
+    handleDeveloperModeToggle: vi.fn(),
+    updateEscapeBehavior: vi.fn(),
+  };
+}
+
+describe('AdvancedTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invokeMock.mockResolvedValue(null);
+    persistedSnippetEnabled.value = undefined;
+    storeGetMock.mockImplementation(async () => persistedSnippetEnabled.value);
+    storeSetMock.mockImplementation(async (_key, value) => {
+      persistedSnippetEnabled.value = value as boolean;
+    });
+    localStorage.clear();
+  });
+
+  it('renders Advanced settings from the handler state without throwing', () => {
+    render(AdvancedTab, { handler: makeHandler('go-back') as any });
+
+    expect(screen.getByText('Extension results in search')).toBeTruthy();
+  });
+
+  it.each([
+    { current: false, expected: true },
+    { current: true, expected: false },
+  ])('persists auto-update $current -> $expected', async ({ current, expected }) => {
+    const handler = makeHandler('go-back');
+    handler.settings.extensions.autoUpdate = current;
+    render(AdvancedTab, { handler: handler as any });
+
+    const toggles = screen.getAllByRole('checkbox');
+    await fireEvent.click(toggles[2]);
+
+    expect(updateSettingsMock).toHaveBeenCalledWith('extensions', { autoUpdate: expected });
+  });
+
+  it('initializes the escape behavior control from escapeInViewBehavior', () => {
+    render(AdvancedTab, { handler: makeHandler('close-window') as any });
+
+    expect(screen.getByRole('radio', { name: 'Hide Window' }).getAttribute('aria-checked')).toBe(
+      'true',
+    );
+  });
+
+  it.each([
+    { initial: true, expected: false },
+    { initial: false, expected: true },
+  ])(
+    'persists Text expansion $initial -> $expected after leaving and returning',
+    async ({ initial, expected }) => {
+      persistedSnippetEnabled.value = initial;
+      const firstMount = render(AdvancedTab, { handler: makeHandler('go-back') as any });
+      const textExpansionToggle = screen.getAllByRole('checkbox')[3] as HTMLInputElement;
+
+      await vi.waitFor(() => expect(storeGetMock).toHaveBeenCalled());
+      await vi.waitFor(() => expect(textExpansionToggle.checked).toBe(initial));
+      await fireEvent.click(textExpansionToggle);
+      await vi.waitFor(() => expect(textExpansionToggle.checked).toBe(expected));
+
+      firstMount.unmount();
+      render(AdvancedTab, { handler: makeHandler('go-back') as any });
+
+      await vi.waitFor(() => {
+        expect((screen.getAllByRole('checkbox')[3] as HTMLInputElement).checked).toBe(expected);
+      });
+    },
+  );
+
+  it('keeps the previous Text expansion state when the backend rejects the toggle', async () => {
+    render(AdvancedTab, { handler: makeHandler('go-back') as any });
+    const textExpansionToggle = screen.getAllByRole('checkbox')[3] as HTMLInputElement;
+    await vi.waitFor(() => expect(storeGetMock).toHaveBeenCalled());
+    invokeMock.mockRejectedValueOnce(new Error('listener unavailable'));
+
+    await fireEvent.click(textExpansionToggle);
+
+    expect(await screen.findByText('set_snippets_enabled failed')).toBeTruthy();
+    expect(textExpansionToggle.checked).toBe(true);
+    expect(storeSetMock).not.toHaveBeenCalled();
+  });
+});

--- a/asyar-launcher/src/services/settings/settingsService.svelte.ts
+++ b/asyar-launcher/src/services/settings/settingsService.svelte.ts
@@ -384,6 +384,8 @@ class SettingsService implements ISettingsService {
           ...typedStored?.appearance,
         },
         extensions: {
+          ...DEFAULT_SETTINGS.extensions,
+          ...typedStored?.extensions,
           enabled: {
             ...DEFAULT_SETTINGS.extensions.enabled,
             ...typedStored?.extensions?.enabled,

--- a/asyar-launcher/src/services/settings/settingsService.test.ts
+++ b/asyar-launcher/src/services/settings/settingsService.test.ts
@@ -122,6 +122,12 @@ describe('mergeWithDefaults', () => {
     expect(result.extensions.enabled.store).toBe(true);
   });
 
+  it('preserves a persisted extensions.autoUpdate=false value', () => {
+    const result = merge({ extensions: { enabled: {}, autoUpdate: false } });
+
+    expect(result.extensions.autoUpdate).toBe(false);
+  });
+
   it('preserves the user field when present', () => {
     const result = merge({ user: { id: 'u1', syncEnabled: true } });
     expect(result.user).toEqual({ id: 'u1', syncEnabled: true });


### PR DESCRIPTION
## Summary

Fixes several state-handling issues in the Advanced Settings tab.

The primary issue caused the Advanced tab to render as a blank/black page because it attempted to access a nonexistent `settingsService.settings` property.

While validating the fix, several related persistence issues were also found and corrected.

## Fixes

- Fix Advanced Settings rendering by using the existing reactive `SettingsHandler` state.
- Fix Auto Update persistence through the supported Settings service API.
- Preserve `extensions.autoUpdate` when merging persisted settings.
- Use the canonical `escapeInViewBehavior` setting.
- Fix Text Expansion preference persistence across:
  - tab changes
  - Settings window reopen
  - application restart
  - Snippets view initialization
- Separate the durable Text Expansion preference from the effective runtime state.
- Prevent temporary macOS Accessibility permission state from overwriting the user's saved preference.
- Explicitly persist the Text Expansion preference during onboarding.

## Text Expansion state model

The fix separates two concepts:

```text
Durable user preference
    ↓
enabledPersistence
    ↓
preference && permissionGranted
    ↓
effective runtime state
    ↓
snippetService.setEnabled()