### PR TITLE
fix(ai): enable output selection and reliable copying

### DIFF
--- a/asyar-launcher/src/built-in-features/agents/AgentChatView.svelte
+++ b/asyar-launcher/src/built-in-features/agents/AgentChatView.svelte
@@ -3,6 +3,7 @@
   import { agentService } from './agentService.svelte';
   import { agentsManager } from './agentsManager.svelte';
   import { renderMarkdown, handleMarkdownCopyClick } from '../../utils/markdown';
+  import { copyText } from '../../utils/copyText';
   import { logService } from '../../services/log/logService';
   import {
     extractTextFromMessage,
@@ -113,10 +114,6 @@
     userScrolledUp = !atBottom;
   }
 
-  function copyText(text: string) {
-    void navigator.clipboard.writeText(text).catch(() => {});
-  }
-
   function onSelectThread(threadId: string) {
     agentsManager.currentThreadId = threadId;
   }
@@ -143,7 +140,7 @@
 
   function handleWindowKeydown(event: KeyboardEvent) {
     // Skip when modifiers are held — those are launcher / OS shortcuts.
-    if (event.metaKey || event.ctrlKey || event.altKey) return;
+    if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
     // When the action panel (Cmd+K) is open, let it own keyboard navigation.
     if (document.querySelector('.action-popup')) return;
     // A modal dialog can open on top of this view — don't steal its keys.
@@ -220,6 +217,7 @@
 
         <div
           class="messages-container custom-scrollbar"
+          data-no-focus-steal
           bind:this={messagesEl}
           onscroll={handleScroll}
           role="log"
@@ -267,7 +265,6 @@
                       class="copy-message-btn"
                       onclick={() => copyText(text)}
                       title={t('features.agents.copy_message')}
-                      tabindex={-1}
                       ariaLabel={t('features.agents.copy_message')}
                       size="sm"
                     >
@@ -442,15 +439,25 @@
     right: var(--space-1);
     opacity: 0;
   }
