### PR TITLE
feat(ai): add Gemini Google Search grounding

### DIFF
--- a/asyar-launcher/src-tauri/src/agents/runner.rs
+++ b/asyar-launcher/src-tauri/src/agents/runner.rs
@@ -461,6 +461,9 @@ pub(crate) fn coalesce_consecutive_messages(messages: Vec<ChatMessage>) -> Vec<C
                 && matches!(message.role.as_str(), "user" | "assistant")
                 && previous.tool_calls.as_ref().is_none_or(Vec::is_empty)
                 && message.tool_calls.as_ref().is_none_or(Vec::is_empty)
+                // Signed provider parts must retain their original message boundary.
+                && previous.provider_context.as_ref().is_none_or(Vec::is_empty)
+                && message.provider_context.as_ref().is_none_or(Vec::is_empty)
         });
         if can_merge {
             let previous = output.last_mut().expect("checked above");

--- a/asyar-launcher/src-tauri/src/agents/runner_test.rs
+++ b/asyar-launcher/src-tauri/src/agents/runner_test.rs
@@ -1015,3 +1015,19 @@ fn resolve_provider_config_errors_when_base_url_is_missing() {
         .to_string()
         .contains("Base URL for provider 'ollama' is not configured"));
 }
+
+#[test]
+fn coalescing_preserves_provider_context_boundaries() {
+    let mut first = chat_message("assistant", "First");
+    first.provider_context = Some(vec![
+        json!({"geminiPart": {"text": "First", "thoughtSignature": "signed"}}),
+    ]);
+    let mut second = chat_message("assistant", "Second");
+    second.provider_context = Some(vec![json!({"geminiPart": {"text": "Second"}})]);
+    let messages = coalesce_consecutive_messages(vec![first, second]);
+    assert_eq!(messages.len(), 2);
+    assert_eq!(
+        messages[1].provider_context.as_ref().unwrap()[0]["geminiPart"]["text"],
+        "Second"
+    );
+}

--- a/asyar-launcher/src-tauri/src/ai/providers.rs
+++ b/asyar-launcher/src-tauri/src/ai/providers.rs
@@ -43,6 +43,7 @@ pub struct ProviderStreamParser {
     openai_tools: BTreeMap<u32, PendingToolCall>,
     anthropic_tool: Option<AnthropicToolBlock>,
     google_tool_counter: u32,
+    google_grounding: serde_json::Map<String, Value>,
     ollama_tool_counter: u32,
 }
 
@@ -58,6 +59,7 @@ impl ProviderStreamParser {
             openai_tools: BTreeMap::new(),
             anthropic_tool: None,
             google_tool_counter: 0,
+            google_grounding: serde_json::Map::new(),
             ollama_tool_counter: 0,
         }
     }
@@ -99,6 +101,10 @@ impl ProviderStreamParser {
                 name: pending.name,
                 input,
             });
+        }
+        if !self.google_grounding.is_empty() {
+            let metadata = Value::Object(std::mem::take(&mut self.google_grounding));
+            events.push(google_grounding_event(metadata));
         }
         Ok(events)
     }
@@ -299,6 +305,14 @@ impl ProviderStreamParser {
             .into_iter()
             .flatten()
         {
+            // Preserve every part (including signed thoughts and server-side tool
+            // context) unchanged for Gemini's next tool-continuation request.
+            if part.get("thought").and_then(Value::as_bool) == Some(true) {
+                events.push(ChatStreamEvent::ProviderContext {
+                    item: json!({ "geminiPart": part }),
+                });
+                continue;
+            }
             if let Some(token) = part.get("text").and_then(Value::as_str) {
                 if !token.is_empty() {
                     events.push(ChatStreamEvent::Token {
@@ -321,6 +335,17 @@ impl ProviderStreamParser {
                     input: call.get("args").cloned().unwrap_or_else(|| json!({})),
                 });
             }
+            events.push(ChatStreamEvent::ProviderContext {
+                item: json!({ "geminiPart": part }),
+            });
+        }
+        if let Some(metadata) = value
+            .pointer("/candidates/0/groundingMetadata")
+            .and_then(Value::as_object)
+        {
+            // Metadata may arrive separately from text and in several chunks.
+            // Keep the latest value for each field and publish one presentation.
+            self.google_grounding.extend(metadata.clone());
         }
         Ok(events)
     }
@@ -356,6 +381,48 @@ impl ProviderStreamParser {
             });
         }
         Ok(events)
