### PR TITLE
perf(ipc): replace per-event emit evals with a long-poll event bridge

### DIFF
--- a/asyar-launcher/src-tauri/src/commands/app.rs
+++ b/asyar-launcher/src-tauri/src/commands/app.rs
@@ -113,6 +113,7 @@ pub fn commit_show(
     // reads is_visible mid-prepare would take the single-shot `show` path and
     // composite at alpha 1 before the new view has committed a fresh frame.
     state.asyar_visible.store(true, Ordering::Relaxed);
+    crate::scripts::inline_scheduler::nudge_reveal();
     Ok(())
 }
 
@@ -148,6 +149,7 @@ pub fn show(app_handle: AppHandle, state: tauri::State<'_, AppState>) -> Result<
         #[cfg(target_os = "linux")]
         crate::mark_launcher_shown(&state);
     }
+    crate::scripts::inline_scheduler::nudge_reveal();
     Ok(())
 }
 

--- a/asyar-launcher/src-tauri/src/commands/shortcuts.rs
+++ b/asyar-launcher/src-tauri/src/commands/shortcuts.rs
@@ -573,6 +573,7 @@ fn reveal_launcher(
 ) {
     state.asyar_visible.store(true, Ordering::Relaxed);
     crate::platform::macos::reveal_launcher_panel(window, panel);
+    crate::scripts::inline_scheduler::nudge_reveal();
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -590,6 +591,7 @@ fn reveal_launcher(state: &tauri::State<'_, AppState>, window: &tauri::WebviewWi
     let _ = window.set_focus();
     #[cfg(target_os = "linux")]
     crate::mark_launcher_shown(state);
+    crate::scripts::inline_scheduler::nudge_reveal();
 }
 
 fn launcher_visibility_after(action: LauncherAction, currently_visible: bool) -> bool {

--- a/asyar-launcher/src-tauri/src/event_bridge.rs
+++ b/asyar-launcher/src-tauri/src/event_bridge.rs
@@ -1,0 +1,129 @@
+//! Long-poll transport replacing Tauri's `app.emit` Rust->JS push.
+//!
+//! `app.emit` evaluates a freshly formatted JS program per event to inline
+//! the payload, which fragments JSC arenas in the always-hot launcher
+//! webview. The JS frontend instead long-polls `bridge_poll` and dispatches
+//! locally; `invoke` is fetch-based and eval-free. This module owns the
+//! Rust half: a bounded queue of pending events plus a `Notify` used to
+//! wake a parked poller. Emitters call [`bridge_emit`]; callers that fire
+//! before the JS side has connected still fall back to `app.emit` so
+//! early-boot events behave exactly as today.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager};
+use tokio::sync::Notify;
+
+/// Cap on the per-process bridge queue. Excess is dropped from the oldest
+/// end with a warning so a slow/absent poller can't OOM the host.
+const QUEUE_CAP: usize = 1024;
+
+/// Timeout for a parked poller. A returning `Ok(vec![])` is the no-op
+/// heartbeat; the JS side re-issues the poll.
+const POLL_TIMEOUT: Duration = Duration::from_secs(45);
+
+#[derive(Clone, serde::Serialize)]
+pub struct BridgeEvent {
+    pub event: String,
+    pub payload: serde_json::Value,
+}
+
+pub struct EventBridge {
+    queue: Mutex<VecDeque<BridgeEvent>>,
+    notify: Notify,
+    connected: AtomicBool,
+}
+
+impl Default for EventBridge {
+    fn default() -> Self {
+        Self {
+            queue: Mutex::new(VecDeque::new()),
+            notify: Notify::new(),
+            connected: AtomicBool::new(false),
+        }
+    }
+}
+
+/// Push `event`/`payload` to the bridge queue when the JS poller has
+/// connected; otherwise fall back to `app.emit` so early-boot events
+/// behave exactly as today. Payload shape is unchanged by this layer.
+pub fn bridge_emit<S: Serialize>(app: &AppHandle, event: &str, payload: S) {
+    let value = match serde_json::to_value(&payload) {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!("[event_bridge] failed to serialize payload for {event}: {e}");
+            return;
+        }
+    };
+
+    if let Some(bridge) = app.try_state::<Arc<EventBridge>>() {
+        if bridge.connected.load(Ordering::Relaxed) {
+            let mut q = bridge.queue.lock().expect("event_bridge mutex poisoned");
+            if q.len() >= QUEUE_CAP {
+                let dropped = q.pop_front();
+                log::warn!(
+                    "[event_bridge] queue full ({QUEUE_CAP}); dropping oldest {:?}",
+                    dropped.map(|e| e.event)
+                );
+            }
+            q.push_back(BridgeEvent {
+                event: event.to_string(),
+                payload: value,
+            });
+            // Lock released here by the end of the scope; notify_waiters is
+            // cheap and synchronous. Drop explicitly to make the boundary
+            // obvious to the reader.
+            drop(q);
+            bridge.notify.notify_waiters();
+            return;
+        }
+    }
+
+    // Sustained fallback means the poller never connected; surface it so a
+    // silent regression to the eval transport can't go unnoticed.
+    static FALLBACK_COUNT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = FALLBACK_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+    if n == 1 || n.is_multiple_of(100) {
+        log::warn!("[event_bridge] emit fallback in use ({n} events so far); latest: {event}");
+    }
+    if let Err(e) = app.emit(event, value) {
+        log::warn!("[event_bridge] fallback app.emit {event} failed: {e}");
+    }
+}
+
+/// Long-poll command. Returns the whole queued batch, waits on `Notify`
+/// (re-draining before each wake) and times out after `POLL_TIMEOUT`.
+#[tauri::command]
+pub async fn bridge_poll(
+    state: tauri::State<'_, Arc<EventBridge>>,
+) -> Result<Vec<BridgeEvent>, ()> {
+    if !state.connected.swap(true, Ordering::Relaxed) {
+        log::info!("[event_bridge] poller connected; eval transport retired");
+    }
+
+    loop {
+        // Register interest before draining: a notify_waiters landing
+        // between the drain and the await would otherwise be lost and the
+        // queued event would wait out the full poll timeout.
+        let notified = state.notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
+        let batch: Vec<BridgeEvent> = {
+            let mut q = state.queue.lock().expect("event_bridge mutex poisoned");
+            q.drain(..).collect()
+        };
+        if !batch.is_empty() {
+            return Ok(batch);
+        }
+
+        tokio::select! {
+            _ = &mut notified => continue,
+            _ = tokio::time::sleep(POLL_TIMEOUT) => return Ok(vec![]),
+        }
+    }
+}

--- a/asyar-launcher/src-tauri/src/extensions/extension_runtime/emitter.rs
+++ b/asyar-launcher/src-tauri/src/extensions/extension_runtime/emitter.rs
@@ -30,7 +30,7 @@ pub fn emit_typed<T: Serialize>(emitter: &dyn EventEmitter, event: &str, payload
     emitter.emit_json(event, v);
 }
 
-use tauri::{AppHandle, Emitter};
+use tauri::AppHandle;
 
 pub struct TauriEventEmitter {
     pub app: AppHandle,
@@ -38,9 +38,7 @@ pub struct TauriEventEmitter {
 
 impl EventEmitter for TauriEventEmitter {
     fn emit_json(&self, event: &str, payload: serde_json::Value) {
-        if let Err(e) = self.app.emit(event, &payload) {
-            log::warn!("[extension-runtime] emit {event} failed: {e}");
-        }
+        crate::event_bridge::bridge_emit(&self.app, event, &payload);
     }
 }
 

--- a/asyar-launcher/src-tauri/src/extensions/extension_state/mod.rs
+++ b/asyar-launcher/src-tauri/src/extensions/extension_state/mod.rs
@@ -297,17 +297,11 @@ pub struct TauriStateEmitter {
 
 impl StateEventEmitter for TauriStateEmitter {
     fn emit_state_changed(&self, payload: &StateChangedPayload) {
-        use tauri::Emitter;
-        if let Err(e) = self.app.emit("asyar:state-changed", payload) {
-            log::warn!("[extension_state] emit state-changed failed: {e}");
-        }
+        crate::event_bridge::bridge_emit(&self.app, "asyar:state-changed", payload);
     }
 
     fn emit_rpc_reply(&self, payload: &RpcReplyPayload) {
-        use tauri::Emitter;
-        if let Err(e) = self.app.emit("asyar:state-rpc-reply", payload) {
-            log::warn!("[extension_state] emit rpc-reply failed: {e}");
-        }
+        crate::event_bridge::bridge_emit(&self.app, "asyar:state-rpc-reply", payload);
     }
 }
 

--- a/asyar-launcher/src-tauri/src/extensions/update_scheduler.rs
+++ b/asyar-launcher/src-tauri/src/extensions/update_scheduler.rs
@@ -1,6 +1,6 @@
 use log::info;
 use std::time::Duration;
-use tauri::{AppHandle, Emitter};
+use tauri::AppHandle;
 
 const STARTUP_DELAY_SECS: u64 = 60;
 const CHECK_INTERVAL_SECS: u64 = 3600; // 1 hour
@@ -29,7 +29,7 @@ fn read_auto_update_setting(app: &AppHandle) -> bool {
 fn run_tick(app: &AppHandle) {
     if read_auto_update_setting(app) {
         info!("extension_updater: scheduled check running...");
-        let _ = app.emit("asyar:extension-update:tick", serde_json::json!({}));
+        crate::event_bridge::bridge_emit(app, "asyar:extension-update:tick", serde_json::json!({}));
     } else {
         info!("extension_updater: auto-update is disabled, skipping scheduled tick");
     }

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -139,6 +139,7 @@ pub mod crypto;
 pub mod deeplink;
 pub mod diagnostics;
 pub mod error;
+pub mod event_bridge;
 pub mod event_hub;
 pub mod ext_builder;
 pub mod extension_tray;
@@ -392,6 +393,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             deeplink::flush_pending_deeplinks,
             scheduler::get_scheduler_snapshot,
+            event_bridge::bridge_poll,
             commands::set_focus_lock,
             commands::feedback_publish,
             commands::feedback_get_current,
@@ -1185,6 +1187,10 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             log::error!("panic: {info}");
         }));
     }
+
+    // Long-poll IPC bridge: queue Rust->JS events for `bridge_poll` instead
+    // of letting Tauri `app.emit` eval-format each one in the webview.
+    app.manage(std::sync::Arc::new(event_bridge::EventBridge::default()));
 
     // ── Crash-report detection (next launch) ──────────────────────────────
     // A marker file left behind from the previous run means it crashed. Read
@@ -2050,9 +2056,11 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 "extensionId": extension_id,
                 "event": event,
             });
