### PR TITLE
fix(search): preserve IME composition in argument dropdown

### DIFF
--- a/asyar-launcher/src/components/form/ModelSelector.svelte
+++ b/asyar-launcher/src/components/form/ModelSelector.svelte
@@ -143,6 +143,10 @@
   }
 
   function handlePopoverKeydown(e: KeyboardEvent): void {
+    if (e.isComposing) {
+      e.stopPropagation();
+      return;
+    }
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       e.stopPropagation();

--- a/asyar-launcher/src/components/form/ModelSelector.test.ts
+++ b/asyar-launcher/src/components/form/ModelSelector.test.ts
@@ -168,4 +168,32 @@ describe('ModelSelector', () => {
 
     expect(screen.queryByRole('region', { name: /Model selector popover/i })).toBeNull();
   });
+
+  it.each(['Enter', 'Escape', 'ArrowDown', 'ArrowUp', 'Tab'])(
+    'leaves %s to the input method while composing in the filter input',
+    async (key) => {
+      const onchange = vi.fn();
+      render(ModelSelector, {
+        models: sampleModels,
+        value: 'openai/gpt-4o',
+        onchange,
+      });
+
+      await fireEvent.click(screen.getByRole('button', { name: /GPT-4o/ }));
+      const popover = screen.getByRole('region', { name: /Model selector popover/i });
+      expect(popover).toBeTruthy();
+
+      const event = new KeyboardEvent('keydown', {
+        key,
+        isComposing: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      await fireEvent(popover, event);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(screen.getByRole('region', { name: /Model selector popover/i })).toBeTruthy();
+      expect(onchange).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/asyar-launcher/src/components/layout/SearchHeader.svelte
+++ b/asyar-launcher/src/components/layout/SearchHeader.svelte
@@ -190,6 +190,9 @@
    * direction of travel first.
    */
   function handleQueryKeydown(e: KeyboardEvent): void {
+    if (e.isComposing) {
+      return;
+    }
     // Closes the Tab ring: forward from the query enters the first field,
     // backward enters the last. Outside argument mode Tab still falls
     // through to the global chain, which is what promotes into the mode.

--- a/asyar-launcher/src/components/search/ArgumentChipRow.svelte
+++ b/asyar-launcher/src/components/search/ArgumentChipRow.svelte
@@ -111,6 +111,10 @@
   }
 
   function handleFieldKeydown(idx: number, e: KeyboardEvent) {
+    if (e.isComposing) {
+      e.stopPropagation();
+      return;
+    }
     const atFirst = idx === 0;
     const isEmpty = (active.values[active.args[idx].name] ?? '') === '';
 

--- a/asyar-launcher/src/components/search/ArgumentChipRow.test.ts
+++ b/asyar-launcher/src/components/search/ArgumentChipRow.test.ts
@@ -279,5 +279,29 @@ describe('ArgumentChipRow', () => {
       await fireEvent.keyDown(trigger, { key: 'Enter' });
       expect(onSubmit).toHaveBeenCalled();
     });
+
+    it.each(['Enter', 'Escape', 'ArrowLeft', 'ArrowRight', 'Tab'])(
+      'leaves %s to the input method while composing text in a field',
+      async (key) => {
+        const row = await renderRow(makeActive());
+        const input = row.inputs[0];
+        const event = new KeyboardEvent('keydown', {
+          key,
+          isComposing: true,
+          bubbles: true,
+          cancelable: true,
+        });
+        await fireEvent(input, event);
+        await tick();
+
+        expect(event.defaultPrevented).toBe(false);
+        expect(row.onSubmit).not.toHaveBeenCalled();
+        expect(row.onExit).not.toHaveBeenCalled();
+        expect(row.onNext).not.toHaveBeenCalled();
+        expect(row.onPrev).not.toHaveBeenCalled();
+        expect(row.onMoveToQuery).not.toHaveBeenCalled();
+        expect(row.onFocusField).not.toHaveBeenCalled();
+      },
+    );
   });
 });

--- a/asyar-launcher/src/components/search/ArgumentDropdownChip.svelte
+++ b/asyar-launcher/src/components/search/ArgumentDropdownChip.svelte
@@ -173,6 +173,12 @@
   }
 
   function onListKeydown(e: KeyboardEvent): void {
+    // Candidate navigation and confirmation belong to the input method until
+    // composition ends, not to the dropdown or the launcher's keyboard handlers.
+    if (e.isComposing) {
+      e.stopPropagation();
+      return;
+    }
     if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
       e.preventDefault();
       e.stopPropagation();

--- a/asyar-launcher/src/components/search/ArgumentDropdownChip.test.ts
+++ b/asyar-launcher/src/components/search/ArgumentDropdownChip.test.ts
@@ -165,6 +165,41 @@ describe('ArgumentDropdownChip', () => {
     expect(reset.onReset).toHaveBeenCalled();
   });
 
+  it.each(['Enter', 'Escape', 'ArrowDown', 'ArrowUp', 'Tab'])(
+    'leaves %s to the input method while composing a search',
+    async (key) => {
+      const { trigger, filter, highlighted, onSelect, onReset, onKeydown } = await renderChip();
+      await fireEvent.click(trigger);
+      await fireEvent.input(filter()!, { target: { value: 'a' } });
+      await fireEvent.keyDown(filter()!, { key: 'ArrowDown' });
+      expect(highlighted()).toBe('All');
+
+      const input = filter()!;
+      const event = new KeyboardEvent('keydown', {
+        key,
+        isComposing: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      await fireEvent(input, event);
+      await tick();
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(filter()).toBe(input);
+      expect(input.value).toBe('a');
+      expect(document.activeElement).toBe(input);
+      expect(highlighted()).toBe('All');
+      expect(onSelect).not.toHaveBeenCalled();
+      expect(onReset).not.toHaveBeenCalled();
+      expect(onKeydown).not.toHaveBeenCalled();
+
+      // Once composition ends, Enter still selects the highlighted option.
+      await fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onSelect).toHaveBeenCalledWith('all');
+      expect(filter()).toBeNull();
+    },
+  );
+
   it('deleting the query keeps the list up; Escape clears it, then closes it', async () => {
     const { trigger, filter, view, optionTitles, onKeydown } = await renderChip();
     await fireEvent.keyDown(trigger, { key: 'a' });

--- a/asyar-launcher/src/components/search/SearchBarAccessoryDropdown.svelte
+++ b/asyar-launcher/src/components/search/SearchBarAccessoryDropdown.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Input, EmptyState } from '..';
+  import Input from '../base/Input.svelte';
+  import EmptyState from '../feedback/EmptyState.svelte';
   import { tick } from 'svelte';
   import KeyboardHint from '../base/KeyboardHint.svelte';
   import { searchBarAccessoryService } from '../../services/search/searchBarAccessoryService.svelte';
@@ -145,6 +146,10 @@
   }
 
   function onPopoverKeydown(e: KeyboardEvent) {
+    if (e.isComposing) {
+      e.stopPropagation();
+      return;
+    }
     if (e.key === 'Escape') {
       e.preventDefault();
       e.stopPropagation();

--- a/asyar-launcher/src/components/search/SearchBarAccessoryDropdown.test.ts
+++ b/asyar-launcher/src/components/search/SearchBarAccessoryDropdown.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import SearchBarAccessoryDropdown from './SearchBarAccessoryDropdown.svelte';
+
+describe('SearchBarAccessoryDropdown', () => {
+  const options = [
+    { value: 'all', title: 'All Items' },
+    { value: 'active', title: 'Active Items' },
+    { value: 'archived', title: 'Archived Items' },
+  ];
+
+  async function renderDropdown(props = {}) {
+    const onChange = vi.fn();
+    const onclose = vi.fn();
+    const view = render(SearchBarAccessoryDropdown, {
+      options,
+      value: 'all',
+      onChange,
+      onclose,
+      ...props,
+    });
+    const button = view.container.querySelector<HTMLButtonElement>('.accessory-button')!;
+    return { view, button, onChange, onclose };
+  }
+
+  it.each(['Enter', 'Escape', 'ArrowDown', 'ArrowUp', 'Tab'])(
+    'leaves %s to the input method while composing in the filter input',
+    async (key) => {
+      const { view, button, onChange, onclose } = await renderDropdown();
+      await fireEvent.click(button);
+      await tick();
+
+      const input = view.container.querySelector<HTMLInputElement>('.accessory-popover input')!;
+      expect(input).not.toBeNull();
+
+      const event = new KeyboardEvent('keydown', {
+        key,
+        isComposing: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      await fireEvent(input, event);
+      await tick();
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(view.container.querySelector('.accessory-popover')).not.toBeNull();
+      expect(onChange).not.toHaveBeenCalled();
+      expect(onclose).not.toHaveBeenCalled();
+
+      // After composition ends, Enter selects normally
+      await fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).toHaveBeenCalledWith('all');
+      expect(view.container.querySelector('.accessory-popover')).toBeNull();
+    },
+  );
+});

--- a/asyar-launcher/src/lib/keyboard/launcherKeyboard.test.ts
+++ b/asyar-launcher/src/lib/keyboard/launcherKeyboard.test.ts
@@ -269,6 +269,17 @@ describe('launcherKeyboard characterization tests', () => {
       expect(deps.handleEnterKey).not.toHaveBeenCalled();
     });
 
+    it('ignores global shortcuts when event.isComposing is true', () => {
+      const deps = createMockDeps();
+      const { handleGlobalKeydown } = createKeyboardHandlers(deps);
+      const event = createKeyEvent('Tab', { isComposing: true });
+
+      handleGlobalKeydown(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(event.stopPropagation).not.toHaveBeenCalled();
+    });
+
     describe('Cmd/Ctrl+Q Block Quit', () => {
       it('Cmd+Q is blocked', () => {
         const deps = createMockDeps();
@@ -942,6 +953,20 @@ describe('launcherKeyboard characterization tests', () => {
   });
 
   describe('handleKeydown', () => {
+    it('ignores navigation and submission keys when event.isComposing is true', () => {
+      searchStores.selectedIndex = 0;
+      const deps = createMockDeps({ getSearchResultsLength: vi.fn(() => 5) });
+      const { handleKeydown } = createKeyboardHandlers(deps);
+
+      for (const key of ['ArrowDown', 'ArrowUp', 'Enter', 'Escape']) {
+        const event = createKeyEvent(key, { isComposing: true });
+        handleKeydown(event);
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(searchStores.selectedIndex).toBe(0);
+        expect(deps.handleEnterKey).not.toHaveBeenCalled();
+      }
+    });
+
     describe('Search Navigation (no active view)', () => {
       it('ArrowDown increments selectedIndex', () => {
         searchStores.selectedIndex = 0;

--- a/asyar-launcher/src/lib/keyboard/launcherKeyboard.ts
+++ b/asyar-launcher/src/lib/keyboard/launcherKeyboard.ts
@@ -345,6 +345,9 @@ export function createKeyboardHandlers(deps: KeyboardDeps) {
       // bare only skips the launcher's own logic below.
       return;
     }
+    if (event.isComposing) {
+      return;
+    }
     // Searchbar accessory popover open: bail for navigation keys so the
     // popover's own keydown handler (Escape/Arrow/Enter/Tab) wins. The
     // launcher's listener is registered window+capture at page mount and
@@ -596,6 +599,7 @@ export function createKeyboardHandlers(deps: KeyboardDeps) {
   function handleKeydown(event: KeyboardEvent) {
     if (shortcutStore.isCapturing || isAnyModalOpen(document)) return;
     if (event.defaultPrevented) return;
+    if (event.isComposing) return;
     if (tryHandleEscape(event)) return;
     if (tryHandleBackspaceInView(event)) return;
     if (tryHandleSearchNavigation(event)) return;


### PR DESCRIPTION
While composing text in the argument dropdown filter, Enter can select an argument prematurely, Escape can clear the query, arrow keys can move the dropdown highlight, and Tab can close the list. These keys may belong to the active input method instead.

Return early for composing key events without preventing their default behavior, and stop them from bubbling to parent handlers. Normal dropdown behavior resumes for non-composing events.

Add five regression cases covering Enter, Escape, ArrowDown, ArrowUp, and Tab. Each checks that the query, focus, and highlight remain intact during composition and that Enter still selects the highlighted option afterward. All five cases failed before the fix and passed afterward.

Validation on Windows:
- Related search components: 61 tests passed across 3 files.
- Full launcher test suite: 3,419 passed, 4 failed. The failures are in external-bin-provisioning.test.mjs (LF-only regexes against CRLF checkout files) and feedbackBoundary.test.ts (Windows path separators versus slash-based allowlists).
- Changed-file Prettier check and design-system check passed.
- The full CI runner stopped at checkout-wide CRLF formatting differences; a separate full Prettier check with --end-of-line auto passed. Rust checks and native IME testing in the full desktop app were not run.