### PR TITLE
fix(snap-guides): defer set_ignore_cursor_events until window is show…

### DIFF
--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -213,19 +213,6 @@ pub fn apply_linux_webkit_dmabuf_workaround() {
     }
 }
 
-/// Pure decision logic for skipping snap-guides click-through configuration on Linux (issue #672).
-///
-/// On Linux (both X11 and Wayland), the snap-guides overlay is created with `visible: false`.
-/// An unmapped GTK window does not have an underlying GdkWindow surface yet (until realized/shown).
-/// Calling `set_ignore_cursor_events` dispatches `CursorIgnoreEvents` to tao's GTK event loop,
-/// which performs `window.window().unwrap()` and panics in an `extern "C"` FFI callback,
-/// causing a fatal non-unwinding abort.
-///
-/// Returns `true` if click-through initialization at startup should be skipped.
-fn should_skip_snap_guides_click_through(is_linux: bool) -> bool {
-    is_linux
-}
-
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Build the MCP transport factory before entering the builder chain. Its
@@ -1427,28 +1414,11 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         });
     }
 
-    // The snap-guides overlay must never intercept the drag it's decorating
-    // — click-through once at startup, not per-drag.
-    //
-    // Skipped on Linux (issue #672): the overlay is declared `visible: false`,
-    // and an unmapped GTK window has no GDK surface yet on either X11 or
-    // Wayland (until realized/shown). tao's CursorIgnoreEvents handler does
-    // `window.window().unwrap()` — see tao/src/platform_impl/linux/event_loop.rs —
-    // so calling this at startup aborts the whole process with a non-unwinding
-    // panic on the event-loop thread.
-    let skip_click_through = should_skip_snap_guides_click_through(cfg!(target_os = "linux"));
-    if skip_click_through {
-        log::warn!(
-            "[snap-guides] Linux session: skipping set_ignore_cursor_events \
-             on the hidden overlay (would abort the process in tao)."
-        );
-    } else if let Some(guides_window) =
-        handle.get_webview_window(crate::snap_guides::service::SNAP_GUIDES_WINDOW_LABEL)
-    {
-        if let Err(e) = guides_window.set_ignore_cursor_events(true) {
-            log::warn!("[snap-guides] set_ignore_cursor_events failed: {e}");
-        }
-    }
+    // The snap-guides overlay is declared `visible: false` in tauri.conf.json.
+    // Calling `set_ignore_cursor_events(true)` on an unmapped/hidden window
+    // causes fatal tao event-loop panics on Linux (unmapped GTK window unwrap)
+    // and Windows (subclassing/DPI runner state machine panic).
+    // Click-through configuration is deferred to `snap_guides::service::show()`.
 
     // Seed the launcher geometry from the persisted launchView BEFORE the
     // first panel.show(), so compact users never see the 480→96 reflow that
@@ -2855,22 +2825,5 @@ mod linux_webkit_dmabuf_workaround_tests {
     #[test]
     fn does_nothing_on_non_linux() {
         assert_eq!(linux_webkit_dmabuf_env_var(false), None);
-    }
-}
-
-#[cfg(test)]
-mod snap_guides_click_through_tests {
-    use super::should_skip_snap_guides_click_through;
-
-    // Issue #672: Calling `set_ignore_cursor_events(true)` on a hidden GTK window
-    // panics in tao on both X11 and Wayland.
-    #[test]
-    fn skips_click_through_on_linux() {
-        assert!(should_skip_snap_guides_click_through(true));
-    }
-
-    #[test]
-    fn enables_click_through_on_non_linux() {
-        assert!(!should_skip_snap_guides_click_through(false));
     }
 }

--- a/asyar-launcher/src-tauri/src/snap_guides/service.rs
+++ b/asyar-launcher/src-tauri/src/snap_guides/service.rs
@@ -35,11 +35,9 @@ pub fn show<R: Runtime>(
         }))
         .map_err(|e| AppError::Platform(format!("snap-guides set_position: {e}")))?;
     let _ = window.show();
-    #[cfg(target_os = "linux")]
-    {
-        // On Linux, set_ignore_cursor_events must be deferred until after the window is shown/realized
-        let _ = window.set_ignore_cursor_events(true);
-    }
+    // set_ignore_cursor_events must be deferred until after the window is shown/realized
+    // to avoid event loop / tao aborts on hidden/unmapped windows on Linux and Windows.
+    let _ = window.set_ignore_cursor_events(true);
     Ok(())
 }
 


### PR DESCRIPTION
…n across all platforms