-            if let Err(e) = app_handle_for_events.emit("asyar:system-event", payload.clone()) {
-                log::warn!("[system_events] failed to emit Tauri event: {e}");
-            }
+            crate::event_bridge::bridge_emit(
+                &app_handle_for_events,
+                "asyar:system-event",
+                &payload,
+            );
             if let Some(mgr) =
                 app_handle_for_events.try_state::<std::sync::Arc<ExtensionRuntimeManager>>()
             {
@@ -2086,9 +2094,11 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 "extensionId": extension_id,
                 "event": event,
             });
-            if let Err(e) = app_handle_for_app_events.emit("asyar:app-event", payload.clone()) {
-                log::warn!("[app_events] failed to emit Tauri event: {e}");
-            }
+            crate::event_bridge::bridge_emit(
+                &app_handle_for_app_events,
+                "asyar:app-event",
+                &payload,
+            );
             if let Some(mgr) =
                 app_handle_for_app_events.try_state::<std::sync::Arc<ExtensionRuntimeManager>>()
             {
@@ -2124,11 +2134,11 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 "extensionId": extension_id,
                 "event": event,
             });
-            if let Err(e) =
-                app_handle_for_index_events.emit("asyar:application-index", payload.clone())
-            {
-                log::warn!("[index_events] failed to emit Tauri event: {e}");
-            }
+            crate::event_bridge::bridge_emit(
+                &app_handle_for_index_events,
+                "asyar:application-index",
+                &payload,
+            );
             if let Some(mgr) =
                 app_handle_for_index_events.try_state::<std::sync::Arc<ExtensionRuntimeManager>>()
             {
@@ -2278,9 +2288,7 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
             });
