### PR TITLE
docs(scheduler): macOS App Nap tolerance of background sleep loops

### DIFF
--- a/asyar-launcher/src-tauri/src/scheduler.rs
+++ b/asyar-launcher/src-tauri/src/scheduler.rs
@@ -82,6 +82,16 @@ impl Scheduler {
             } => {
                 // tauri's runtime (not raw tokio::spawn): setup_app can run
                 // before a Tokio reactor is attached.
+                //
+                // macOS App Nap coalesces long tokio sleeps once the app sits
+                // idle and hidden; a period of minutes or hours can stretch
+                // far past nominal until the next app wakeup. Acceptable for
+                // every current job (update checks, GC): each is periodic
+                // best-effort housekeeping that simply runs on wake. A job
+                // that needs punctual firing while the app is napping must
+                // not use this loop as-is; it needs OS-scheduled timing
+                // (NSBackgroundActivityScheduler or an explicit-tolerance
+                // timer).
                 async_runtime::spawn(async move {
                     tokio::time::sleep(startup_delay).await;
                     loop {

--- a/asyar-launcher/src-tauri/src/timers/scheduler.rs
+++ b/asyar-launcher/src-tauri/src/timers/scheduler.rs
@@ -49,6 +49,12 @@ pub fn start(app: AppHandle, registry: TimerRegistry) {
         let mut last_prune_ms: u64 = 0;
 
         loop {
+            // App Nap can add leeway to this sleep while the app idles
+            // hidden. Tolerable for the 1s cadence: a stretched tick fires a
+            // due timer late but never loses it (poll_due surfaces everything
+            // with fire_at <= now, and startup catch-up covers a relaunch),
+            // and observed coalescing on short intervals is far below the
+            // hours-scale stretch that hits minutes-long sleeps.
             tokio::time::sleep(Duration::from_secs(POLL_INTERVAL_SECS)).await;
             let now = now_millis();
             let plan = TickPlan::new(registry.should_poll(), now, last_prune_ms);


### PR DESCRIPTION
On macOS, App Nap stretches long tokio sleeps drastically once the app is idle and hidden. Overnight a 600s loop ran 2 iterations instead of ~40, whilst 1s and 10s loops held their cadence. The stretch hits sleeps up to minutes long, and only when napping, where the same loop is snappy when the app is warm.

Comments only, no behavioural change. Two additions so nobody builds punctuality on top of a loop that does not have it:
- scheduler.rs (fixed-interval supervisor: update checks, shell GC, notification purge): stretch is acceptable, every job is best-effort housekeeping. Anything needing punctual firing while napping must use OS-scheduled timing instead.
- timers/scheduler.rs (user-facing one-shot timers): a stretched tick fires a due timer late but never loses it, since the poll surfaces everything with fire_at <= now and startup catch-up covers relaunches.

The inline-script scheduler is left out: #712 makes parked behaviour explicit (ticks hold while hidden, flush on reveal).

Test:
- cargo fmt --check clean; comments only
- Overnight stretch measurements on test machine (600s loop: 2 iterations instead of ~40; 10s loops: cadence held)