+    }
+}
+
+fn google_grounding_event(metadata: Value) -> ChatStreamEvent {
+    let sources = metadata
+        .get("groundingChunks")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|chunk| {
+            let web = chunk.get("web")?;
+            let uri = web.get("uri")?.as_str()?;
+            let url = url::Url::parse(uri).ok()?;
+            if !matches!(url.scheme(), "http" | "https")
+                || url.host_str().is_none()
+                || !url.username().is_empty()
+                || url.password().is_some()
+            {
+                return None;
+            }
+            Some(crate::ai::types::GroundingSource {
+                title: web
+                    .get("title")
+                    .and_then(Value::as_str)
+                    .unwrap_or(uri)
+                    .to_owned(),
+                url: uri.to_owned(),
+            })
+        })
+        .collect();
+    let display = crate::ai::types::GeminiGrounding {
+        sources,
+        search_suggestions_html: metadata
+            .pointer("/searchEntryPoint/renderedContent")
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+    };
+    ChatStreamEvent::ProviderContext {
+        item: json!({
+            "geminiGrounding": metadata,
+            "geminiGroundingDisplay": display,
+        }),
     }
 }
 
@@ -697,6 +764,15 @@ fn build_google_request(
     messages: &[ChatMessage],
     params: &ChatParams,
 ) -> Result<RequestSpec, AppError> {
+    let custom_tools = params.tools.as_deref().unwrap_or_default();
+    let search_enabled = config.hosted_web_search == Some(true);
+    let gemini_3 =
+        params.model_id.starts_with("gemini-3-") || params.model_id.starts_with("gemini-3.");
+    if search_enabled && !custom_tools.is_empty() && !gemini_3 {
+        return Err(AppError::Validation(
+            "Google Search with agent tools requires Gemini 3. Select a Gemini 3 model, remove the agent's tools, or disable Google Search in AI settings.".into(),
+        ));
+    }
     let api_key = config.api_key.as_deref().unwrap_or("");
     let url = format!(
         "https://generativelanguage.googleapis.com/v1beta/models/{}:streamGenerateContent?alt=sse",
@@ -717,11 +793,46 @@ fn build_google_request(
             )
         })
         .collect();