-            if let Err(e) = app_handle_for_fs_watch.emit("asyar:fs-watch", payload) {
-                log::warn!("[fs_watcher] failed to emit Tauri event: {e}");
-            }
+            crate::event_bridge::bridge_emit(&app_handle_for_fs_watch, "asyar:fs-watch", &payload);
         }));
     }
 
@@ -2389,9 +2397,11 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     "extensionId": extension_id,
                     "event": event,
                 });
-                if let Err(e) = app_handle_for_events.emit("asyar:browser-event", payload.clone()) {
-                    log::warn!("[browser_events] failed to emit Tauri event: {e}");
-                }
+                crate::event_bridge::bridge_emit(
+                    &app_handle_for_events,
+                    "asyar:browser-event",
+                    &payload,
+                );
                 if let Some(mgr) = app_handle_for_events.try_state::<Arc<ExtensionRuntimeManager>>()
                 {
                     let now = std::time::Instant::now();

--- a/asyar-launcher/src-tauri/src/scripts/inline_scheduler.rs
+++ b/asyar-launcher/src-tauri/src/scripts/inline_scheduler.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Manager};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::task::JoinHandle;
 
@@ -190,21 +190,64 @@ pub fn clear_inline_scripts(state: &InlineSchedulerState) -> Result<(), AppError
     Ok(())
 }
 
+static REVEAL_NUDGE: std::sync::OnceLock<std::sync::Arc<tokio::sync::Notify>> =
+    std::sync::OnceLock::new();
+
+/// Wake any parked inline-script tasks. Cheap and synchronous
+/// (`Notify::notify_waiters`); safe to call from the show path. No-op if
+/// no scheduler task has spun up yet (OnceLock not initialized).
+pub fn nudge_reveal() {
+    if let Some(n) = REVEAL_NUDGE.get() {
+        n.notify_waiters();
+    }
+}
+
+fn shared_nudge() -> std::sync::Arc<tokio::sync::Notify> {
+    REVEAL_NUDGE
+        .get_or_init(|| std::sync::Arc::new(tokio::sync::Notify::new()))
+        .clone()
+}
+
 /// Spawn the per-spec ticking loop. Fires once immediately so the row's
 /// subtitle is populated as soon as the script is registered, then every
-/// `refresh_time_seconds`.
+/// `refresh_time_seconds`. While the launcher is hidden (`asyar_visible ==
+/// false`) interval ticks set `pending` and skip the spawn; a reveal
+/// nudge (`nudge_reveal`) wakes the loop and flushes a single pending tick
+/// so subtitles refresh immediately on show without spawning background
+/// processes while parked.
 fn spawn_inline_task(app: AppHandle, spec: InlineScriptSpec) -> JoinHandle<()> {
+    let nudge = shared_nudge();
     tokio::spawn(async move {
-        // Immediate first tick
+        // Immediate first tick, unconditional: populates the subtitle.
         run_one_tick(&app, &spec).await;
 
         let mut interval = tokio::time::interval(Duration::from_secs(spec.refresh_time_seconds));
         // interval.tick() fires immediately by default; we already fired,
         // so skip the leading tick.
         interval.tick().await;
+
+        let mut pending = false;
         loop {
-            interval.tick().await;
-            run_one_tick(&app, &spec).await;
+            tokio::select! {
+                _ = interval.tick() => {
+                    let visible = app
+                        .try_state::<crate::AppState>()
+                        .map(|s| s.asyar_visible.load(std::sync::atomic::Ordering::Relaxed))
+                        .unwrap_or(true);
+                    if visible {
+                        run_one_tick(&app, &spec).await;
+                        pending = false;
+                    } else {
+                        pending = true;
+                    }
+                }
+                _ = nudge.notified() => {
+                    if pending {
+                        run_one_tick(&app, &spec).await;
+                        pending = false;
+                    }
+                }
+            }
         }
     })
 }
@@ -223,7 +266,7 @@ async fn run_one_tick(app: &AppHandle, spec: &InlineScriptSpec) {
             error: Some(e.to_string()),
         },
     };
-    let _ = app.emit("scripts:inline:tick", payload);
+    crate::event_bridge::bridge_emit(app, "scripts:inline:tick", &payload);
 }
 
 /// Spawn the script, read stdout, return the first non-empty trimmed

--- a/asyar-launcher/src-tauri/src/timers/scheduler.rs
+++ b/asyar-launcher/src-tauri/src/timers/scheduler.rs
@@ -14,7 +14,7 @@ use crate::shell::now_millis;
 use crate::timers::{TimerDescriptor, TimerFirePayload, TimerRegistry, TIMER_FIRE_EVENT};
 use log::{info, warn};
 use std::time::Duration;
-use tauri::{AppHandle, Emitter};
+use tauri::AppHandle;
 
 const POLL_INTERVAL_SECS: u64 = 1;
 const PRUNE_INTERVAL_SECS: u64 = 3600;