-  .message-bubble:hover :global(.copy-message-btn) {
+  .message-bubble:hover :global(.copy-message-btn),
+  .message-bubble:focus-within :global(.copy-message-btn) {
     opacity: 1;
   }
   .message-bubble.user :global(.copy-message-btn) {
     color: inherit;
     opacity: 0;
   }
-  .message-bubble.user:hover :global(.copy-message-btn) {
+  .message-bubble.user:hover :global(.copy-message-btn),
+  .message-bubble.user:focus-within :global(.copy-message-btn) {
     opacity: 0.7;
+  }
+
+  .md-content,
+  .user-text,
+  .tool-result,
+  .chip-input {
+    -webkit-user-select: text;
+    user-select: text;
   }
 
   .tool-use-chip {

--- a/asyar-launcher/src/built-in-features/agents/AgentChatView.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/AgentChatView.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('./agentService.svelte', () => ({
@@ -28,6 +28,9 @@ vi.mock('../../lib/ipc/commands', () => ({
   replaceDynamicCommandsBuiltin: vi.fn(),
   showSettingsWindow: vi.fn(),
 }));
+
+vi.mock('../../utils/copyText', () => ({ copyText: vi.fn() }));
+import { copyText } from '../../utils/copyText';
 
 import AgentChatView from './AgentChatView.svelte';
 import { agentService } from './agentService.svelte';
@@ -80,6 +83,42 @@ describe('AgentChatView', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it('offers keyboard-accessible whole-message copy and preserves native copy', async () => {
+    const text = '**Answer**\n\n```ts\nconst n = 1;\n```';
+    mockedAgentService.listMessages.mockResolvedValue([
+      {
+        id: 'answer',
+        threadId: thread.id,
+        role: 'assistant',
+        content: { text },
+        createdAt: 1,
+        runId: null,
+      },
+    ]);
+    render(AgentChatView);
+    const button = await screen.findByRole('button', { name: 'Copy message' });
+    expect(button.tabIndex).toBe(0);
+    expect(button.closest('[data-no-focus-steal]')).not.toBeNull();
+    await fireEvent.click(button);
+    expect(copyText).toHaveBeenCalledWith(text);
+    const event = new KeyboardEvent('keydown', {
+      key: 'c',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    button.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(false);
+    const selectionEvent = new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    button.dispatchEvent(selectionEvent);
+    expect(selectionEvent.defaultPrevented).toBe(false);
   });
 
   it('refreshes the sidebar when the selected thread is cleared after deletion', async () => {

--- a/asyar-launcher/src/locales/en.json
+++ b/asyar-launcher/src/locales/en.json
@@ -862,5 +862,11 @@
     "panel_events": {
       "pause_display": "Pause display"
     }
+  },
+  "clipboard_copy": {
+    "copy": "Copy",
+    "copied": "Copied!",
+    "success": "Copied to clipboard",
+    "error": "Could not copy to clipboard. Try again."
   }
 }

--- a/asyar-launcher/src/locales/pt-BR.json
+++ b/asyar-launcher/src/locales/pt-BR.json
@@ -859,5 +859,11 @@
     "panel_events": {
       "pause_display": "Pausar exibição"
     }
+  },
+  "clipboard_copy": {
+    "copy": "Copiar",
+    "copied": "Copiado!",
+    "success": "Copiado para a área de transferência",
+    "error": "Não foi possível copiar para a área de transferência. Tente novamente."
   }
 }

--- a/asyar-launcher/src/utils/copyText.test.ts
+++ b/asyar-launcher/src/utils/copyText.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+vi.mock('tauri-plugin-clipboard-x-api', () => ({ writeText: vi.fn() }));
+vi.mock('../services/feedback/feedbackService.svelte', () => ({
+  feedbackService: { report: vi.fn() },
+}));
+import { writeText } from 'tauri-plugin-clipboard-x-api';
+import { feedbackService } from '../services/feedback/feedbackService.svelte';
+import { copyText } from './copyText';
+
+describe('copyText', () => {
+  beforeEach(() => vi.clearAllMocks());
+  it('reports success only after the native clipboard write resolves', async () => {
+    let resolve!: () => void;
+    vi.mocked(writeText).mockReturnValueOnce(
+      new Promise<void>((r) => {
+        resolve = r;
+      }),
+    );
+    const result = copyText('**Full message**\nwith code');
+    expect(writeText).toHaveBeenCalledWith('**Full message**\nwith code');
+    expect(feedbackService.report).not.toHaveBeenCalled();
+    resolve();
+    expect(await result).toBe(true);
+    expect(feedbackService.report).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'success' }),
+    );
+  });
+  it('reports a safe failure and allows retry', async () => {
+    vi.mocked(writeText).mockRejectedValueOnce(new Error('secret content'));
+    expect(await copyText('private output')).toBe(false);
+    expect(feedbackService.report).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error' }),
+    );
+    expect(JSON.stringify(vi.mocked(feedbackService.report).mock.calls)).not.toMatch(
+      /secret content|private output/,
+    );
+    vi.mocked(writeText).mockResolvedValueOnce(undefined);
+    expect(await copyText('private output')).toBe(true);
+  });
+});

--- a/asyar-launcher/src/utils/copyText.ts
+++ b/asyar-launcher/src/utils/copyText.ts
@@ -1,0 +1,24 @@
+import { t } from '../services/i18n';
+import { writeText } from 'tauri-plugin-clipboard-x-api';
+import { feedbackService } from '../services/feedback/feedbackService.svelte';
+
+/** Copy through the native clipboard and report the outcome without exposing content. */
+export async function copyText(text: string): Promise<boolean> {
+  let copied = false;
+  try {
+    await writeText(text);
+    copied = true;
+  } catch {
+    // Clipboard errors may contain the text being copied; do not publish them.
+  }
+  await feedbackService.report({
+    source: 'frontend',
+    kind: 'manual',
+    severity: copied ? 'success' : 'error',
+    retryable: false,
+    context: {
+      message: t(copied ? 'clipboard_copy.success' : 'clipboard_copy.error'),
+    },
+  });
+  return copied;
+}

--- a/asyar-launcher/src/utils/markdown.ts
+++ b/asyar-launcher/src/utils/markdown.ts
@@ -12,6 +12,9 @@
  *   - LaTeX math: `$...$`, `$$...$$`, `\(...\)`, `\[...\]`
  *   - HTML sanitisation (strips `<script>`, event handlers)
  */
+import { t } from '../services/i18n';
+import { feedbackService } from '../services/feedback/feedbackService.svelte';
+import { copyText } from './copyText';
 import { marked } from 'marked';
 import Prism from 'prismjs';
 import { extractLatexBeforeMarkdown, containsLatex } from './latex';
@@ -31,6 +34,10 @@ import 'prismjs/components/prism-php';
 
 // ── Configure marked ────────────────────────────────────────────────────
 
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 function highlight(code: string, lang: string): string {
   if (lang && Prism.languages[lang]) {
     try {
@@ -40,7 +47,7 @@ function highlight(code: string, lang: string): string {
     }
   }
   // Fallback to escaped plain text
-  return code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return escapeHtml(code);
 }
 
 // Custom renderer to inject a copy-button header into fenced code blocks
@@ -60,7 +67,7 @@ renderer.code = function (token) {
 
   return (
     `<div class="md-code-block">` +
-    `<div class="md-code-header">${langLabel}<button class="md-copy-btn btn btn-secondary" data-code="${encodeURIComponent(code)}">Copy</button></div>` +
+    `<div class="md-code-header">${langLabel}<button type="button" class="md-copy-btn btn btn-secondary" data-code="${encodeURIComponent(code)}">${escapeHtml(t('clipboard_copy.copy'))}</button></div>` +
     `<pre><code class="language-${lang}">${highlightedCode}</code></pre>` +
     `</div>`
   );
@@ -223,16 +230,33 @@ export function renderMarkdown(text: string, options: RenderMarkdownOptions = {}
  * </div>
  * ```
  */
-export function handleMarkdownCopyClick(e: MouseEvent): void {
-  const btn = (e.target as HTMLElement).closest('button.md-copy-btn') as HTMLButtonElement | null;
-  if (!btn) return;
+export async function handleMarkdownCopyClick(e: MouseEvent): Promise<void> {
+  if (!(e.target instanceof Element)) return;
+  const btn = e.target.closest<HTMLButtonElement>('button.md-copy-btn');
+  if (!btn || btn.disabled) return;
 
-  const code = decodeURIComponent(btn.dataset.code ?? '');
-  navigator.clipboard
-    .writeText(code)
-    .catch((err) => console.warn('[markdown] Copy to clipboard failed:', err));
-  btn.textContent = 'Copied!';
+  let code: string;
+  try {
+    code = decodeURIComponent(btn.dataset.code ?? '');
+  } catch {
+    await feedbackService.report({
+      source: 'frontend',
+      kind: 'manual',
+      severity: 'error',
+      retryable: false,
+      context: { message: t('clipboard_copy.error') },
+    });
+    return;
+  }
+  btn.disabled = true;
+  const copied = await copyText(code);
+  if (!copied) {
+    btn.disabled = false;
+    return;
+  }
+  btn.textContent = t('clipboard_copy.copied');
   setTimeout(() => {
-    btn.textContent = 'Copy';
+    btn.textContent = t('clipboard_copy.copy');
+    btn.disabled = false;
   }, 2000);
 }

--- a/asyar-launcher/src/utils/markdownCopy.test.ts
+++ b/asyar-launcher/src/utils/markdownCopy.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+vi.mock('../services/feedback/feedbackService.svelte', () => ({
+  feedbackService: { report: vi.fn() },
+}));
+import { feedbackService } from '../services/feedback/feedbackService.svelte';
+vi.mock('./copyText', () => ({ copyText: vi.fn() }));
+import { copyText } from './copyText';
+import { renderMarkdown, handleMarkdownCopyClick } from './markdown';
+
+describe('markdown copy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+  function button() {
+    document.body.innerHTML = renderMarkdown('```ts\nconst value = "<&>";\n```');
+    return document.querySelector('button')!;
+  }
+  function click(btn: HTMLButtonElement) {
+    const event = new MouseEvent('click');
+    Object.defineProperty(event, 'target', { value: btn });
+    return handleMarkdownCopyClick(event);
+  }
+  it('waits for a successful write and prevents overlapping copies', async () => {
+    const btn = button();
+    let resolve!: (value: boolean) => void;
+    vi.mocked(copyText).mockReturnValueOnce(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+    const result = click(btn);
+    expect(btn.textContent).not.toContain('Copied');
+    expect(btn.disabled).toBe(true);
+    await click(btn);
+    expect(copyText).toHaveBeenCalledTimes(1);
+    expect(copyText).toHaveBeenCalledWith('const value = "<&>";');
+    resolve(true);
+    await result;
+    expect(btn.textContent).toBe('Copied!');
+    await vi.runAllTimersAsync();
+    expect(btn.textContent).toBe('Copy');
+    expect(btn.disabled).toBe(false);
+  });
+  it('reports malformed code data without throwing or disabling retry', async () => {
+    const btn = button();
+    btn.dataset.code = '%invalid';
+    await expect(click(btn)).resolves.toBeUndefined();
+    expect(copyText).not.toHaveBeenCalled();
+    expect(feedbackService.report).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error' }),
+    );
+    expect(btn.disabled).toBe(false);
+  });
+  it('keeps failed copies available for retry without claiming success', async () => {
+    const btn = button();
+    vi.mocked(copyText).mockResolvedValueOnce(false);
+    await click(btn);
+    expect(btn.textContent).toBe('Copy');
+    expect(btn.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
Hi! I've been using Asyar since yesterday - after trying to migrate away from Raycast.

It's been mostly smooth so far but I've noticed three missing feature from my normal use, and probably something most people would need to.

Here's the first one about copying the AI responses.

---

AI responses inherit the launcher's text-selection restriction, and clicking the conversation can move focus back to search. This enables selection only in message content and uses the existing focus opt-out so users can select a passage and copy it normally.

Message copy buttons now participate in keyboard navigation and appear on focus. Message and fenced-code copying use the existing native clipboard adapter, report failures without exposing copied content, and show success only after the write completes. Native copy and Shift+Arrow shortcuts remain available.