+    // Internal IDs also identify calls from older Gemini models that omit IDs
+    // on the wire. Pair calls by their original order, without editing signatures.
+    let mut wire_ids = HashMap::new();
+    for message in messages {
+        let original_calls: Vec<&Value> = message
+            .provider_context
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|item| item.pointer("/geminiPart/functionCall"))
+            .collect();
+        for (index, call) in message
+            .tool_calls
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .enumerate()
+        {
+            let wire_id = original_calls
+                .get(index)
+                .map(|original| original.get("id").cloned())
+                .unwrap_or_else(|| Some(json!(call.id)));
+            wire_ids.insert(call.id.as_str(), wire_id);
+        }
+    }
     let contents = messages
         .iter()
         .filter(|message| message.role != "system")
         .map(|message| match message.role.as_str() {
             "assistant" => {
+                let original_parts: Vec<Value> = message
+                    .provider_context
+                    .as_deref()
+                    .unwrap_or_default()
+                    .iter()
+                    .filter_map(|item| item.get("geminiPart").cloned())
+                    .collect();
+                if !original_parts.is_empty() {
+                    return json!({ "role": "model", "parts": original_parts });
+                }
                 let mut parts = Vec::new();
                 if !message.content.is_empty() {
                     parts.push(json!({ "text": message.content }));
@@ -748,16 +859,14 @@ fn build_google_request(
                 let tool_call_id = message.tool_call_id.as_deref().unwrap_or_default();
                 let output = serde_json::from_str::<Value>(&message.content)
                     .unwrap_or_else(|_| Value::String(message.content.clone()));
-                json!({
-                    "role": "user",
-                    "parts": [{
-                        "functionResponse": {
-                            "id": tool_call_id,
-                            "name": tool_names_by_id.get(tool_call_id).cloned().unwrap_or_default(),
-                            "response": { "output": output },
-                        }
-                    }]
-                })
+                let mut response = json!({
+                    "name": tool_names_by_id.get(tool_call_id).cloned().unwrap_or_default(),
+                    "response": { "output": output },
+                });
+                if let Some(Some(id)) = wire_ids.get(tool_call_id) {
+                    response["id"] = id.clone();
+                }
+                json!({ "role": "user", "parts": [{ "functionResponse": response }] })
             }
             _ => json!({ "role": "user", "parts": [{ "text": message.content }] }),
         })
@@ -806,19 +915,24 @@ fn build_google_request(
             .insert("thinkingConfig".to_string(), thinking_config);
     }
 
-    if let Some(tools) = &params.tools {
-        if !tools.is_empty() {
-            body_map.as_object_mut().unwrap().insert(
-                "tools".to_string(),
-                json!([{
-                    "functionDeclarations": tools.iter().map(|tool| json!({
-                        "name": tool.name,
-                        "description": tool.description,
-                        "parameters": tool.parameters,
-                    })).collect::<Vec<_>>()
-                }]),
-            );
+    let mut tools = Vec::new();
+    if !custom_tools.is_empty() {
+        tools.push(json!({
+            "functionDeclarations": custom_tools.iter().map(|tool| json!({
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.parameters,
+            })).collect::<Vec<_>>()
+        }));
+    }
+    if search_enabled {
+        tools.push(json!({ "google_search": {} }));
+        if !custom_tools.is_empty() {
+            body_map["toolConfig"] = json!({ "includeServerSideToolInvocations": true });
         }
+    }
+    if !tools.is_empty() {
+        body_map["tools"] = json!(tools);
     }
 
     Ok(RequestSpec {

--- a/asyar-launcher/src-tauri/src/ai/providers_test.rs
+++ b/asyar-launcher/src-tauri/src/ai/providers_test.rs
@@ -578,3 +578,155 @@ fn test_build_ollama_request_includes_temperature_when_some() {
     let req = build_request("ollama", &config, &messages, &params).unwrap();
     assert_eq!(req.body["options"]["temperature"], 0.6);
 }
+
+#[test]
+fn google_search_preserves_custom_tools_on_gemini_3() {
+    let mut config = mock_config();
+    config.hosted_web_search = Some(true);
+    let mut params = tool_params();
+    params.model_id = "gemini-3-flash-preview".into();
+    let request = build_request("google", &config, &[], &params).unwrap();
+    assert_eq!(request.body["tools"][1], json!({"google_search": {}}));
+    assert_eq!(
+        request.body["toolConfig"]["includeServerSideToolInvocations"],
+        true
+    );
+    assert_eq!(
+        request.body["tools"][0]["functionDeclarations"][0]["name"],
+        "builtin__echo"
+    );
+}
+
+#[test]
+fn google_search_rejects_unsupported_custom_tool_combination() {
+    let mut config = mock_config();
+    config.hosted_web_search = Some(true);
+    let mut params = tool_params();
+    params.model_id = "gemini-2.5-flash".into();
+    assert!(build_request("google", &config, &[], &params)
+        .unwrap_err()
+        .to_string()
+        .contains("Gemini 3"));
+    params.tools = None;
+    assert_eq!(
+        build_request("google", &config, &[], &params).unwrap().body["tools"],
+        json!([{"google_search": {}}])
+    );
+    config.hosted_web_search = Some(false);
+    assert!(build_request("google", &config, &[], &params)
+        .unwrap()
+        .body
+        .get("tools")
+        .is_none());
+}
+
+#[test]
+fn google_retains_grounding_and_signed_parts_for_continuation() {
+    let config = mock_config();
+    let mut parser = ProviderStreamParser::new("google", &config);
+    let part = json!({"functionCall": {"id": "call-1", "name": "builtin__echo", "args": {}}, "thoughtSignature": "opaque"});
+    let grounding = json!({"webSearchQueries": ["weather"], "groundingChunks": [{"web": {"uri": "https://example.com", "title": "Weather"}}]});
+    let mut events = parser.push_line(&format!("data: {}", json!({"candidates": [{"content": {"parts": [part.clone()]}, "groundingMetadata": grounding.clone()}]}))).unwrap();
+    events.extend(parser.finish().unwrap());
+    let context: Vec<_> = events
+        .into_iter()
+        .filter_map(|event| match event {
+            ChatStreamEvent::ProviderContext { item } => Some(item),
+            _ => None,
+        })
+        .collect();
+    assert!(context.iter().any(|item| item["geminiPart"] == part));
+    assert!(context
+        .iter()
+        .any(|item| item["geminiGrounding"] == grounding));
+    let mut history = tool_history();
+    history[1].provider_context = Some(context);
+    let request = build_request("google", &config, &history, &tool_params()).unwrap();
+    assert_eq!(request.body["contents"][1]["parts"], json!([part]));
+}
+
+#[test]
+fn google_metadata_only_chunk_has_safe_typed_sources() {
+    let mut parser = ProviderStreamParser::new("google", &mock_config());
+    let mut events = parser.push_line(&format!("data: {}", json!({"candidates": [{"groundingMetadata": {
+        "groundingChunks": [{"web": {"uri": "https://example.com/a", "title": "A"}}, {"web": {"uri": "javascript:alert(1)", "title": "Unsafe"}}],
+        "searchEntryPoint": {"renderedContent": "<div>Search suggestions</div>"},
+        "groundingSupports": [{"segment": {"text": "Claim"}, "groundingChunkIndices": [0]}]
+    }}]}))).unwrap();
+    events.extend(parser.finish().unwrap());
+    let display = events
+        .iter()
+        .find_map(|event| match event {
+            ChatStreamEvent::ProviderContext { item } => item.get("geminiGroundingDisplay"),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(
+        display["sources"],
+        json!([{"title": "A", "url": "https://example.com/a"}])
+    );
+    assert_eq!(
+        display["searchSuggestionsHtml"],
+        "<div>Search suggestions</div>"
+    );
+    assert!(events.iter().any(|event| matches!(event, ChatStreamEvent::ProviderContext { item } if item["geminiGrounding"]["groundingSupports"].is_array())));
+}
+
+#[test]
+fn google_continuation_does_not_send_synthetic_id_to_api() {
+    let mut parser = ProviderStreamParser::new("google", &mock_config());
+    let events = parser.push_line("data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"builtin__echo\",\"args\":{}}}]}}]}").unwrap();
+    let mut history = tool_history();
+    history[1].provider_context = Some(
+        events
+            .iter()
+            .filter_map(|event| match event {
+                ChatStreamEvent::ProviderContext { item } => Some(item.clone()),
+                _ => None,
+            })
+            .collect(),
+    );
+    history[1].tool_calls.as_mut().unwrap()[0].id = "gemini-1".into();
+    history[2].tool_call_id = Some("gemini-1".into());
+    let request = build_request("google", &mock_config(), &history, &tool_params()).unwrap();
+    assert!(request.body["contents"][1]["parts"][0]["functionCall"]
+        .get("id")
+        .is_none());
+    assert!(request.body["contents"][2]["parts"][0]["functionResponse"]
+        .get("id")
+        .is_none());
+}
+
+#[test]
+fn google_emits_one_grounding_display_after_partial_metadata_chunks() {
+    let mut parser = ProviderStreamParser::new("google", &mock_config());
+    for metadata in [
+        json!({}),
+        json!({"groundingChunks": [{"web": {"uri": "https://example.com", "title": "Source"}}]}),
+        json!({"searchEntryPoint": {"renderedContent": "Suggestions"}}),
+    ] {
+        parser
+            .push_line(&format!(
+                "data: {}",
+                json!({"candidates": [{"groundingMetadata": metadata}]})
+            ))
+            .unwrap();
+    }
+    let events = parser.finish().unwrap();
+    assert_eq!(events.len(), 1);
+    let ChatStreamEvent::ProviderContext { item } = &events[0] else {
+        panic!("Expected grounding");
+    };
+    assert_eq!(
+        item["geminiGroundingDisplay"]["sources"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        item["geminiGroundingDisplay"]["searchSuggestionsHtml"],
+        "Suggestions"
+    );
+    assert!(parser.finish().unwrap().is_empty());
+}

--- a/asyar-launcher/src-tauri/src/ai/types.rs
+++ b/asyar-launcher/src-tauri/src/ai/types.rs
@@ -126,3 +126,19 @@ pub enum ChatStreamEventPayload {
         error: String,
     },
 }
+
+/// Presentation data derived from Gemini grounding metadata. The complete
+/// provider metadata remains in provider_context for attribution/history.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct GeminiGrounding {
+    pub sources: Vec<GroundingSource>,
+    pub search_suggestions_html: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct GroundingSource {
+    pub title: String,
+    pub url: String,
+}

--- a/asyar-launcher/src-tauri/src/search_engine/models.rs
+++ b/asyar-launcher/src-tauri/src/search_engine/models.rs
@@ -498,6 +498,7 @@ mod bindings_export {
             .register::<crate::calculator::CalcResult>()
             .register::<crate::calculator::CalcKind>()
             .register::<crate::ai::types::ChatMessage>()
+            .register::<crate::ai::types::GeminiGrounding>()
             .register::<crate::ai::types::ProviderConfig>()
             .register::<crate::ai::types::ModelInfo>()
             .register::<crate::ai::types::ChatParams>()

--- a/asyar-launcher/src/bindings.ts
+++ b/asyar-launcher/src/bindings.ts
@@ -189,6 +189,20 @@ export type FileSearchResponse = {
 export type FileType = "document" | "image" | "code" | "audio-video" | "archive" | "folder" | "other";
 
 /**
+ *  Presentation data derived from Gemini grounding metadata. The complete
+ *  provider metadata remains in provider_context for attribution/history.
+ */
+export type GeminiGrounding = {
+	sources: GroundingSource[],
+	searchSuggestionsHtml: string | null,
+};
+
+export type GroundingSource = {
+	title: string,
+	url: string,
+};
+
+/**
  *  Where a hit came from: the local index or an on-demand deep-search
  *  provider (mdfind / Everything / plocate).
  */

--- a/asyar-launcher/src/built-in-features/agents/AgentChatView.svelte
+++ b/asyar-launcher/src/built-in-features/agents/AgentChatView.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { openerService } from '../../services/opener/openerService';
+  import { externalSearchUrl } from '../../components/ai/googleSearchSuggestions';
   import { onMount, onDestroy, tick } from 'svelte';
   import { agentService } from './agentService.svelte';
   import { agentsManager } from './agentsManager.svelte';
@@ -6,12 +8,13 @@
   import { logService } from '../../services/log/logService';
   import {
     extractTextFromMessage,
+    extractGroundingFromMessage,
     extractToolUsesFromMessage,
     messageBubbleVariant,
     resolveThreadId,
   } from './agentChatView.helpers';
   import EmptyState from '../../components/feedback/EmptyState.svelte';
-  import { Button, IconButton } from '../../components';
+  import { Button, IconButton, GoogleSearchSuggestions } from '../../components';
   import ThreadListSidebar from './ThreadListSidebar.svelte';
   import type { AgentDef, ThreadDef, MessageDef } from './types';
   import { showSettingsWindow } from '../../lib/ipc/commands';
@@ -111,6 +114,14 @@
     if (!messagesEl) return;
     const atBottom = messagesEl.scrollHeight - messagesEl.scrollTop - messagesEl.clientHeight < 40;
     userScrolledUp = !atBottom;
+  }
+
+  function openSearchSource(value: string) {
+    const url = externalSearchUrl(value);
+    if (url)
+      void openerService
+        .open(null, url)
+        .catch((error) => logService.warn(`[agents] Cannot open source: ${error}`));
   }
 
   function copyText(text: string) {
@@ -238,6 +249,7 @@
               {#each messages as message (message.id)}
                 {@const variant = messageBubbleVariant(message)}
                 {@const text = extractTextFromMessage(message)}
+                {@const grounding = extractGroundingFromMessage(message)}
                 {@const toolUses = extractToolUsesFromMessage(message)}
                 <div class="message-row {variant}">
                   {#if variant === 'assistant'}
@@ -252,6 +264,28 @@
                       {#if text.length > 0}
                         <div class="md-content">{@html renderMarkdown(text)}</div>
                       {/if}
+                      {#each grounding as search}
+                        {#if search.sources.length > 0}
+                          <div class="grounding-sources">
+                            <span class="text-caption">{t('features.agents.sources')}</span>
+                            {#each search.sources as source, index}
+                              <a
+                                href={source.url}
+                                onclick={(event) => {
+                                  event.preventDefault();
+                                  openSearchSource(source.url);
+                                }}>{index + 1}. {source.title}</a
+                              >
+                            {/each}
+                          </div>
+                        {/if}
+                        {#if search.searchSuggestionsHtml}
+                          <GoogleSearchSuggestions
+                            html={search.searchSuggestionsHtml}
+                            onOpen={openSearchSource}
+                          />
+                        {/if}
+                      {/each}
                       {#each toolUses as tu (tu.id)}
                         <div class="tool-use-chip">
                           <span class="chip-name">{tu.name}</span>
@@ -451,6 +485,17 @@
   }
   .message-bubble.user:hover :global(.copy-message-btn) {
     opacity: 0.7;
+  }
+
+  .grounding-sources {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    margin-top: var(--space-3);
+    font-size: var(--font-size-sm);
+  }
+  .grounding-sources a {
+    color: var(--accent-primary);
   }
 
   .tool-use-chip {

--- a/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.test.ts
@@ -288,3 +288,23 @@ describe('resolveThreadId', () => {
     expect(resolveThreadId(null, [])).toBeNull();
   });
 });
+
+describe('persisted Gemini grounding', () => {
+  it('rehydrates presentation from provider context and ignores unrelated messages', async () => {
+    const { extractGroundingFromMessage } = await import('./agentChatView.helpers');
+    const display = {
+      sources: [{ title: 'Example', url: 'https://example.com' }],
+      searchSuggestionsHtml: '<div>Google</div>',
+    };
+    const message = {
+      role: 'assistant',
+      content: {
+        text: 'Answer',
+        providerContext: [{ geminiPart: { text: 'Answer' } }, { geminiGroundingDisplay: display }],
+      },
+    } as MessageDef;
+    expect(extractGroundingFromMessage(message)).toEqual([display]);
+    expect(extractGroundingFromMessage({ ...message, content: { text: 'No search' } })).toEqual([]);
+    expect(extractGroundingFromMessage({ ...message, role: 'user' })).toEqual([]);
+  });
+});

--- a/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.ts
@@ -1,4 +1,5 @@
 import type { ThreadDef, MessageDef } from './types';
+import type { GeminiGrounding } from '../../bindings';
 import type { ToolCall } from '../../services/ai/IProviderPlugin';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -108,4 +109,19 @@ export function resolveThreadId(
 ): string | null {
   if (!currentThreadId) return null;
   return threads.some((t) => t.id === currentThreadId) ? currentThreadId : null;
+}
+
+/** Rust prepares safe source URLs; this only reads the saved presentation. */
+export function extractGroundingFromMessage(msg: MessageDef): GeminiGrounding[] {
+  if (msg.role !== 'assistant') return [];
+  const context = (
+    msg.content as {
+      providerContext?: { geminiGroundingDisplay?: GeminiGrounding }[];
+    }
+  ).providerContext;
+  return (
+    context?.flatMap((item) =>
+      item.geminiGroundingDisplay ? [item.geminiGroundingDisplay] : [],
+    ) ?? []
+  );
 }

--- a/asyar-launcher/src/components/ai/GoogleSearchSuggestions.svelte
+++ b/asyar-launcher/src/components/ai/GoogleSearchSuggestions.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import {
+    externalSearchUrl,
+    searchSuggestionsDocument,
+    isSearchSuggestionsMessage,
+  } from './googleSearchSuggestions';
+  import { t } from '../../services/i18n';
+
+  let { html, onOpen }: { html: string; onOpen: (url: string) => void } = $props();
+  let frame = $state<HTMLIFrameElement>();
+  let src = $state('');
+  let token = $state('');
+  let height = $state(120);
+
+  $effect(() => {
+    const nonce = crypto.randomUUID();
+    token = nonce;
+    const document = searchSuggestionsDocument(html, nonce);
+    const url = URL.createObjectURL(new Blob([document], { type: 'text/html' }));
+    src = url;
+    return () => URL.revokeObjectURL(url);
+  });
+
+  function receive(event: MessageEvent) {
+    if (!isSearchSuggestionsMessage(event, frame?.contentWindow, token)) return;
+    if (event.data?.type === 'google-search-size' && Number.isFinite(event.data.height)) {
+      height = Math.max(1, Math.min(2000, event.data.height));
+    } else if (event.data?.type === 'google-search-link') {
+      const url = externalSearchUrl(event.data.url);
+      if (url) onOpen(url);
+    }
+  }
+</script>
+
+<svelte:window onmessage={receive} />
+{#if src}
+  <iframe
+    bind:this={frame}
+    {src}
+    title={t('features.agents.google_search_suggestions')}
+    sandbox="allow-scripts"
+    referrerpolicy="no-referrer"
+    style:height="{height}px"
+  ></iframe>
+{/if}
+
+<style>
+  iframe {
+    display: block;
+    width: 100%;
+    border: 0;
+    margin-top: var(--space-3);
+  }
+</style>

--- a/asyar-launcher/src/components/ai/googleSearchSuggestions.test.ts
+++ b/asyar-launcher/src/components/ai/googleSearchSuggestions.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import {
+  searchSuggestionsDocument,
+  externalSearchUrl,
+  isSearchSuggestionsMessage,
+} from './googleSearchSuggestions';
+
+describe('Google Search Suggestions isolation', () => {
+  it('retains provider HTML with only the trusted bridge permitted by CSP', () => {
+    const html =
+      '<style>.chip { color: red }</style><a href="https://google.com/search?q=test">Test</a><script>alert(1)</script>';
+    const result = searchSuggestionsDocument(html, 'random-nonce');
+    expect(result).toContain(html);
+    const document = new DOMParser().parseFromString(result, 'text/html');
+    const policy = document
+      .querySelector('meta[http-equiv="Content-Security-Policy"]')!
+      .getAttribute('content')!;
+    expect(policy).toContain("default-src 'none'");
+    expect(policy).toContain("script-src 'nonce-random-nonce'");
+    expect(policy).toContain("base-uri 'none'");
+    expect(document.querySelectorAll('script[nonce="random-nonce"]')).toHaveLength(1);
+    expect(policy).not.toContain("script-src 'unsafe-inline'");
+  });
+  it('permits only HTTP(S) links, excluding credentials and dangerous protocols', () => {
+    expect(externalSearchUrl('https://example.com/a')).toBe('https://example.com/a');
+    for (const value of [
+      'javascript:alert(1)',
+      'data:text/html,test',
+      'file:///tmp/a',
+      'https://user:pass@example.com',
+      null,
+    ]) {
+      expect(externalSearchUrl(value)).toBeNull();
+    }
+  });
+});
+
+it('rejects messages from other frames or a navigated document without the bridge token', () => {
+  const frame = {} as Window;
+  const event = {
+    source: frame,
+    data: { token: 'secret', type: 'google-search-link' },
+  } as MessageEvent;
+  expect(isSearchSuggestionsMessage(event, frame, 'secret')).toBe(true);
+  expect(isSearchSuggestionsMessage(event, {} as Window, 'secret')).toBe(false);
+  expect(
+    isSearchSuggestionsMessage(
+      { ...event, data: { type: 'google-search-link' } } as MessageEvent,
+      frame,
+      'secret',
+    ),
+  ).toBe(false);
+});

--- a/asyar-launcher/src/components/ai/googleSearchSuggestions.ts
+++ b/asyar-launcher/src/components/ai/googleSearchSuggestions.ts
@@ -1,0 +1,44 @@
+/** Restrict links crossing the isolated provider-content boundary. */
+export function externalSearchUrl(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  try {
+    const url = new URL(value);
+    return ['https:', 'http:'].includes(url.protocol) &&
+      url.hostname &&
+      !url.username &&
+      !url.password
+      ? url.href
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Preserve Google's supplied HTML/CSS in an opaque-origin sandbox.
+ * CSP permits only our nonce-bearing bridge; provider scripts and handlers
+ * cannot run. The caller must never grant allow-same-origin or navigation.
+ */
+export function searchSuggestionsDocument(html: string, nonce: string): string {
+  if (!/^[a-zA-Z0-9-]+$/.test(nonce)) throw new Error('Invalid script nonce');
+  return `<!doctype html><html><head><meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline'; img-src data: https://www.gstatic.com https://www.google.com; base-uri 'none'; form-action 'none'">
+<script nonce="${nonce}">
+document.addEventListener('click', event => {
+  const link = event.target.closest?.('a');
+  if (!link) return;
+  event.preventDefault();
+  if (event.isTrusted) parent.postMessage({type: 'google-search-link', token: '${nonce}', url: link.href}, '*');
+}, true);
+document.addEventListener('DOMContentLoaded', () => {
+  new ResizeObserver(() => parent.postMessage({type: 'google-search-size', token: '${nonce}', height: document.documentElement.scrollHeight}, '*')).observe(document.body);
+});
+</script></head><body>${html}</body></html>`;
+}
+
+export function isSearchSuggestionsMessage(
+  event: MessageEvent,
+  frame: Window | null | undefined,
+  token: string,
+): boolean {
+  return !!frame && event.source === frame && !!token && event.data?.token === token;
+}

--- a/asyar-launcher/src/components/index.ts
+++ b/asyar-launcher/src/components/index.ts
@@ -152,3 +152,6 @@ export { default as InspectorShell } from './dev/InspectorShell.svelte';
 //                       services/feedback/feedbackBoundary.test.ts.
 // dev/Panel*, dev/JsonTree, dev/StreamTail, dev/ExtensionNav, dev/HelpPanel,
 // dev/TimestampRelative — internals of InspectorShell (see above).
+
+// AI
+export { default as GoogleSearchSuggestions } from './ai/GoogleSearchSuggestions.svelte';

--- a/asyar-launcher/src/locales/en.json
+++ b/asyar-launcher/src/locales/en.json
@@ -285,6 +285,8 @@
       "type_theme": "Theme"
     },
     "ai": {
+      "google_search": "Google Search",
+      "google_search_description": "Let Gemini search the web and show sources. Uses your Gemini API key. Combining search with agent tools requires a Gemini 3 model; provider search charges may apply.",
       "no_provider": "No AI provider configured yet",
       "tab_continues_last_thread": "Tab continues last thread",
       "tab_continues_last_thread_description": "Pressing Tab in the launcher reopens your previous conversation instead of starting a new one.",
@@ -652,6 +654,8 @@
       "you": "You",
       "copy_message": "Copy message",
       "searching": "Searching…",
+      "sources": "Sources",
+      "google_search_suggestions": "Google Search Suggestions",
       "error_open_ai_settings": "Could not open AI settings. Try again."
     },
     "sticky": {

--- a/asyar-launcher/src/locales/pt-BR.json
+++ b/asyar-launcher/src/locales/pt-BR.json
@@ -285,6 +285,8 @@
       "type_theme": "Tema"
     },
     "ai": {
+      "google_search": "Pesquisa Google",
+      "google_search_description": "Permita que o Gemini pesquise na web e mostre fontes. Usa sua chave de API do Gemini. Combinar pesquisa com ferramentas do agente exige um modelo Gemini 3; podem ser aplicadas cobranças de pesquisa do provedor.",
       "no_provider": "Nenhum provedor de IA configurado ainda",
       "tab_continues_last_thread": "Tab continua a última conversa",
       "tab_continues_last_thread_description": "Pressionar Tab no launcher reabre a conversa anterior em vez de iniciar uma nova.",
@@ -650,7 +652,9 @@
       "you": "Você",
       "copy_message": "Copiar mensagem",
       "searching": "Pesquisando…",
-      "error_open_ai_settings": "Não foi possível abrir as configurações de IA. Tente novamente."
+      "error_open_ai_settings": "Não foi possível abrir as configurações de IA. Tente novamente.",
+      "sources": "Fontes",
+      "google_search_suggestions": "Sugestões da Pesquisa Google"
     },
     "sticky": {
       "new_sticky": "Novo lembrete",

--- a/asyar-launcher/src/routes/settings/tabs/AiTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/AiTab.svelte
@@ -495,7 +495,9 @@
                     <div class="hosted-search-setting">
                       <div class="hosted-search-heading">
                         <label class="field-label" for="hosted-web-search-{providerId}">
-                          OpenAI Hosted Web Search
+                          {plugin.id === 'google'
+                            ? t('settings.ai.google_search')
+                            : 'OpenAI Hosted Web Search'}
                         </label>
                         <Toggle
                           id="hosted-web-search-{providerId}"
@@ -507,9 +509,13 @@
                         />
                       </div>
                       <p class="field-description">
-                        Lets compatible OpenAI/Codex proxy endpoints search the live web. No
-                        separate search API key is needed; unsupported endpoints may reject requests
-                        while this is enabled.
+                        {#if plugin.id === 'google'}
+                          {t('settings.ai.google_search_description')}
+                        {:else}
+                          Lets compatible OpenAI/Codex proxy endpoints search the live web. No
+                          separate search API key is needed; unsupported endpoints may reject
+                          requests while this is enabled.
+                        {/if}
                       </p>
                     </div>
                   {/if}

--- a/asyar-launcher/src/services/ai/initProviders.test.ts
+++ b/asyar-launcher/src/services/ai/initProviders.test.ts
@@ -11,6 +11,13 @@ describe('initProviders', () => {
     vi.clearAllMocks();
   });
 
+  it('exposes native Google Search', () => {
+    initProviders();
+    expect(providerRegistry.list().find((p) => p.id === 'google')?.supportsHostedWebSearch).toBe(
+      true,
+    );
+  });
+
   it('registers exactly 6 provider plugins', () => {
     initProviders();
     expect(providerRegistry.list()).toHaveLength(6);

--- a/asyar-launcher/src/services/ai/initProviders.ts
+++ b/asyar-launcher/src/services/ai/initProviders.ts
@@ -31,6 +31,7 @@ const PROVIDERS: IProviderPlugin[] = [
   descriptor({
     id: 'google',
     name: 'Google Gemini',
+    supportsHostedWebSearch: true,
     requiresApiKey: true,
     requiresBaseUrl: false,
     reasoningEfforts: ['minimal', 'low', 'medium', 'high'],


### PR DESCRIPTION
Hi! I've been using Asyar since yesterday - after trying to migrate away from Raycast.

It's been mostly smooth so far but I've noticed three missing feature from my normal use, and probably something most people would need to.

Here's the first one, about Google Search.

--- 

Gemini requests currently include custom agent functions but never enable native Google Search. This adds a Google Search setting, includes the native tool in requests, and displays source links and Google Search Suggestions in the AI conversation.

The adapter retains signed response parts for tool continuation and rejects Google Search combined with custom functions on unsupported models. Suggestions render in a sandboxed frame with a restrictive CSP; validated link clicks use the existing opener service.

Remaining draft review points:

- Grounding metadata, including Search Suggestions, currently persists in conversation context.
- Sources appear below the answer. Claim-level inline markers are not implemented.