@@ -108,9 +108,7 @@ pub(crate) fn fire_one(
         fire_at: desc.fire_at,
         fired_at,
     };
-    if let Err(e) = app.emit(TIMER_FIRE_EVENT, &payload) {
-        warn!("[timers] failed to emit {}: {}", TIMER_FIRE_EVENT, e);
-    }
+    crate::event_bridge::bridge_emit(app, TIMER_FIRE_EVENT, &payload);
 }
 
 #[cfg(test)]

--- a/asyar-launcher/src/built-in-features/scripts/scriptsManager.svelte.ts
+++ b/asyar-launcher/src/built-in-features/scripts/scriptsManager.svelte.ts
@@ -12,6 +12,7 @@ import {
 import { logService } from '../../services/log/logService';
 import { commandService } from '../../services/extension/commandService.svelte';
 import { feedbackService } from '../../services/feedback/feedbackService.svelte';
+import { bridgeListen } from '../../lib/ipc/bridgeEvents';
 import type { ScannedScript, ScriptScanIssue } from './types';
 import type { DynamicCommandRegistration } from 'asyar-sdk/contracts';
 
@@ -42,9 +43,12 @@ export class ScriptsManager {
         logService.warn(`[scripts] refresh on event failed: ${err}`);
       });
     });
-    this.unlistenInlineTick = await listen<InlineTickPayload>('scripts:inline:tick', (event) => {
-      this.applyInlineTick(event.payload);
-    });
+    this.unlistenInlineTick = await bridgeListen<InlineTickPayload>(
+      'scripts:inline:tick',
+      (event) => {
+        this.applyInlineTick(event.payload);
+      },
+    );
     try {
       await this.refresh();
     } catch (err) {

--- a/asyar-launcher/src/built-in-features/scripts/scriptsManager.test.ts
+++ b/asyar-launcher/src/built-in-features/scripts/scriptsManager.test.ts
@@ -17,6 +17,10 @@ vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn(async () => () => {}),
 }));
 
+vi.mock('../../lib/ipc/bridgeEvents', () => ({
+  bridgeListen: vi.fn(async () => () => {}),
+}));
+
 vi.mock('../../services/log/logService', () => ({
   logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
@@ -32,6 +36,7 @@ vi.mock('../../services/extension/commandService.svelte', () => ({
 import { scriptsManager } from './scriptsManager.svelte';
 import * as commands from '../../lib/ipc/commands';
 import { listen } from '@tauri-apps/api/event';
+import { bridgeListen } from '../../lib/ipc/bridgeEvents';
 import { feedbackService } from '../../services/feedback/feedbackService.svelte';
 import { commandService } from '../../services/extension/commandService.svelte';
 import type { ScannedScript, ScriptScanIssue, ScriptScanReport } from './types';
@@ -121,9 +126,6 @@ describe('ScriptsManager', () => {
   it('scripts_changed_event_triggers_rescan', async () => {
     let capturedHandler: (() => void) | null = null;
     vi.mocked(listen).mockImplementation(async (event, handler) => {
-      // start() registers two listeners; only `scripts:changed` carries
-      // the rescan trigger. The inline-tick handler reads `event.payload`,
-      // so we MUST scope this capture to the right event name.
       if (event === 'scripts:changed') {
         capturedHandler = handler as () => void;
       }
@@ -224,11 +226,10 @@ describe('ScriptsManager', () => {
   it('stop_clears_registrations_and_unsubscribes', async () => {
     const unlistenChanged = vi.fn();
     const unlistenInlineTick = vi.fn();
-    // start() registers two listeners in order: scripts:changed, then
-    // scripts:inline:tick. Queue both unlisten mocks in the same order.
-    vi.mocked(listen)
-      .mockResolvedValueOnce(unlistenChanged)
-      .mockResolvedValueOnce(unlistenInlineTick);
+    // scripts:changed subscribes via listen, scripts:inline:tick via the
+    // eval-free bridge.
+    vi.mocked(listen).mockResolvedValueOnce(unlistenChanged);
+    vi.mocked(bridgeListen).mockResolvedValueOnce(unlistenInlineTick);
 
     await scriptsManager.start();
     await scriptsManager.stop();
@@ -344,13 +345,11 @@ describe('ScriptsManager', () => {
           payload: { dynamicId: string; subtitle: string | null; error: string | null };
         }) => void)
       | null = null;
-    // First listen() call = 'scripts:changed' (unused here), second = 'scripts:inline:tick'.
-    vi.mocked(listen)
-      .mockImplementationOnce(async () => () => {})
-      .mockImplementationOnce(async (_event, handler) => {
-        captured = handler as any;
-        return () => {};
-      });
+    // 'scripts:inline:tick' subscribes via the eval-free bridge.
+    vi.mocked(bridgeListen).mockImplementationOnce(async (_event, handler) => {
+      captured = handler as any;
+      return () => {};
+    });
 
     await scriptsManager.start();
     expect(captured).toBeTruthy();
@@ -367,12 +366,10 @@ describe('ScriptsManager', () => {
           payload: { dynamicId: string; subtitle: string | null; error: string | null };
         }) => void)
       | null = null;
-    vi.mocked(listen)
-      .mockImplementationOnce(async () => () => {})
-      .mockImplementationOnce(async (_event, handler) => {
-        captured = handler as any;
-        return () => {};
-      });
+    vi.mocked(bridgeListen).mockImplementationOnce(async (_event, handler) => {
+      captured = handler as any;
+      return () => {};
+    });
 
     await scriptsManager.start();
     captured!({

--- a/asyar-launcher/src/lib/ipc/bridgeEvents.ts
+++ b/asyar-launcher/src/lib/ipc/bridgeEvents.ts
@@ -1,0 +1,84 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export interface BridgeEvent {
+  event: string;
+  payload: unknown;
+}
+
+const PENDING_CAP = 256;
+
+const handlers = new Map<string, Set<(e: { payload: any }) => void>>();
+const pending = new Map<string, unknown[]>();
+let started = false;
+
+function bufferPayload(event: string, payload: unknown): void {
+  const queue = pending.get(event);
+  if (!queue) {
+    pending.set(event, [payload]);
+    return;
+  }
+  queue.push(payload);
+  if (queue.length > PENDING_CAP) queue.shift();
+}
+
+export async function bridgeListen<T>(
+  event: string,
+  cb: (e: { payload: T }) => void,
+): Promise<() => void> {
+  let set = handlers.get(event);
+  if (!set) {
+    set = new Set();
+    handlers.set(event, set);
+  }
+  set.add(cb as (e: { payload: any }) => void);
+
+  const queue = pending.get(event);
+  if (queue && queue.length > 0) {
+    pending.delete(event);
+    for (const payload of queue) {
+      try {
+        cb({ payload: payload as T });
+      } catch {
+        // A flushing handler throwing must not block subsequent flushes.
+      }
+    }
+  }
+
+  return () => {
+    const current = handlers.get(event);
+    if (!current) return;
+    current.delete(cb as (e: { payload: any }) => void);
+    if (current.size === 0) handlers.delete(event);
+  };
+}
+
+export function startBridgeLoop(): void {
+  if (started) return;
+  started = true;
+
+  void (async () => {
+    while (true) {
+      let events: BridgeEvent[];
+      try {
+        events = await invoke<BridgeEvent[]>('bridge_poll');
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        continue;
+      }
+      for (const { event, payload } of events) {
+        const set = handlers.get(event);
+        if (set && set.size > 0) {
+          for (const handler of set) {
+            try {
+              handler({ payload });
+            } catch {
+              // A throwing handler must not kill the loop or skip other handlers.
+            }
+          }
+        } else {
+          bufferPayload(event, payload);
+        }
+      }
+    }
+  })();
+}

--- a/asyar-launcher/src/services/appInitializer.ts
+++ b/asyar-launcher/src/services/appInitializer.ts
@@ -53,6 +53,7 @@ import { iframeDeliveryListener } from './extension/iframeDeliveryListener.svelt
 import { restoreWorkers } from '../lib/ipc/iframeLifecycleCommands';
 import { feedbackService } from './feedback/feedbackService.svelte';
 import { setInvokeFailureReporter } from '../lib/ipc/invokeSafe';
+import { startBridgeLoop } from '../lib/ipc/bridgeEvents';
 
 // Flag to prevent multiple initializations
 let isInitialized = false;
@@ -83,6 +84,10 @@ export const appInitializer = {
     isInitialized = true; // Set early to prevent concurrent calls
 
     try {
+      // Start the eval-free event bridge loop first so early Rust events
+      // get buffered rather than lost before listeners register.
+      startBridgeLoop();
+
       logService.info(`Application starting initialization...`);
 
       // Route invoke failures to the diagnostics UI. Wired here (composition

--- a/asyar-launcher/src/services/dev/inspectorStore.svelte.ts
+++ b/asyar-launcher/src/services/dev/inspectorStore.svelte.ts
@@ -13,6 +13,7 @@ import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { logService } from '../log/logService';
 import extensionManager from '../extension/extensionManager.svelte';
 import { developerSettingsService } from '../settings/developerSettingsService.svelte';
+import { bridgeListen } from '../../lib/ipc/bridgeEvents';
 import { getExtensionRuntimeSnapshot } from '../../lib/ipc/iframeLifecycleCommands';
 import {
   forceRemountWorker as forceRemountWorkerCommand,
@@ -200,7 +201,7 @@ class InspectorStore {
       void this.refreshSubscriptions(id);
     }, SUBS_POLL_MS);
 
-    const unsubMount = await listen<{
+    const unsubMount = await bridgeListen<{
       extensionId: string;
       mountToken?: number;
       role?: ContextRoleWire;
@@ -213,7 +214,7 @@ class InspectorStore {
       });
     });
 
-    const unsubUnmount = await listen<{
+    const unsubUnmount = await bridgeListen<{
       extensionId: string;
       role?: ContextRoleWire;
       reason?: string;
@@ -226,7 +227,7 @@ class InspectorStore {
       }
     });
 
-    const unsubDegraded = await listen<{
+    const unsubDegraded = await bridgeListen<{
       extensionId: string;
       strikes?: number;
       role?: ContextRoleWire;
@@ -239,7 +240,7 @@ class InspectorStore {
       });
     });
 
-    const unsubStateChanged = await listen<{
+    const unsubStateChanged = await bridgeListen<{
       extensionId: string;
       key: string;
       value: unknown;
@@ -252,8 +253,19 @@ class InspectorStore {
 
     this.#unlisteners.push(unsubMount, unsubUnmount, unsubDegraded, unsubStateChanged);
 
+    const BRIDGED_EVENTS = new Set([
+      'asyar:iframe:mount',
+      'asyar:iframe:unmount',
+      'asyar:iframe:degraded',
+      'asyar:state-changed',
+      'asyar:state-rpc-reply',
+      'asyar:system-event',
+      'asyar:app-event',
+    ]);
+
     for (const channel of TAPPED_EVENTS) {
-      const un = await listen<unknown>(channel, (event) => {
+      const subscribe = BRIDGED_EVENTS.has(channel) ? bridgeListen<unknown> : listen<unknown>;
+      const un = await subscribe(channel, (event) => {
         this.recordEvent(channel, event.payload);
       });
       this.#unlisteners.push(un);

--- a/asyar-launcher/src/services/eventPushBridge/createPushBridge.ts
+++ b/asyar-launcher/src/services/eventPushBridge/createPushBridge.ts
@@ -1,6 +1,7 @@
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { type UnlistenFn } from '@tauri-apps/api/event';
 import { logService } from '../log/logService';
 import { getExtensionFrameOrigin } from '../../lib/ipc/extensionOrigin';
+import { bridgeListen } from '../../lib/ipc/bridgeEvents';
 
 interface EventEnvelope {
   extensionId: string;
@@ -38,7 +39,7 @@ export function createPushBridge(
   return {
     async init(): Promise<void> {
       if (unlisten) return;
-      unlisten = await listen<EventEnvelope>(tauriEventName, (msg) => {
+      unlisten = await bridgeListen<EventEnvelope>(tauriEventName, (msg) => {
         const { extensionId, event } = msg.payload;
         // Prefer the worker iframe. Push-event subscribers (systemEvents,
         // appEvents, etc.) are installed from the worker so their callbacks

--- a/asyar-launcher/src/services/extension/extensionUpdateService.svelte.ts
+++ b/asyar-launcher/src/services/extension/extensionUpdateService.svelte.ts
@@ -4,6 +4,7 @@ import { logService } from '../log/logService';
 import { permissionConsentService } from './permissionConsentService.svelte';
 import { settingsService } from '../settings/settingsService.svelte';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { bridgeListen } from '../../lib/ipc/bridgeEvents';
 import type { AvailableUpdate, UpdateProgressStatus } from '../../types/ExtensionUpdate';
 
 class ExtensionUpdateService {
@@ -40,7 +41,7 @@ class ExtensionUpdateService {
         this.updateProgress = event.payload;
       },
     );
-    this.unlistenTick = await listen<void>('asyar:extension-update:tick', () => {
+    this.unlistenTick = await bridgeListen<void>('asyar:extension-update:tick', () => {
       this.checkAndAutoApply();
     });
   }

--- a/asyar-launcher/src/services/extension/extensionUpdateService.test.ts
+++ b/asyar-launcher/src/services/extension/extensionUpdateService.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn().mockResolvedValue(vi.fn()) }));
+vi.mock('../../lib/ipc/bridgeEvents', () => ({
+  bridgeListen: vi.fn().mockResolvedValue(vi.fn()),
+}));
 vi.mock('../envService', () => ({
   envService: { storeApiBaseUrl: 'http://localhost' },
 }));
@@ -24,16 +27,20 @@ vi.mock('../../lib/ipc/commands', () => ({
 describe('extensionUpdateService', () => {
   let extensionUpdateService: any;
   let listen: any;
+  let bridgeListen: any;
   let commands: any;
 
   beforeEach(async () => {
     vi.resetModules();
     ({ extensionUpdateService } = await import('./extensionUpdateService.svelte'));
     ({ listen } = await import('@tauri-apps/api/event'));
+    ({ bridgeListen } = await import('../../lib/ipc/bridgeEvents'));
     commands = await import('../../lib/ipc/commands');
     // Reset call history only, keep mock implementations from factory
     vi.mocked(listen).mockClear();
     vi.mocked(listen).mockResolvedValue(vi.fn());
+    vi.mocked(bridgeListen).mockClear();
+    vi.mocked(bridgeListen).mockResolvedValue(vi.fn());
     vi.mocked(commands.checkExtensionUpdates).mockClear();
   });
 
@@ -43,8 +50,8 @@ describe('extensionUpdateService', () => {
       async () => {},
     );
 
-    // listen must have been called with the tick event
-    const listenCalls = vi.mocked(listen).mock.calls;
+    // the tick subscription goes through the eval-free bridge
+    const listenCalls = vi.mocked(bridgeListen).mock.calls;
     const tickCall = listenCalls.find(
       ([eventName]: [string]) => eventName === 'asyar:extension-update:tick',
     );

--- a/asyar-launcher/src/services/extension/iframeDeliveryListener.svelte.test.ts
+++ b/asyar-launcher/src/services/extension/iframeDeliveryListener.svelte.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const listeners = new Map<string, (e: { payload: unknown }) => void>();
 
-vi.mock('@tauri-apps/api/event', () => ({
-  listen: vi.fn(async (event: string, cb: (e: { payload: unknown }) => void) => {
+vi.mock('../../lib/ipc/bridgeEvents', () => ({
+  bridgeListen: vi.fn(async (event: string, cb: (e: { payload: unknown }) => void) => {
     listeners.set(event, cb);
     return () => listeners.delete(event);
   }),

--- a/asyar-launcher/src/services/extension/iframeDeliveryListener.svelte.ts
+++ b/asyar-launcher/src/services/extension/iframeDeliveryListener.svelte.ts
@@ -1,4 +1,4 @@
-import { listen } from '@tauri-apps/api/event';
+import { bridgeListen } from '../../lib/ipc/bridgeEvents';
 import { post } from './extensionDelivery';
 import type { IpcPendingMessage } from '../../lib/ipc/iframeLifecycleCommands';
 import { feedbackService } from '../feedback/feedbackService.svelte';
@@ -14,7 +14,7 @@ export class IframeDeliveryListener {
 
   async init(): Promise<void> {
     if (this.unlisten) return;
-    this.unlisten = await listen<DeliverPayload>('asyar:iframe:deliver', (e) => {
+    this.unlisten = await bridgeListen<DeliverPayload>('asyar:iframe:deliver', (e) => {
       const { extensionId, role, messages } = e.payload;
       const iframe = document.querySelector<HTMLIFrameElement>(
         `iframe[data-extension-id="${extensionId}"][data-role="${role}"]`,

--- a/asyar-launcher/src/services/extension/viewRegistry.svelte.test.ts
+++ b/asyar-launcher/src/services/extension/viewRegistry.svelte.test.ts
@@ -2,8 +2,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const listeners = new Map<string, (e: { payload: any }) => void>();
-vi.mock('@tauri-apps/api/event', () => ({
-  listen: vi.fn(async (event: string, handler: (e: { payload: any }) => void) => {
+vi.mock('../../lib/ipc/bridgeEvents', () => ({
+  bridgeListen: vi.fn(async (event: string, handler: (e: { payload: any }) => void) => {
     listeners.set(event, handler);
     return () => listeners.delete(event);
   }),

--- a/asyar-launcher/src/services/extension/viewRegistry.svelte.ts
+++ b/asyar-launcher/src/services/extension/viewRegistry.svelte.ts
@@ -1,4 +1,4 @@
-import { listen } from '@tauri-apps/api/event';
+import { bridgeListen } from '../../lib/ipc/bridgeEvents';
 import { iframeUnmountAck } from '../../lib/ipc/iframeLifecycleCommands';
 import { logService } from '../log/logService';
 
@@ -18,14 +18,16 @@ class ViewRegistry {
 
   async init(): Promise<void> {
     if (this.unlistenMount) return;
-    this.unlistenMount = await listen<{ extensionId: string; mountToken: number; role?: string }>(
-      'asyar:iframe:mount',
-      (e) => this.handleMount(e.payload),
-    );
-    this.unlistenUnmount = await listen<{ extensionId: string; reason: string; role?: string }>(
-      'asyar:iframe:unmount',
-      (e) => this.handleUnmount(e.payload),
-    );
+    this.unlistenMount = await bridgeListen<{
+      extensionId: string;
+      mountToken: number;
+      role?: string;
+    }>('asyar:iframe:mount', (e) => this.handleMount(e.payload));
+    this.unlistenUnmount = await bridgeListen<{
+      extensionId: string;
+      reason: string;
+      role?: string;
+    }>('asyar:iframe:unmount', (e) => this.handleUnmount(e.payload));
   }
 
   async reset(): Promise<void> {

--- a/asyar-launcher/src/services/extension/workerRegistry.svelte.test.ts
+++ b/asyar-launcher/src/services/extension/workerRegistry.svelte.test.ts
@@ -2,8 +2,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const listeners = new Map<string, (e: { payload: any }) => void>();
-vi.mock('@tauri-apps/api/event', () => ({
-  listen: vi.fn(async (event: string, handler: (e: { payload: any }) => void) => {
+vi.mock('../../lib/ipc/bridgeEvents', () => ({
+  bridgeListen: vi.fn(async (event: string, handler: (e: { payload: any }) => void) => {
     listeners.set(event, handler);
     return () => listeners.delete(event);
   }),

--- a/asyar-launcher/src/services/extension/workerRegistry.svelte.ts
+++ b/asyar-launcher/src/services/extension/workerRegistry.svelte.ts
@@ -1,4 +1,4 @@
-import { listen } from '@tauri-apps/api/event';
+import { bridgeListen } from '../../lib/ipc/bridgeEvents';
 import { iframeUnmountAck } from '../../lib/ipc/iframeLifecycleCommands';
 import { logService } from '../log/logService';
 
@@ -18,14 +18,16 @@ class WorkerRegistry {
 
   async init(): Promise<void> {
     if (this.unlistenMount) return;
-    this.unlistenMount = await listen<{ extensionId: string; mountToken: number; role?: string }>(
-      'asyar:iframe:mount',
-      (e) => this.handleMount(e.payload),
-    );
-    this.unlistenUnmount = await listen<{ extensionId: string; reason: string; role?: string }>(
-      'asyar:iframe:unmount',
-      (e) => this.handleUnmount(e.payload),
-    );
+    this.unlistenMount = await bridgeListen<{
+      extensionId: string;
+      mountToken: number;
+      role?: string;
+    }>('asyar:iframe:mount', (e) => this.handleMount(e.payload));
+    this.unlistenUnmount = await bridgeListen<{
+      extensionId: string;
+      reason: string;
+      role?: string;
+    }>('asyar:iframe:unmount', (e) => this.handleUnmount(e.payload));
   }
 
   async reset(): Promise<void> {

--- a/asyar-launcher/src/services/extensionState/rpcReplyBridge.svelte.ts
+++ b/asyar-launcher/src/services/extensionState/rpcReplyBridge.svelte.ts
@@ -1,6 +1,7 @@
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { type UnlistenFn } from '@tauri-apps/api/event';
 import { logService } from '../log/logService';
 import { getExtensionFrameOrigin } from '../../lib/ipc/extensionOrigin';
+import { bridgeListen } from '../../lib/ipc/bridgeEvents';
 
 /**
  * Bridges Rust-relayed worker → view RPC replies to the calling view
@@ -31,7 +32,7 @@ class RpcReplyBridge implements PushBridge {
 
   async init(): Promise<void> {
     if (this.unlisten) return;
-    this.unlisten = await listen<RpcReplyEnvelope>('asyar:state-rpc-reply', (msg) => {
+    this.unlisten = await bridgeListen<RpcReplyEnvelope>('asyar:state-rpc-reply', (msg) => {
       const { extensionId, correlationId, result, error } = msg.payload;
       const iframe = document.querySelector(
         `iframe[data-extension-id="${extensionId}"][data-role="view"]`,

--- a/asyar-launcher/src/services/extensionState/stateChangedBridge.svelte.ts
+++ b/asyar-launcher/src/services/extensionState/stateChangedBridge.svelte.ts
@@ -1,6 +1,7 @@
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { type UnlistenFn } from '@tauri-apps/api/event';
 import { logService } from '../log/logService';
 import { getExtensionFrameOrigin } from '../../lib/ipc/extensionOrigin';
+import { bridgeListen } from '../../lib/ipc/bridgeEvents';
 
 /**
  * Bridges Rust-emitted `asyar:state-changed` Tauri events to the matching
@@ -32,7 +33,7 @@ class StateChangedBridge implements PushBridge {
 
   async init(): Promise<void> {
     if (this.unlisten) return;
-    this.unlisten = await listen<StateChangedEnvelope>('asyar:state-changed', (msg) => {
+    this.unlisten = await bridgeListen<StateChangedEnvelope>('asyar:state-changed', (msg) => {
       const { extensionId, key, value, role } = msg.payload;
       const iframe = document.querySelector(
         `iframe[data-extension-id="${extensionId}"][data-role="${role}"]`,

--- a/asyar-launcher/src/services/timers/timerBridge.svelte.ts
+++ b/asyar-launcher/src/services/timers/timerBridge.svelte.ts
@@ -1,4 +1,4 @@
-import { listen } from '@tauri-apps/api/event';
+import { bridgeListen } from '../../lib/ipc/bridgeEvents';
 import { logService } from '../log/logService';
 import { dispatch } from '../extension/extensionDispatcher.svelte';
 
@@ -47,7 +47,7 @@ export class TimerBridge {
   private unlisten: (() => void) | null = null;
 
   async subscribe(deps: TimerBridgeDeps): Promise<void> {
-    this.unlisten = await listen<TimerFirePayload>('asyar:timer:fire', (event) =>
+    this.unlisten = await bridgeListen<TimerFirePayload>('asyar:timer:fire', (event) =>
       this.handleFire(event.payload, deps.isExtensionEnabled),
     );
   }

--- a/asyar-launcher/src/services/timers/timerBridge.test.ts
+++ b/asyar-launcher/src/services/timers/timerBridge.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+vi.mock('../../lib/ipc/bridgeEvents', () => ({ bridgeListen: vi.fn() }));
 vi.mock('../log/logService', () => ({
   logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 vi.mock('../extension/extensionDispatcher.svelte', () => ({ dispatch: vi.fn() }));
 
-import { listen } from '@tauri-apps/api/event';
+import { bridgeListen } from '../../lib/ipc/bridgeEvents';
 import { dispatch } from '../extension/extensionDispatcher.svelte';
 import { logService } from '../log/logService';
 import { TimerBridge } from './timerBridge.svelte';
@@ -29,7 +29,7 @@ async function captureFireHandler(
   },
 ): Promise<FireHandler> {
   let captured: FireHandler | undefined;
-  vi.mocked(listen).mockImplementationOnce(async (_event, handler) => {
+  vi.mocked(bridgeListen).mockImplementationOnce(async (_event, handler) => {
     captured = handler as unknown as FireHandler;
     return vi.fn();
   });
@@ -41,11 +41,11 @@ async function captureFireHandler(
 describe('TimerBridge.subscribe', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('registers a Tauri listener for asyar:timer:fire', async () => {
+  it('registers a bridge listener for asyar:timer:fire', async () => {
     const bridge = new TimerBridge();
-    vi.mocked(listen).mockResolvedValueOnce(vi.fn());
+    vi.mocked(bridgeListen).mockResolvedValueOnce(vi.fn());
     await bridge.subscribe({ isExtensionEnabled: () => true });
-    expect(listen).toHaveBeenCalledWith('asyar:timer:fire', expect.any(Function));
+    expect(bridgeListen).toHaveBeenCalledWith('asyar:timer:fire', expect.any(Function));
   });
 });
 
@@ -160,7 +160,7 @@ describe('TimerBridge.unsubscribe', () => {
   it('calls the stored unlisten function and nulls it out', async () => {
     const bridge = new TimerBridge();
     const unlisten = vi.fn();
-    vi.mocked(listen).mockResolvedValueOnce(unlisten);
+    vi.mocked(bridgeListen).mockResolvedValueOnce(unlisten);
     await bridge.subscribe({ isExtensionEnabled: () => true });
 
     bridge.unsubscribe();


### PR DESCRIPTION
Sorry it's been a while @Xoshbin

I think I've found a bug in webkit on os 27, but chasing that showed a couple of other things. If I put a radar in with Apple, I don't think it'll get fixed before release now. I'll get these in and when I have time, I'll share what's been discovered because I think we could change on our side to work around it anyway.

Turned out @abdelrahman-alshurafa actually spotted that and PRd before I put mine in https://github.com/Xoshbin/asyar/pull/689

I'll keep my branch up so you can see what I was going for:
https://github.com/AllDaGearNoIdea/asyar/tree/fix/second-instance-main-thread

Anyway, for this one:
Every Tauri app.emit builds a new JS program with the payload in-lined into the source and evaluates it in webview (tauri 2.11.1 emit_js_script). Having a unique source per event means JSC's code cache never hits, so every scheduler tick, timer fire, and push event compiles fresh code. That's happening while the launcher sits hidden. On my machine, one of the extensions I've been building was making the launcher compile around 5 of these every 10s when parked.

This PR moves those tick-class events onto an eval-free path: Rust queues them in a bounded bridge (event_bridge.rs) and the front-end drains batches through a long-poll bridge_poll invoke (bridgeEvents.ts). One-shot user-action events stay on emit. Until the poller connects the bridge falls back to emit, with the fallback logged so a silent regression can't hide. Extensions see identical postMessages; no SDK surface changes.

It also gates the inline-script scheduler on launcher visibility: interval ticks (each spawns a process) hold while hidden, and a nudge on reveal runs one catch-up tick.

Under a load test at ~17x the shipping dispatch rate, webview growth stayed under 2x. Summon latency is unchanged (p50 13-16 ms, p95 23-27 ms, matching the control build).

Test:
- Frontend suite green (3273 tests; 6 test files updated to mock the bridge transport)
- cargo test, clippy -D warnings, fmt, and cargo doc clean
- Ran the branch: bridge connects at webview boot, zero fallback events after, scheduled deliveries and the hourly update tick flow end-to-end