### PR TITLE
feat(ai): support native web search with Anthropic and OpenRouter

### DIFF
--- a/asyar-launcher/src-tauri/src/agents/runner.rs
+++ b/asyar-launcher/src-tauri/src/agents/runner.rs
@@ -461,6 +461,9 @@ pub(crate) fn coalesce_consecutive_messages(messages: Vec<ChatMessage>) -> Vec<C
                 && matches!(message.role.as_str(), "user" | "assistant")
                 && previous.tool_calls.as_ref().is_none_or(Vec::is_empty)
                 && message.tool_calls.as_ref().is_none_or(Vec::is_empty)
+                // Signed provider parts must retain their original message boundary.
+                && previous.provider_context.as_ref().is_none_or(Vec::is_empty)
+                && message.provider_context.as_ref().is_none_or(Vec::is_empty)
         });
         if can_merge {
             let previous = output.last_mut().expect("checked above");

--- a/asyar-launcher/src-tauri/src/agents/runner.rs
+++ b/asyar-launcher/src-tauri/src/agents/runner.rs
@@ -730,6 +730,10 @@ where
             });
         }
 
+        let continue_turn = turn
+            .provider_context
+            .iter()
+            .any(|item| item["continueTurn"] == true);
         let assistant_persisted = conversation.push_assistant(
             turn.text.clone(),
             resolved_calls.clone(),
@@ -740,7 +744,7 @@ where
         }
 
         stream_result?;
-        if resolved_calls.is_empty() {
+        if resolved_calls.is_empty() && !continue_turn {
             return Ok(Some(turn.text));
         }
 

--- a/asyar-launcher/src-tauri/src/agents/runner_test.rs
+++ b/asyar-launcher/src-tauri/src/agents/runner_test.rs
@@ -1015,3 +1015,19 @@ fn resolve_provider_config_errors_when_base_url_is_missing() {
         .to_string()
         .contains("Base URL for provider 'ollama' is not configured"));
 }
+
+#[test]
+fn coalescing_preserves_provider_context_boundaries() {
+    let mut first = chat_message("assistant", "First");
+    first.provider_context = Some(vec![
+        json!({"geminiPart": {"text": "First", "thoughtSignature": "signed"}}),
+    ]);
+    let mut second = chat_message("assistant", "Second");
+    second.provider_context = Some(vec![json!({"geminiPart": {"text": "Second"}})]);
+    let messages = coalesce_consecutive_messages(vec![first, second]);
+    assert_eq!(messages.len(), 2);
+    assert_eq!(
+        messages[1].provider_context.as_ref().unwrap()[0]["geminiPart"]["text"],
+        "Second"
+    );
+}

--- a/asyar-launcher/src-tauri/src/agents/runner_test.rs
+++ b/asyar-launcher/src-tauri/src/agents/runner_test.rs
@@ -1031,3 +1031,153 @@ fn coalescing_preserves_provider_context_boundaries() {
         "Second"
     );
 }
+
+#[tokio::test]
+async fn anthropic_paused_search_continues_with_native_context() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let server = tokio::spawn(async move {
+        let mut requests = Vec::new();
+        for paused in [true, false] {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut bytes = Vec::new();
+            loop {
+                let mut chunk = [0; 8192];
+                let count = tokio::io::AsyncReadExt::read(&mut socket, &mut chunk)
+                    .await
+                    .unwrap();
+                bytes.extend_from_slice(&chunk[..count]);
+                if let Some(split) = bytes.windows(4).position(|part| part == b"\r\n\r\n") {
+                    let headers = String::from_utf8_lossy(&bytes[..split]);
+                    let length: usize = headers
+                        .lines()
+                        .find_map(|line| {
+                            line.to_lowercase()
+                                .strip_prefix("content-length: ")
+                                .map(str::to_owned)
+                        })
+                        .unwrap()
+                        .parse()
+                        .unwrap();
+                    if bytes.len() >= split + 4 + length {
+                        requests.push(
+                            serde_json::from_slice::<serde_json::Value>(&bytes[split + 4..])
+                                .unwrap(),
+                        );
+                        break;
+                    }
+                }
+                assert!(count > 0);
+            }
+            let block = if paused {
+                json!({"type":"server_tool_use","id":"srvtoolu_1","name":"web_search","input":{"query":"news"}})
+            } else {
+                json!({"type":"text","text":"Corrected text"})
+            };
+            let body = [json!({"type":"content_block_start","index":0,"content_block":block}), json!({"type":"content_block_stop","index":0}), json!({"type":"message_delta","delta":{"stop_reason":if paused {"pause_turn"} else {"end_turn"}}})]
+                .into_iter().map(|event| format!("data: {event}\n\n")).collect::<String>();
+            socket.write_all(format!("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",body.len()).as_bytes()).await.unwrap();
+        }
+        requests
+    });
+
+    let store = make_store();
+    let agent_id = "silent-agent".to_string();
+    let now = chrono::Utc::now().timestamp_millis();
+    insert_agent(
+        &store.conn().unwrap(),
+        &AgentRow {
+            id: agent_id.clone(),
+            name: "Silent Agent".to_string(),
+            description: None,
+            system_prompt: "Correct grammar".to_string(),
+            provider_id: "anthropic".to_string(),
+            model_id: "claude-sonnet-4-5".to_string(),
+            tool_selection: vec![],
+            silent: true,
+            input_source: crate::storage::agents::SilentInputSource::Argument,
+            output_action: crate::storage::agents::SilentOutputAction::ReplaceSelection,
+            cache_responses: false,
+            shortcode_trigger: ":".to_string(),
+            created_at: Some(now),
+            updated_at: Some(now),
+        },
+    )
+    .unwrap();
+
+    let registry = Arc::new(ToolRegistry::new());
+    let config = crate::ai::types::ProviderConfig {
+        enabled: true,
+        name: None,
+        provider_type: None,
+        api_key: Some("test-key".to_string()),
+        base_url: Some(format!("http://127.0.0.1:{}", port)),
+        last_model_id: None,
+        open_ai_api_mode: None,
+        hosted_web_search: None,
+        reasoning_effort: None,
+        temperature: None,
+        max_tokens: None,
+    };
+
+    let before = {
+        let conn = store.conn().unwrap();
+        (
+            conn.query_row("SELECT COUNT(*) FROM threads", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap(),
+            conn.query_row("SELECT COUNT(*) FROM messages", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap(),
+        )
+    };
+
+    let result = run_silent_loop_impl(
+        &store,
+        &registry,
+        &agent_id,
+        "helo".to_string(),
+        run_config("anthropic", config, Some(0.7), 2048),
+        |_| {},
+        |_| async {
+            Err(AppError::Other(
+                "unexpected external tool dispatch".to_string(),
+            ))
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    let after = {
+        let conn = store.conn().unwrap();
+        (
+            conn.query_row("SELECT COUNT(*) FROM threads", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap(),
+            conn.query_row("SELECT COUNT(*) FROM messages", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap(),
+        )
+    };
+
+    assert_eq!(result, "Corrected text");
+    let requests = tokio::time::timeout(std::time::Duration::from_secs(3), server)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(requests[1]["messages"][1]["content"][0]["id"], "srvtoolu_1");
+    assert_eq!(
+        requests[1]["messages"][1]["content"][0]["input"]["query"],
+        "news"
+    );
+    assert_eq!(
+        after, before,
+        "silent execution must not write threads or messages"
+    );
+}

--- a/asyar-launcher/src-tauri/src/ai/providers.rs
+++ b/asyar-launcher/src-tauri/src/ai/providers.rs
@@ -43,6 +43,7 @@ pub struct ProviderStreamParser {
     openai_tools: BTreeMap<u32, PendingToolCall>,
     anthropic_tool: Option<AnthropicToolBlock>,
     google_tool_counter: u32,
+    google_grounding: serde_json::Map<String, Value>,
     ollama_tool_counter: u32,
 }
 
@@ -58,6 +59,7 @@ impl ProviderStreamParser {
             openai_tools: BTreeMap::new(),
             anthropic_tool: None,
             google_tool_counter: 0,
+            google_grounding: serde_json::Map::new(),
             ollama_tool_counter: 0,
         }
     }
@@ -99,6 +101,10 @@ impl ProviderStreamParser {
                 name: pending.name,
                 input,
             });
+        }
+        if !self.google_grounding.is_empty() {
+            let metadata = Value::Object(std::mem::take(&mut self.google_grounding));
+            events.push(google_grounding_event(metadata));
         }
         Ok(events)
     }
@@ -299,6 +305,14 @@ impl ProviderStreamParser {
             .into_iter()
             .flatten()
         {
+            // Preserve every part (including signed thoughts and server-side tool
+            // context) unchanged for Gemini's next tool-continuation request.
+            if part.get("thought").and_then(Value::as_bool) == Some(true) {
+                events.push(ChatStreamEvent::ProviderContext {
+                    item: json!({ "geminiPart": part }),
+                });
+                continue;
+            }
             if let Some(token) = part.get("text").and_then(Value::as_str) {
                 if !token.is_empty() {
                     events.push(ChatStreamEvent::Token {
@@ -321,6 +335,17 @@ impl ProviderStreamParser {
                     input: call.get("args").cloned().unwrap_or_else(|| json!({})),
                 });
             }
+            events.push(ChatStreamEvent::ProviderContext {
+                item: json!({ "geminiPart": part }),
+            });
+        }
+        if let Some(metadata) = value
+            .pointer("/candidates/0/groundingMetadata")
+            .and_then(Value::as_object)
+        {
+            // Metadata may arrive separately from text and in several chunks.
+            // Keep the latest value for each field and publish one presentation.
+            self.google_grounding.extend(metadata.clone());
         }
         Ok(events)
     }
@@ -356,6 +381,48 @@ impl ProviderStreamParser {
             });
         }
         Ok(events)
+    }
+}
+
+fn google_grounding_event(metadata: Value) -> ChatStreamEvent {
+    let sources = metadata
+        .get("groundingChunks")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|chunk| {
+            let web = chunk.get("web")?;
+            let uri = web.get("uri")?.as_str()?;
+            let url = url::Url::parse(uri).ok()?;
+            if !matches!(url.scheme(), "http" | "https")
+                || url.host_str().is_none()
+                || !url.username().is_empty()
+                || url.password().is_some()
+            {
+                return None;
+            }
+            Some(crate::ai::types::GroundingSource {
+                title: web
+                    .get("title")
+                    .and_then(Value::as_str)
+                    .unwrap_or(uri)
+                    .to_owned(),
+                url: uri.to_owned(),
+            })
+        })
+        .collect();
+    let display = crate::ai::types::GeminiGrounding {
+        sources,
+        search_suggestions_html: metadata
+            .pointer("/searchEntryPoint/renderedContent")
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+    };
+    ChatStreamEvent::ProviderContext {
+        item: json!({
+            "geminiGrounding": metadata,
+            "geminiGroundingDisplay": display,
+        }),
     }
 }
 
@@ -697,6 +764,15 @@ fn build_google_request(
     messages: &[ChatMessage],
     params: &ChatParams,
 ) -> Result<RequestSpec, AppError> {
+    let custom_tools = params.tools.as_deref().unwrap_or_default();
+    let search_enabled = config.hosted_web_search == Some(true);
+    let gemini_3 =
+        params.model_id.starts_with("gemini-3-") || params.model_id.starts_with("gemini-3.");
+    if search_enabled && !custom_tools.is_empty() && !gemini_3 {
+        return Err(AppError::Validation(
+            "Google Search with agent tools requires Gemini 3. Select a Gemini 3 model, remove the agent's tools, or disable Google Search in AI settings.".into(),
+        ));
+    }
     let api_key = config.api_key.as_deref().unwrap_or("");
     let url = format!(
         "https://generativelanguage.googleapis.com/v1beta/models/{}:streamGenerateContent?alt=sse",
@@ -717,11 +793,46 @@ fn build_google_request(
             )
         })
         .collect();
+    // Internal IDs also identify calls from older Gemini models that omit IDs
+    // on the wire. Pair calls by their original order, without editing signatures.
+    let mut wire_ids = HashMap::new();
+    for message in messages {
+        let original_calls: Vec<&Value> = message
+            .provider_context
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|item| item.pointer("/geminiPart/functionCall"))
+            .collect();
+        for (index, call) in message
+            .tool_calls
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .enumerate()
+        {
+            let wire_id = original_calls
+                .get(index)
+                .map(|original| original.get("id").cloned())
+                .unwrap_or_else(|| Some(json!(call.id)));
+            wire_ids.insert(call.id.as_str(), wire_id);
+        }
+    }
     let contents = messages
         .iter()
         .filter(|message| message.role != "system")
         .map(|message| match message.role.as_str() {
             "assistant" => {
+                let original_parts: Vec<Value> = message
+                    .provider_context
+                    .as_deref()
+                    .unwrap_or_default()
+                    .iter()
+                    .filter_map(|item| item.get("geminiPart").cloned())
+                    .collect();
+                if !original_parts.is_empty() {
+                    return json!({ "role": "model", "parts": original_parts });
+                }
                 let mut parts = Vec::new();
                 if !message.content.is_empty() {
                     parts.push(json!({ "text": message.content }));
@@ -748,16 +859,14 @@ fn build_google_request(
                 let tool_call_id = message.tool_call_id.as_deref().unwrap_or_default();
                 let output = serde_json::from_str::<Value>(&message.content)
                     .unwrap_or_else(|_| Value::String(message.content.clone()));
-                json!({
-                    "role": "user",
-                    "parts": [{
-                        "functionResponse": {
-                            "id": tool_call_id,
-                            "name": tool_names_by_id.get(tool_call_id).cloned().unwrap_or_default(),
-                            "response": { "output": output },
-                        }
-                    }]
-                })
+                let mut response = json!({
+                    "name": tool_names_by_id.get(tool_call_id).cloned().unwrap_or_default(),
+                    "response": { "output": output },
+                });
+                if let Some(Some(id)) = wire_ids.get(tool_call_id) {
+                    response["id"] = id.clone();
+                }
+                json!({ "role": "user", "parts": [{ "functionResponse": response }] })
             }
             _ => json!({ "role": "user", "parts": [{ "text": message.content }] }),
         })
@@ -806,19 +915,24 @@ fn build_google_request(
             .insert("thinkingConfig".to_string(), thinking_config);
     }
 
-    if let Some(tools) = &params.tools {
-        if !tools.is_empty() {
-            body_map.as_object_mut().unwrap().insert(
-                "tools".to_string(),
-                json!([{
-                    "functionDeclarations": tools.iter().map(|tool| json!({
-                        "name": tool.name,
-                        "description": tool.description,
-                        "parameters": tool.parameters,
-                    })).collect::<Vec<_>>()
-                }]),
-            );
+    let mut tools = Vec::new();
+    if !custom_tools.is_empty() {
+        tools.push(json!({
+            "functionDeclarations": custom_tools.iter().map(|tool| json!({
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.parameters,
+            })).collect::<Vec<_>>()
+        }));
+    }
+    if search_enabled {
+        tools.push(json!({ "google_search": {} }));
+        if !custom_tools.is_empty() {
+            body_map["toolConfig"] = json!({ "includeServerSideToolInvocations": true });
         }
+    }
+    if !tools.is_empty() {
+        body_map["tools"] = json!(tools);
     }
 
     Ok(RequestSpec {

--- a/asyar-launcher/src-tauri/src/ai/providers.rs
+++ b/asyar-launcher/src-tauri/src/ai/providers.rs
@@ -29,9 +29,8 @@ struct PendingToolCall {
 }
 
 #[derive(Default)]
-struct AnthropicToolBlock {
-    id: String,
-    name: String,
+struct AnthropicContentBlock {
+    value: Value,
     arguments: String,
 }
 
@@ -41,7 +40,9 @@ pub struct ProviderStreamParser {
     provider_id: String,
     config: ProviderConfig,
     openai_tools: BTreeMap<u32, PendingToolCall>,
-    anthropic_tool: Option<AnthropicToolBlock>,
+    anthropic_blocks: BTreeMap<u64, AnthropicContentBlock>,
+    search_sources: Vec<crate::ai::types::GroundingSource>,
+    search_error: Option<String>,
     google_tool_counter: u32,
     google_grounding: serde_json::Map<String, Value>,
     ollama_tool_counter: u32,
@@ -57,7 +58,9 @@ impl ProviderStreamParser {
             provider_id: engine_type,
             config: config.clone(),
             openai_tools: BTreeMap::new(),
-            anthropic_tool: None,
+            anthropic_blocks: BTreeMap::new(),
+            search_sources: Vec::new(),
+            search_error: None,
             google_tool_counter: 0,
             google_grounding: serde_json::Map::new(),
             ollama_tool_counter: 0,
@@ -93,6 +96,10 @@ impl ProviderStreamParser {
     }
 
     pub fn finish(&mut self) -> Result<Vec<ChatStreamEvent>, AppError> {
+        // Native content blocks have already been emitted for conversation replay.
+        if let Some(error) = self.search_error.take() {
+            return Err(AppError::Other(error));
+        }
         let mut events = Vec::new();
         for (_, pending) in std::mem::take(&mut self.openai_tools) {
             let input = serde_json::from_str(&pending.arguments).unwrap_or_else(|_| json!({}));
@@ -106,6 +113,13 @@ impl ProviderStreamParser {
             let metadata = Value::Object(std::mem::take(&mut self.google_grounding));
             events.push(google_grounding_event(metadata));
         }
+        if !self.search_sources.is_empty() {
+            events.push(ChatStreamEvent::ProviderContext {
+                item: json!({"webSearchGroundingDisplay": crate::ai::types::WebSearchGrounding {
+                    sources: std::mem::take(&mut self.search_sources), search_suggestions_html: None,
+                }}),
+            });
+        }
         Ok(events)
     }
 
@@ -117,6 +131,28 @@ impl ProviderStreamParser {
             return Ok(Vec::new());
         };
         let mut events = Vec::new();
+        if self.provider_id == "openrouter" {
+            for annotations in [
+                choice.pointer("/delta/annotations"),
+                choice.pointer("/message/annotations"),
+            ]
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_array)
+            {
+                for annotation in annotations {
+                    if annotation["type"] == "url_citation" {
+                        if let Some(source) = web_source(&annotation["url_citation"], "url") {
+                            add_source(&mut self.search_sources, source);
+                        }
+                    }
+                    events.push(ChatStreamEvent::ProviderContext {
+                        item: json!({"openrouterAnnotation": annotation}),
+                    });
+                }
+            }
+        }
+
         if let Some(delta) = choice.get("delta") {
             for item in delta
                 .get("reasoning_details")
@@ -230,69 +266,149 @@ impl ProviderStreamParser {
     fn parse_anthropic(&mut self, payload: &str) -> Result<Vec<ChatStreamEvent>, AppError> {
         let value: Value = serde_json::from_str(payload)
             .map_err(|error| AppError::Other(format!("invalid Anthropic stream event: {error}")))?;
+        let index = value.get("index").and_then(Value::as_u64).unwrap_or(0);
+        let mut events = Vec::new();
         match value.get("type").and_then(Value::as_str) {
             Some("content_block_start") => {
-                let block = value.get("content_block").unwrap_or(&Value::Null);
-                if block.get("type").and_then(Value::as_str) == Some("tool_use") {
-                    self.anthropic_tool = Some(AnthropicToolBlock {
-                        id: block
-                            .get("id")
-                            .and_then(Value::as_str)
-                            .unwrap_or_default()
-                            .to_string(),
-                        name: block
-                            .get("name")
-                            .and_then(Value::as_str)
-                            .unwrap_or_default()
-                            .to_string(),
-                        arguments: String::new(),
+                let block = value.get("content_block").cloned().unwrap_or(Value::Null);
+                if let Some(code) = block.pointer("/content/error_code").and_then(Value::as_str) {
+                    if block["type"] == "web_search_tool_result" {
+                        self.search_error = Some(format!("Anthropic web search failed: {code}"));
+                    }
+                }
+                if block["type"] == "server_tool_use" && block["name"] == "web_search" {
+                    events.push(ChatStreamEvent::Status {
+                        status: "searching".into(),
                     });
                 }
-                Ok(Vec::new())
+                if let Some(text) = block
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .filter(|text| !text.is_empty())
+                {
+                    events.push(ChatStreamEvent::Token {
+                        token: text.to_owned(),
+                    });
+                }
+                self.anthropic_blocks.insert(
+                    index,
+                    AnthropicContentBlock {
+                        value: block,
+                        arguments: String::new(),
+                    },
+                );
             }
             Some("content_block_delta") => {
-                let delta = value.get("delta").unwrap_or(&Value::Null);
-                match delta.get("type").and_then(Value::as_str) {
-                    Some("text_delta") => Ok(delta
-                        .get("text")
-                        .and_then(Value::as_str)
-                        .map(|token| {
-                            vec![ChatStreamEvent::Token {
-                                token: token.to_string(),
-                            }]
-                        })
-                        .unwrap_or_default()),
-                    Some("input_json_delta") => {
-                        if let (Some(tool), Some(partial)) = (
-                            self.anthropic_tool.as_mut(),
-                            delta.get("partial_json").and_then(Value::as_str),
-                        ) {
-                            tool.arguments.push_str(partial);
-                        }
-                        Ok(Vec::new())
+                let delta = &value["delta"];
+                if delta["type"] == "text_delta" {
+                    if let Some(text) = delta["text"].as_str() {
+                        events.push(ChatStreamEvent::Token {
+                            token: text.to_owned(),
+                        });
                     }
-                    _ => Ok(Vec::new()),
+                }
+                if let Some(block) = self.anthropic_blocks.get_mut(&index) {
+                    match delta["type"].as_str() {
+                        Some("text_delta") | Some("thinking_delta") | Some("signature_delta") => {
+                            let field = match delta["type"].as_str() {
+                                Some("thinking_delta") => "thinking",
+                                Some("signature_delta") => "signature",
+                                _ => "text",
+                            };
+                            if let Some(text) = delta[field].as_str() {
+                                let previous = block.value[field].as_str().unwrap_or_default();
+                                block.value[field] = json!(format!("{previous}{text}"));
+                            }
+                        }
+                        Some("input_json_delta") => {
+                            if let Some(partial) = delta["partial_json"].as_str() {
+                                block.arguments.push_str(partial);
+                            }
+                        }
+                        Some("citations_delta") => {
+                            if let Some(citation) = delta.get("citation") {
+                                if !block.value["citations"].is_array() {
+                                    block.value["citations"] = json!([]);
+                                }
+                                block.value["citations"]
+                                    .as_array_mut()
+                                    .unwrap()
+                                    .push(citation.clone());
+                            }
+                        }
+                        _ => {}
+                    }
                 }
             }
             Some("content_block_stop") => {
-                let Some(tool) = self.anthropic_tool.take() else {
-                    return Ok(Vec::new());
-                };
-                Ok(vec![ChatStreamEvent::ToolCall {
-                    id: tool.id,
-                    name: tool.name,
-                    input: serde_json::from_str(&tool.arguments).unwrap_or_else(|_| json!({})),
-                }])
+                if let Some(mut block) = self.anthropic_blocks.remove(&index) {
+                    if !block.arguments.is_empty() {
+                        block.value["input"] =
+                            serde_json::from_str(&block.arguments).map_err(|error| {
+                                AppError::Other(format!("invalid Anthropic tool input: {error}"))
+                            })?;
+                    }
+                    if block.value["type"] == "tool_use" {
+                        events.push(ChatStreamEvent::ToolCall {
+                            id: block.value["id"].as_str().unwrap_or_default().into(),
+                            name: block.value["name"].as_str().unwrap_or_default().into(),
+                            input: block
+                                .value
+                                .get("input")
+                                .cloned()
+                                .unwrap_or_else(|| json!({})),
+                        });
+                    }
+                    // Citation links are presentation only. Native text, encrypted
+                    // references and server results are replayed without these links.
+                    for citation in block
+                        .value
+                        .get("citations")
+                        .and_then(Value::as_array)
+                        .into_iter()
+                        .flatten()
+                    {
+                        if citation["type"] == "web_search_result_location" {
+                            if let Some(source) = web_source(citation, "url") {
+                                let destination = url::Url::parse(&source.url)
+                                    .unwrap()
+                                    .to_string()
+                                    .replace('(', "%28")
+                                    .replace(')', "%29")
+                                    .replace('<', "%3C")
+                                    .replace('>', "%3E");
+                                let number = add_source(&mut self.search_sources, source);
+                                events.push(ChatStreamEvent::Token {
+                                    token: format!(" [{number}]({destination})"),
+                                });
+                            }
+                        }
+                    }
+                    events.push(ChatStreamEvent::ProviderContext {
+                        item: json!({"anthropicBlock": block.value}),
+                    });
+                }
+            }
+            Some("message_delta")
+                if value.pointer("/delta/stop_reason").and_then(Value::as_str)
+                    == Some("pause_turn") =>
+            {
+                events.push(ChatStreamEvent::ProviderContext {
+                    item: json!({"continueTurn": true}),
+                });
             }
             Some("error") => {
-                let message = value
-                    .pointer("/error/message")
-                    .and_then(Value::as_str)
-                    .unwrap_or("Anthropic request failed");
-                Err(AppError::Other(message.to_string()))
+                return Err(AppError::Other(
+                    value
+                        .pointer("/error/message")
+                        .and_then(Value::as_str)
+                        .unwrap_or("Anthropic request failed")
+                        .into(),
+                ));
             }
-            _ => Ok(Vec::new()),
+            _ => {}
         }
+        Ok(events)
     }
 
     fn parse_google(&mut self, payload: &str) -> Result<Vec<ChatStreamEvent>, AppError> {
@@ -384,34 +500,52 @@ impl ProviderStreamParser {
     }
 }
 
+fn web_source(value: &Value, url_key: &str) -> Option<crate::ai::types::GroundingSource> {
+    let uri = value.get(url_key)?.as_str()?;
+    if uri.chars().any(char::is_control) {
+        return None;
+    }
+    let url = url::Url::parse(uri).ok()?;
+    if !matches!(url.scheme(), "http" | "https")
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+    {
+        return None;
+    }
+    Some(crate::ai::types::GroundingSource {
+        title: value
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or(uri)
+            .to_owned(),
+        url: uri.to_owned(),
+    })
+}
+
+fn add_source(
+    sources: &mut Vec<crate::ai::types::GroundingSource>,
+    source: crate::ai::types::GroundingSource,
+) -> usize {
+    if let Some(index) = sources
+        .iter()
+        .position(|existing| existing.url == source.url)
+    {
+        return index + 1;
+    }
+    sources.push(source);
+    sources.len()
+}
+
 fn google_grounding_event(metadata: Value) -> ChatStreamEvent {
     let sources = metadata
         .get("groundingChunks")
         .and_then(Value::as_array)
         .into_iter()
         .flatten()
-        .filter_map(|chunk| {
-            let web = chunk.get("web")?;
-            let uri = web.get("uri")?.as_str()?;
-            let url = url::Url::parse(uri).ok()?;
-            if !matches!(url.scheme(), "http" | "https")
-                || url.host_str().is_none()
-                || !url.username().is_empty()
-                || url.password().is_some()
-            {
-                return None;
-            }
-            Some(crate::ai::types::GroundingSource {
-                title: web
-                    .get("title")
-                    .and_then(Value::as_str)
-                    .unwrap_or(uri)
-                    .to_owned(),
-                url: uri.to_owned(),
-            })
-        })
+        .filter_map(|chunk| web_source(chunk.get("web")?, "uri"))
         .collect();
-    let display = crate::ai::types::GeminiGrounding {
+    let display = crate::ai::types::WebSearchGrounding {
         sources,
         search_suggestions_html: metadata
             .pointer("/searchEntryPoint/renderedContent")
@@ -462,8 +596,24 @@ fn openai_messages(messages: &[ChatMessage], stringify_tool_arguments: bool) -> 
                     );
                 }
                 if let Some(context) = &message.provider_context {
-                    if !context.is_empty() {
-                        value["reasoning_details"] = Value::Array(context.clone());
+                    let reasoning: Vec<Value> = context
+                        .iter()
+                        .filter(|item| {
+                            item.get("type")
+                                .and_then(Value::as_str)
+                                .is_some_and(|kind| kind.starts_with("reasoning."))
+                        })
+                        .cloned()
+                        .collect();
+                    if !reasoning.is_empty() {
+                        value["reasoning_details"] = json!(reasoning);
+                    }
+                    let annotations: Vec<Value> = context
+                        .iter()
+                        .filter_map(|item| item.get("openrouterAnnotation").cloned())
+                        .collect();
+                    if !annotations.is_empty() {
+                        value["annotations"] = json!(annotations);
                     }
                 }
                 value
@@ -665,6 +815,16 @@ fn build_anthropic_request(
         .filter(|message| message.role != "system")
         .map(|message| match message.role.as_str() {
             "assistant" => {
+                let original_blocks: Vec<Value> = message
+                    .provider_context
+                    .as_deref()
+                    .unwrap_or_default()
+                    .iter()
+                    .filter_map(|item| item.get("anthropicBlock").cloned())
+                    .collect();
+                if !original_blocks.is_empty() {
+                    return json!({ "role": "assistant", "content": original_blocks });
+                }
                 let mut blocks = Vec::new();
                 if !message.content.is_empty() {
                     blocks.push(json!({ "type": "text", "text": message.content }));
@@ -730,24 +890,24 @@ fn build_anthropic_request(
         );
     }
 
-    if let Some(tools) = &params.tools {
-        if !tools.is_empty() {
-            body_map.as_object_mut().unwrap().insert(
-                "tools".to_string(),
-                Value::Array(
-                    tools
-                        .iter()
-                        .map(|tool| {
-                            json!({
-                                "name": tool.name,
-                                "description": tool.description,
-                                "input_schema": tool.parameters,
-                            })
-                        })
-                        .collect(),
-                ),
-            );
-        }
+    let mut tools: Vec<Value> = params
+        .tools
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|tool| {
+            json!({
+                "name": tool.name,
+                "description": tool.description,
+                "input_schema": tool.parameters,
+            })
+        })
+        .collect();
+    if config.hosted_web_search == Some(true) {
+        tools.push(json!({"type": "web_search_20250305", "name": "web_search", "max_uses": 5}));
+    }
+    if !tools.is_empty() {
+        body_map["tools"] = json!(tools);
     }
 
     Ok(RequestSpec {
@@ -1043,6 +1203,10 @@ fn build_openrouter_request(
         if !tools.is_empty() {
             obj.insert("tools".to_string(), Value::Array(tools));
         }
+    }
+
+    if config.hosted_web_search == Some(true) {
+        body_map["plugins"] = json!([{ "id": "web" }]);
     }
 
     Ok(RequestSpec {

--- a/asyar-launcher/src-tauri/src/ai/providers_test.rs
+++ b/asyar-launcher/src-tauri/src/ai/providers_test.rs
@@ -578,3 +578,155 @@ fn test_build_ollama_request_includes_temperature_when_some() {
     let req = build_request("ollama", &config, &messages, &params).unwrap();
     assert_eq!(req.body["options"]["temperature"], 0.6);
 }
+
+#[test]
+fn google_search_preserves_custom_tools_on_gemini_3() {
+    let mut config = mock_config();
+    config.hosted_web_search = Some(true);
+    let mut params = tool_params();
+    params.model_id = "gemini-3-flash-preview".into();
+    let request = build_request("google", &config, &[], &params).unwrap();
+    assert_eq!(request.body["tools"][1], json!({"google_search": {}}));
+    assert_eq!(
+        request.body["toolConfig"]["includeServerSideToolInvocations"],
+        true
+    );
+    assert_eq!(
+        request.body["tools"][0]["functionDeclarations"][0]["name"],
+        "builtin__echo"
+    );
+}
+
+#[test]
+fn google_search_rejects_unsupported_custom_tool_combination() {
+    let mut config = mock_config();
+    config.hosted_web_search = Some(true);
+    let mut params = tool_params();
+    params.model_id = "gemini-2.5-flash".into();
+    assert!(build_request("google", &config, &[], &params)
+        .unwrap_err()
+        .to_string()
+        .contains("Gemini 3"));
+    params.tools = None;
+    assert_eq!(
+        build_request("google", &config, &[], &params).unwrap().body["tools"],
+        json!([{"google_search": {}}])
+    );
+    config.hosted_web_search = Some(false);
+    assert!(build_request("google", &config, &[], &params)
+        .unwrap()
+        .body
+        .get("tools")
+        .is_none());
+}
+
+#[test]
+fn google_retains_grounding_and_signed_parts_for_continuation() {
+    let config = mock_config();
+    let mut parser = ProviderStreamParser::new("google", &config);
+    let part = json!({"functionCall": {"id": "call-1", "name": "builtin__echo", "args": {}}, "thoughtSignature": "opaque"});
+    let grounding = json!({"webSearchQueries": ["weather"], "groundingChunks": [{"web": {"uri": "https://example.com", "title": "Weather"}}]});
+    let mut events = parser.push_line(&format!("data: {}", json!({"candidates": [{"content": {"parts": [part.clone()]}, "groundingMetadata": grounding.clone()}]}))).unwrap();
+    events.extend(parser.finish().unwrap());
+    let context: Vec<_> = events
+        .into_iter()
+        .filter_map(|event| match event {
+            ChatStreamEvent::ProviderContext { item } => Some(item),
+            _ => None,
+        })
+        .collect();
+    assert!(context.iter().any(|item| item["geminiPart"] == part));
+    assert!(context
+        .iter()
+        .any(|item| item["geminiGrounding"] == grounding));
+    let mut history = tool_history();
+    history[1].provider_context = Some(context);
+    let request = build_request("google", &config, &history, &tool_params()).unwrap();
+    assert_eq!(request.body["contents"][1]["parts"], json!([part]));
+}
+
+#[test]
+fn google_metadata_only_chunk_has_safe_typed_sources() {
+    let mut parser = ProviderStreamParser::new("google", &mock_config());
+    let mut events = parser.push_line(&format!("data: {}", json!({"candidates": [{"groundingMetadata": {
+        "groundingChunks": [{"web": {"uri": "https://example.com/a", "title": "A"}}, {"web": {"uri": "javascript:alert(1)", "title": "Unsafe"}}],
+        "searchEntryPoint": {"renderedContent": "<div>Search suggestions</div>"},
+        "groundingSupports": [{"segment": {"text": "Claim"}, "groundingChunkIndices": [0]}]
+    }}]}))).unwrap();
+    events.extend(parser.finish().unwrap());
+    let display = events
+        .iter()
+        .find_map(|event| match event {
+            ChatStreamEvent::ProviderContext { item } => item.get("geminiGroundingDisplay"),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(
+        display["sources"],
+        json!([{"title": "A", "url": "https://example.com/a"}])
+    );
+    assert_eq!(
+        display["searchSuggestionsHtml"],
+        "<div>Search suggestions</div>"
+    );
+    assert!(events.iter().any(|event| matches!(event, ChatStreamEvent::ProviderContext { item } if item["geminiGrounding"]["groundingSupports"].is_array())));
+}
+
+#[test]
+fn google_continuation_does_not_send_synthetic_id_to_api() {
+    let mut parser = ProviderStreamParser::new("google", &mock_config());
+    let events = parser.push_line("data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"builtin__echo\",\"args\":{}}}]}}]}").unwrap();
+    let mut history = tool_history();
+    history[1].provider_context = Some(
+        events
+            .iter()
+            .filter_map(|event| match event {
+                ChatStreamEvent::ProviderContext { item } => Some(item.clone()),
+                _ => None,
+            })
+            .collect(),
+    );
+    history[1].tool_calls.as_mut().unwrap()[0].id = "gemini-1".into();
+    history[2].tool_call_id = Some("gemini-1".into());
+    let request = build_request("google", &mock_config(), &history, &tool_params()).unwrap();
+    assert!(request.body["contents"][1]["parts"][0]["functionCall"]
+        .get("id")
+        .is_none());
+    assert!(request.body["contents"][2]["parts"][0]["functionResponse"]
+        .get("id")
+        .is_none());
+}
+
+#[test]
+fn google_emits_one_grounding_display_after_partial_metadata_chunks() {
+    let mut parser = ProviderStreamParser::new("google", &mock_config());
+    for metadata in [
+        json!({}),
+        json!({"groundingChunks": [{"web": {"uri": "https://example.com", "title": "Source"}}]}),
+        json!({"searchEntryPoint": {"renderedContent": "Suggestions"}}),
+    ] {
+        parser
+            .push_line(&format!(
+                "data: {}",
+                json!({"candidates": [{"groundingMetadata": metadata}]})
+            ))
+            .unwrap();
+    }
+    let events = parser.finish().unwrap();
+    assert_eq!(events.len(), 1);
+    let ChatStreamEvent::ProviderContext { item } = &events[0] else {
+        panic!("Expected grounding");
+    };
+    assert_eq!(
+        item["geminiGroundingDisplay"]["sources"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        item["geminiGroundingDisplay"]["searchSuggestionsHtml"],
+        "Suggestions"
+    );
+    assert!(parser.finish().unwrap().is_empty());
+}

--- a/asyar-launcher/src-tauri/src/ai/providers_test.rs
+++ b/asyar-launcher/src-tauri/src/ai/providers_test.rs
@@ -730,3 +730,216 @@ fn google_emits_one_grounding_display_after_partial_metadata_chunks() {
     );
     assert!(parser.finish().unwrap().is_empty());
 }
+
+#[test]
+fn hosted_search_provider_requests_keep_client_tools() {
+    let mut config = mock_config();
+    config.hosted_web_search = Some(true);
+    let mut params = mock_params(None);
+    params.model_id = "claude-sonnet-4-5".into();
+    params.tools = Some(vec![ToolDefinition {
+        name: "local".into(),
+        description: "Local".into(),
+        parameters: json!({"type":"object"}),
+    }]);
+    let anthropic = build_request("anthropic", &config, &mock_messages(), &params).unwrap();
+    assert_eq!(
+        anthropic.body["tools"][1],
+        json!({"type":"web_search_20250305","name":"web_search","max_uses":5})
+    );
+    let router = build_request("openrouter", &config, &mock_messages(), &params).unwrap();
+    assert_eq!(router.body["plugins"], json!([{"id":"web"}]));
+    assert_eq!(router.body["tools"][0]["function"]["name"], "local");
+    config.hosted_web_search = Some(false);
+    assert!(build_request("openrouter", &config, &[], &params)
+        .unwrap()
+        .body
+        .get("plugins")
+        .is_none());
+    assert_eq!(
+        build_request("anthropic", &config, &[], &params)
+            .unwrap()
+            .body["tools"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn anthropic_search_stream_preserves_native_blocks_and_cites_text() {
+    let config = mock_config();
+    let mut parser = ProviderStreamParser::new("anthropic", &config);
+    let blocks = vec![
+        json!({"type":"server_tool_use","id":"srvtoolu_1","name":"web_search","input":{"query":"news"}}),
+        json!({"type":"web_search_tool_result","tool_use_id":"srvtoolu_1","content":[{"type":"web_search_result","url":"https://example.com","title":"News","encrypted_content":"opaque"}]}),
+        json!({"type":"text","text":"News today.","citations":[{"type":"web_search_result_location","url":"https://example.com","title":"News","encrypted_index":"encrypted","cited_text":"Today"}]}),
+        json!({"type":"tool_use","id":"toolu_1","name":"local","input":{"value":1}}),
+    ];
+    let mut events = Vec::new();
+    for (index, block) in blocks.iter().enumerate() {
+        events.extend(
+            parser
+                .push_line(&format!(
+                    "data: {}",
+                    json!({"type":"content_block_start","index":index,"content_block":block})
+                ))
+                .unwrap(),
+        );
+        events.extend(
+            parser
+                .push_line(&format!(
+                    "data: {}",
+                    json!({"type":"content_block_stop","index":index})
+                ))
+                .unwrap(),
+        );
+    }
+    events.extend(parser.finish().unwrap());
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| matches!(e, ChatStreamEvent::ToolCall { .. }))
+            .count(),
+        1
+    );
+    let context: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            ChatStreamEvent::ProviderContext { item } => Some(item.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        context
+            .iter()
+            .filter_map(|c| c.get("anthropicBlock").cloned())
+            .collect::<Vec<_>>(),
+        blocks
+    );
+    assert!(events.iter().any(
+        |e| matches!(e, ChatStreamEvent::Token {token} if token.contains("https://example.com"))
+    ));
+    let mut message = mock_messages().pop().unwrap();
+    message.provider_context = Some(context);
+    let request = build_request("anthropic", &config, &[message], &mock_params(None)).unwrap();
+    assert_eq!(request.body["messages"][0]["content"], json!(blocks));
+}
+
+#[test]
+fn openrouter_stream_annotations_are_not_reasoning_details() {
+    let config = mock_config();
+    let mut parser = ProviderStreamParser::new("openrouter", &config);
+    let annotation = json!({"type":"url_citation","url_citation":{"url":"https://example.com","title":"Example","start_index":0,"end_index":5}});
+    let mut events = parser.push_line(&format!("data: {}", json!({"choices":[{"delta":{"content":"Hello","annotations":[annotation.clone()],"reasoning_details":[{"type":"reasoning.text","text":"Reason"}]}}]}))).unwrap();
+    events.extend(parser.finish().unwrap());
+    let context: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            ChatStreamEvent::ProviderContext { item } => Some(item.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(context
+        .iter()
+        .any(|c| c["webSearchGroundingDisplay"]["sources"][0]["url"] == "https://example.com"));
+    let mut message = mock_messages().pop().unwrap();
+    message.provider_context = Some(context);
+    let request = build_request("openrouter", &config, &[message], &mock_params(None)).unwrap();
+    assert_eq!(
+        request.body["messages"][0]["annotations"],
+        json!([annotation])
+    );
+    assert_eq!(
+        request.body["messages"][0]["reasoning_details"],
+        json!([{"type":"reasoning.text","text":"Reason"}])
+    );
+}
+
+#[test]
+fn anthropic_pause_turn_requests_continuation_and_search_errors_surface() {
+    let mut parser = ProviderStreamParser::new("anthropic", &mock_config());
+    let events = parser
+        .push_line(r#"data: {"type":"message_delta","delta":{"stop_reason":"pause_turn"}}"#)
+        .unwrap();
+    assert!(events.iter().any(|event| matches!(event, ChatStreamEvent::ProviderContext {item} if item["continueTurn"] == true)));
+    parser.push_line(r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"web_search_tool_result","content":{"type":"web_search_tool_result_error","error_code":"unavailable"}}}"#).unwrap();
+    let events = parser
+        .push_line(r#"data: {"type":"content_block_stop","index":0}"#)
+        .unwrap();
+    assert!(events.iter().any(|event| matches!(event, ChatStreamEvent::ProviderContext {item} if item["anthropicBlock"]["content"]["error_code"] == "unavailable")));
+    assert!(parser
+        .finish()
+        .unwrap_err()
+        .to_string()
+        .contains("unavailable"));
+}
+
+#[test]
+fn anthropic_streamed_citations_and_inputs_round_trip_without_markdown_injection() {
+    let mut parser = ProviderStreamParser::new("anthropic", &mock_config());
+    let citation = json!({"type":"web_search_result_location","url":"https://example.com/a(b)<c>","title":"[unsafe](javascript:alert(1))","encrypted_index":"opaque"});
+    let chunks = [
+        json!({"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srv_1","name":"web_search","input":{}}}),
+        json!({"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"news\"}"}}),
+        json!({"type":"content_block_stop","index":0}),
+        json!({"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}),
+        json!({"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Answer"}}),
+        json!({"type":"content_block_delta","index":1,"delta":{"type":"citations_delta","citation":citation}}),
+        json!({"type":"content_block_delta","index":1,"delta":{"type":"citations_delta","citation":{"type":"web_search_result_location","url":"javascript:alert(1)"}}}),
+        json!({"type":"content_block_stop","index":1}),
+    ];
+    let mut events = Vec::new();
+    for chunk in chunks {
+        events.extend(parser.push_line(&format!("data: {chunk}")).unwrap());
+    }
+    events.extend(parser.finish().unwrap());
+    let tokens = events
+        .iter()
+        .filter_map(|event| match event {
+            ChatStreamEvent::Token { token } => Some(token.as_str()),
+            _ => None,
+        })
+        .collect::<String>();
+    assert_eq!(tokens, "Answer [1](https://example.com/a%28b%29%3Cc%3E)");
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event, ChatStreamEvent::ToolCall { .. })));
+    assert!(events.iter().any(|event| matches!(event, ChatStreamEvent::ProviderContext {item} if item["anthropicBlock"]["input"]["query"] == "news")));
+    assert!(events.iter().any(|event| matches!(event, ChatStreamEvent::ProviderContext {item} if item["anthropicBlock"]["text"] == "Answer" && item["anthropicBlock"]["citations"][0]["encrypted_index"] == "opaque")));
+    let display = events
+        .iter()
+        .find_map(|event| match event {
+            ChatStreamEvent::ProviderContext { item } => item.get("webSearchGroundingDisplay"),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(display["sources"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn openrouter_message_annotations_filter_unsafe_urls_and_deduplicate_sources() {
+    let mut parser = ProviderStreamParser::new("openrouter", &mock_config());
+    let annotations = [
+        "https://example.com",
+        "https://example.com",
+        "javascript:alert(1)",
+        "https://user:password@example.com",
+        "https://example.com/\npath",
+    ]
+    .into_iter()
+    .map(|url| json!({"type":"url_citation","url_citation":{"url":url,"title":"Example"}}))
+    .collect::<Vec<_>>();
+    parser
+        .push_line(&format!(
+            "data: {}",
+            json!({"choices":[{"message":{"annotations":annotations}}]})
+        ))
+        .unwrap();
+    let events = parser.finish().unwrap();
+    assert!(
+        matches!(&events[0], ChatStreamEvent::ProviderContext {item} if item["webSearchGroundingDisplay"]["sources"].as_array().unwrap().len() == 1)
+    );
+    assert!(parser.finish().unwrap().is_empty());
+}

--- a/asyar-launcher/src-tauri/src/ai/types.rs
+++ b/asyar-launcher/src-tauri/src/ai/types.rs
@@ -126,3 +126,19 @@ pub enum ChatStreamEventPayload {
         error: String,
     },
 }
+
+/// Presentation data derived from Gemini grounding metadata. The complete
+/// provider metadata remains in provider_context for attribution/history.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct GeminiGrounding {
+    pub sources: Vec<GroundingSource>,
+    pub search_suggestions_html: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct GroundingSource {
+    pub title: String,
+    pub url: String,
+}

--- a/asyar-launcher/src-tauri/src/ai/types.rs
+++ b/asyar-launcher/src-tauri/src/ai/types.rs
@@ -127,11 +127,11 @@ pub enum ChatStreamEventPayload {
     },
 }
 
-/// Presentation data derived from Gemini grounding metadata. The complete
+/// Presentation data derived from provider web search metadata. The complete
 /// provider metadata remains in provider_context for attribution/history.
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
-pub struct GeminiGrounding {
+pub struct WebSearchGrounding {
     pub sources: Vec<GroundingSource>,
     pub search_suggestions_html: Option<String>,
 }

--- a/asyar-launcher/src-tauri/src/search_engine/models.rs
+++ b/asyar-launcher/src-tauri/src/search_engine/models.rs
@@ -498,6 +498,7 @@ mod bindings_export {
             .register::<crate::calculator::CalcResult>()
             .register::<crate::calculator::CalcKind>()
             .register::<crate::ai::types::ChatMessage>()
+            .register::<crate::ai::types::GeminiGrounding>()
             .register::<crate::ai::types::ProviderConfig>()
             .register::<crate::ai::types::ModelInfo>()
             .register::<crate::ai::types::ChatParams>()

--- a/asyar-launcher/src-tauri/src/search_engine/models.rs
+++ b/asyar-launcher/src-tauri/src/search_engine/models.rs
@@ -498,7 +498,7 @@ mod bindings_export {
             .register::<crate::calculator::CalcResult>()
             .register::<crate::calculator::CalcKind>()
             .register::<crate::ai::types::ChatMessage>()
-            .register::<crate::ai::types::GeminiGrounding>()
+            .register::<crate::ai::types::WebSearchGrounding>()
             .register::<crate::ai::types::ProviderConfig>()
             .register::<crate::ai::types::ModelInfo>()
             .register::<crate::ai::types::ChatParams>()

--- a/asyar-launcher/src/bindings.ts
+++ b/asyar-launcher/src/bindings.ts
@@ -189,6 +189,20 @@ export type FileSearchResponse = {
 export type FileType = "document" | "image" | "code" | "audio-video" | "archive" | "folder" | "other";
 
 /**
+ *  Presentation data derived from Gemini grounding metadata. The complete
+ *  provider metadata remains in provider_context for attribution/history.
+ */
+export type GeminiGrounding = {
+	sources: GroundingSource[],
+	searchSuggestionsHtml: string | null,
+};
+
+export type GroundingSource = {
+	title: string,
+	url: string,
+};
+
+/**
  *  Where a hit came from: the local index or an on-demand deep-search
  *  provider (mdfind / Everything / plocate).
  */

--- a/asyar-launcher/src/bindings.ts
+++ b/asyar-launcher/src/bindings.ts
@@ -188,15 +188,6 @@ export type FileSearchResponse = {
  */
 export type FileType = "document" | "image" | "code" | "audio-video" | "archive" | "folder" | "other";
 
-/**
- *  Presentation data derived from Gemini grounding metadata. The complete
- *  provider metadata remains in provider_context for attribution/history.
- */
-export type GeminiGrounding = {
-	sources: GroundingSource[],
-	searchSuggestionsHtml: string | null,
-};
-
 export type GroundingSource = {
 	title: string,
 	url: string,
@@ -391,6 +382,15 @@ export type ToolDefinition = {
 export type UpdateCommandMetadataInput = {
 	commandObjectId: string,
 	subtitle: string | null,
+};
+
+/**
+ *  Presentation data derived from provider web search metadata. The complete
+ *  provider metadata remains in provider_context for attribution/history.
+ */
+export type WebSearchGrounding = {
+	sources: GroundingSource[],
+	searchSuggestionsHtml: string | null,
 };
 
 /**

--- a/asyar-launcher/src/built-in-features/agents/AgentChatView.svelte
+++ b/asyar-launcher/src/built-in-features/agents/AgentChatView.svelte
@@ -124,6 +124,16 @@
         .catch((error) => logService.warn(`[agents] Cannot open source: ${error}`));
   }
 
+  function handleMessageClick(event: MouseEvent) {
+    handleMarkdownCopyClick(event);
+    const link = event.target instanceof Element ? event.target.closest('.md-content a') : null;
+    if (link) {
+      event.preventDefault();
+      const href = link.getAttribute('href');
+      if (href) openSearchSource(href);
+    }
+  }
+
   function copyText(text: string) {
     void navigator.clipboard.writeText(text).catch(() => {});
   }
@@ -245,7 +255,7 @@
           {:else}
             <!-- svelte-ignore a11y_click_events_have_key_events -->
             <!-- svelte-ignore a11y_no_static_element_interactions -->
-            <div class="messages-list" onclick={handleMarkdownCopyClick}>
+            <div class="messages-list" onclick={handleMessageClick}>
               {#each messages as message (message.id)}
                 {@const variant = messageBubbleVariant(message)}
                 {@const text = extractTextFromMessage(message)}

--- a/asyar-launcher/src/built-in-features/agents/AgentChatView.svelte
+++ b/asyar-launcher/src/built-in-features/agents/AgentChatView.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { openerService } from '../../services/opener/openerService';
+  import { externalSearchUrl } from '../../components/ai/googleSearchSuggestions';
   import { onMount, onDestroy, tick } from 'svelte';
   import { agentService } from './agentService.svelte';
   import { agentsManager } from './agentsManager.svelte';
@@ -6,12 +8,13 @@
   import { logService } from '../../services/log/logService';
   import {
     extractTextFromMessage,
+    extractGroundingFromMessage,
     extractToolUsesFromMessage,
     messageBubbleVariant,
     resolveThreadId,
   } from './agentChatView.helpers';
   import EmptyState from '../../components/feedback/EmptyState.svelte';
-  import { Button, IconButton } from '../../components';
+  import { Button, IconButton, GoogleSearchSuggestions } from '../../components';
   import ThreadListSidebar from './ThreadListSidebar.svelte';
   import type { AgentDef, ThreadDef, MessageDef } from './types';
   import { showSettingsWindow } from '../../lib/ipc/commands';
@@ -111,6 +114,14 @@
     if (!messagesEl) return;
     const atBottom = messagesEl.scrollHeight - messagesEl.scrollTop - messagesEl.clientHeight < 40;
     userScrolledUp = !atBottom;
+  }
+
+  function openSearchSource(value: string) {
+    const url = externalSearchUrl(value);
+    if (url)
+      void openerService
+        .open(null, url)
+        .catch((error) => logService.warn(`[agents] Cannot open source: ${error}`));
   }
 
   function copyText(text: string) {
@@ -238,6 +249,7 @@
               {#each messages as message (message.id)}
                 {@const variant = messageBubbleVariant(message)}
                 {@const text = extractTextFromMessage(message)}
+                {@const grounding = extractGroundingFromMessage(message)}
                 {@const toolUses = extractToolUsesFromMessage(message)}
                 <div class="message-row {variant}">
                   {#if variant === 'assistant'}
@@ -252,6 +264,28 @@
                       {#if text.length > 0}
                         <div class="md-content">{@html renderMarkdown(text)}</div>
                       {/if}
+                      {#each grounding as search}
+                        {#if search.sources.length > 0}
+                          <div class="grounding-sources">
+                            <span class="text-caption">{t('features.agents.sources')}</span>
+                            {#each search.sources as source, index}
+                              <a
+                                href={source.url}
+                                onclick={(event) => {
+                                  event.preventDefault();
+                                  openSearchSource(source.url);
+                                }}>{index + 1}. {source.title}</a
+                              >
+                            {/each}
+                          </div>
+                        {/if}
+                        {#if search.searchSuggestionsHtml}
+                          <GoogleSearchSuggestions
+                            html={search.searchSuggestionsHtml}
+                            onOpen={openSearchSource}
+                          />
+                        {/if}
+                      {/each}
                       {#each toolUses as tu (tu.id)}
                         <div class="tool-use-chip">
                           <span class="chip-name">{tu.name}</span>
@@ -451,6 +485,17 @@
   }
   .message-bubble.user:hover :global(.copy-message-btn) {
     opacity: 0.7;
+  }
+
+  .grounding-sources {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    margin-top: var(--space-3);
+    font-size: var(--font-size-sm);
+  }
+  .grounding-sources a {
+    color: var(--accent-primary);
   }
 
   .tool-use-chip {

--- a/asyar-launcher/src/built-in-features/agents/AgentChatView.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/AgentChatView.test.ts
@@ -29,6 +29,11 @@ vi.mock('../../lib/ipc/commands', () => ({
   showSettingsWindow: vi.fn(),
 }));
 
+vi.mock('../../services/opener/openerService', () => ({
+  openerService: { open: vi.fn().mockResolvedValue(undefined) },
+}));
+
+import { openerService } from '../../services/opener/openerService';
 import AgentChatView from './AgentChatView.svelte';
 import { agentService } from './agentService.svelte';
 import { agentsManager } from './agentsManager.svelte';
@@ -80,6 +85,32 @@ describe('AgentChatView', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it('opens citation links externally and prevents launcher navigation', async () => {
+    mockedAgentService.listMessages.mockResolvedValue([
+      {
+        id: 'citation-message',
+        threadId: thread.id,
+        role: 'assistant',
+        content: { text: 'Answer [1](https://example.com/a%28b%29)' },
+        createdAt: 1,
+        runId: null,
+      },
+    ]);
+    render(AgentChatView);
+    const citation = await screen.findByRole('link', { name: '1' });
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true });
+    citation.dispatchEvent(click);
+    expect(click.defaultPrevented).toBe(true);
+    expect(openerService.open).toHaveBeenCalledWith(null, 'https://example.com/a%28b%29');
+
+    vi.mocked(openerService.open).mockClear();
+    citation.setAttribute('href', 'javascript:alert(1)');
+    const unsafeClick = new MouseEvent('click', { bubbles: true, cancelable: true });
+    citation.dispatchEvent(unsafeClick);
+    expect(unsafeClick.defaultPrevented).toBe(true);
+    expect(openerService.open).not.toHaveBeenCalled();
   });
 
   it('refreshes the sidebar when the selected thread is cleared after deletion', async () => {

--- a/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.test.ts
@@ -288,3 +288,23 @@ describe('resolveThreadId', () => {
     expect(resolveThreadId(null, [])).toBeNull();
   });
 });
+
+describe('persisted Gemini grounding', () => {
+  it('rehydrates presentation from provider context and ignores unrelated messages', async () => {
+    const { extractGroundingFromMessage } = await import('./agentChatView.helpers');
+    const display = {
+      sources: [{ title: 'Example', url: 'https://example.com' }],
+      searchSuggestionsHtml: '<div>Google</div>',
+    };
+    const message = {
+      role: 'assistant',
+      content: {
+        text: 'Answer',
+        providerContext: [{ geminiPart: { text: 'Answer' } }, { geminiGroundingDisplay: display }],
+      },
+    } as MessageDef;
+    expect(extractGroundingFromMessage(message)).toEqual([display]);
+    expect(extractGroundingFromMessage({ ...message, content: { text: 'No search' } })).toEqual([]);
+    expect(extractGroundingFromMessage({ ...message, role: 'user' })).toEqual([]);
+  });
+});

--- a/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.test.ts
@@ -289,22 +289,27 @@ describe('resolveThreadId', () => {
   });
 });
 
-describe('persisted Gemini grounding', () => {
-  it('rehydrates presentation from provider context and ignores unrelated messages', async () => {
-    const { extractGroundingFromMessage } = await import('./agentChatView.helpers');
-    const display = {
-      sources: [{ title: 'Example', url: 'https://example.com' }],
-      searchSuggestionsHtml: '<div>Google</div>',
-    };
-    const message = {
-      role: 'assistant',
-      content: {
-        text: 'Answer',
-        providerContext: [{ geminiPart: { text: 'Answer' } }, { geminiGroundingDisplay: display }],
-      },
-    } as MessageDef;
-    expect(extractGroundingFromMessage(message)).toEqual([display]);
-    expect(extractGroundingFromMessage({ ...message, content: { text: 'No search' } })).toEqual([]);
-    expect(extractGroundingFromMessage({ ...message, role: 'user' })).toEqual([]);
-  });
+describe('persisted web search grounding', () => {
+  it.each(['geminiGroundingDisplay', 'webSearchGroundingDisplay'])(
+    'rehydrates %s and ignores unrelated messages',
+    async (key) => {
+      const { extractGroundingFromMessage } = await import('./agentChatView.helpers');
+      const display = {
+        sources: [{ title: 'Example', url: 'https://example.com' }],
+        searchSuggestionsHtml: '<div>Google</div>',
+      };
+      const message = {
+        role: 'assistant',
+        content: {
+          text: 'Answer',
+          providerContext: [{ geminiPart: { text: 'Answer' } }, { [key]: display }],
+        },
+      } as MessageDef;
+      expect(extractGroundingFromMessage(message)).toEqual([display]);
+      expect(extractGroundingFromMessage({ ...message, content: { text: 'No search' } })).toEqual(
+        [],
+      );
+      expect(extractGroundingFromMessage({ ...message, role: 'user' })).toEqual([]);
+    },
+  );
 });

--- a/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.ts
@@ -1,4 +1,5 @@
 import type { ThreadDef, MessageDef } from './types';
+import type { GeminiGrounding } from '../../bindings';
 import type { ToolCall } from '../../services/ai/IProviderPlugin';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -108,4 +109,19 @@ export function resolveThreadId(
 ): string | null {
   if (!currentThreadId) return null;
   return threads.some((t) => t.id === currentThreadId) ? currentThreadId : null;
+}
+
+/** Rust prepares safe source URLs; this only reads the saved presentation. */
+export function extractGroundingFromMessage(msg: MessageDef): GeminiGrounding[] {
+  if (msg.role !== 'assistant') return [];
+  const context = (
+    msg.content as {
+      providerContext?: { geminiGroundingDisplay?: GeminiGrounding }[];
+    }
+  ).providerContext;
+  return (
+    context?.flatMap((item) =>
+      item.geminiGroundingDisplay ? [item.geminiGroundingDisplay] : [],
+    ) ?? []
+  );
 }

--- a/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.ts
@@ -1,5 +1,5 @@
 import type { ThreadDef, MessageDef } from './types';
-import type { GeminiGrounding } from '../../bindings';
+import type { WebSearchGrounding } from '../../bindings';
 import type { ToolCall } from '../../services/ai/IProviderPlugin';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -112,16 +112,20 @@ export function resolveThreadId(
 }
 
 /** Rust prepares safe source URLs; this only reads the saved presentation. */
-export function extractGroundingFromMessage(msg: MessageDef): GeminiGrounding[] {
+export function extractGroundingFromMessage(msg: MessageDef): WebSearchGrounding[] {
   if (msg.role !== 'assistant') return [];
   const context = (
     msg.content as {
-      providerContext?: { geminiGroundingDisplay?: GeminiGrounding }[];
+      providerContext?: {
+        geminiGroundingDisplay?: WebSearchGrounding;
+        webSearchGroundingDisplay?: WebSearchGrounding;
+      }[];
     }
   ).providerContext;
   return (
-    context?.flatMap((item) =>
-      item.geminiGroundingDisplay ? [item.geminiGroundingDisplay] : [],
-    ) ?? []
+    context?.flatMap((item) => {
+      const display = item.webSearchGroundingDisplay ?? item.geminiGroundingDisplay;
+      return display ? [display] : [];
+    }) ?? []
   );
 }

--- a/asyar-launcher/src/components/ai/GoogleSearchSuggestions.svelte
+++ b/asyar-launcher/src/components/ai/GoogleSearchSuggestions.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import {
+    externalSearchUrl,
+    searchSuggestionsDocument,
+    isSearchSuggestionsMessage,
+  } from './googleSearchSuggestions';
+  import { t } from '../../services/i18n';
+
+  let { html, onOpen }: { html: string; onOpen: (url: string) => void } = $props();
+  let frame = $state<HTMLIFrameElement>();
+  let src = $state('');
+  let token = $state('');
+  let height = $state(120);
+
+  $effect(() => {
+    const nonce = crypto.randomUUID();
+    token = nonce;
+    const document = searchSuggestionsDocument(html, nonce);
+    const url = URL.createObjectURL(new Blob([document], { type: 'text/html' }));
+    src = url;
+    return () => URL.revokeObjectURL(url);
+  });
+
+  function receive(event: MessageEvent) {
+    if (!isSearchSuggestionsMessage(event, frame?.contentWindow, token)) return;
+    if (event.data?.type === 'google-search-size' && Number.isFinite(event.data.height)) {
+      height = Math.max(1, Math.min(2000, event.data.height));
+    } else if (event.data?.type === 'google-search-link') {
+      const url = externalSearchUrl(event.data.url);
+      if (url) onOpen(url);
+    }
+  }
+</script>
+
+<svelte:window onmessage={receive} />
+{#if src}
+  <iframe
+    bind:this={frame}
+    {src}
+    title={t('features.agents.google_search_suggestions')}
+    sandbox="allow-scripts"
+    referrerpolicy="no-referrer"
+    style:height="{height}px"
+  ></iframe>
+{/if}
+
+<style>
+  iframe {
+    display: block;
+    width: 100%;
+    border: 0;
+    margin-top: var(--space-3);
+  }
+</style>

--- a/asyar-launcher/src/components/ai/googleSearchSuggestions.test.ts
+++ b/asyar-launcher/src/components/ai/googleSearchSuggestions.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import {
+  searchSuggestionsDocument,
+  externalSearchUrl,
+  isSearchSuggestionsMessage,
+} from './googleSearchSuggestions';
+
+describe('Google Search Suggestions isolation', () => {
+  it('retains provider HTML with only the trusted bridge permitted by CSP', () => {
+    const html =
+      '<style>.chip { color: red }</style><a href="https://google.com/search?q=test">Test</a><script>alert(1)</script>';
+    const result = searchSuggestionsDocument(html, 'random-nonce');
+    expect(result).toContain(html);
+    const document = new DOMParser().parseFromString(result, 'text/html');
+    const policy = document
+      .querySelector('meta[http-equiv="Content-Security-Policy"]')!
+      .getAttribute('content')!;
+    expect(policy).toContain("default-src 'none'");
+    expect(policy).toContain("script-src 'nonce-random-nonce'");
+    expect(policy).toContain("base-uri 'none'");
+    expect(document.querySelectorAll('script[nonce="random-nonce"]')).toHaveLength(1);
+    expect(policy).not.toContain("script-src 'unsafe-inline'");
+  });
+  it('permits only HTTP(S) links, excluding credentials and dangerous protocols', () => {
+    expect(externalSearchUrl('https://example.com/a')).toBe('https://example.com/a');
+    for (const value of [
+      'javascript:alert(1)',
+      'data:text/html,test',
+      'file:///tmp/a',
+      'https://user:pass@example.com',
+      null,
+    ]) {
+      expect(externalSearchUrl(value)).toBeNull();
+    }
+  });
+});
+
+it('rejects messages from other frames or a navigated document without the bridge token', () => {
+  const frame = {} as Window;
+  const event = {
+    source: frame,
+    data: { token: 'secret', type: 'google-search-link' },
+  } as MessageEvent;
+  expect(isSearchSuggestionsMessage(event, frame, 'secret')).toBe(true);
+  expect(isSearchSuggestionsMessage(event, {} as Window, 'secret')).toBe(false);
+  expect(
+    isSearchSuggestionsMessage(
+      { ...event, data: { type: 'google-search-link' } } as MessageEvent,
+      frame,
+      'secret',
+    ),
+  ).toBe(false);
+});

--- a/asyar-launcher/src/components/ai/googleSearchSuggestions.ts
+++ b/asyar-launcher/src/components/ai/googleSearchSuggestions.ts
@@ -1,0 +1,44 @@
+/** Restrict links crossing the isolated provider-content boundary. */
+export function externalSearchUrl(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  try {
+    const url = new URL(value);
+    return ['https:', 'http:'].includes(url.protocol) &&
+      url.hostname &&
+      !url.username &&
+      !url.password
+      ? url.href
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Preserve Google's supplied HTML/CSS in an opaque-origin sandbox.
+ * CSP permits only our nonce-bearing bridge; provider scripts and handlers
+ * cannot run. The caller must never grant allow-same-origin or navigation.
+ */
+export function searchSuggestionsDocument(html: string, nonce: string): string {
+  if (!/^[a-zA-Z0-9-]+$/.test(nonce)) throw new Error('Invalid script nonce');
+  return `<!doctype html><html><head><meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline'; img-src data: https://www.gstatic.com https://www.google.com; base-uri 'none'; form-action 'none'">
+<script nonce="${nonce}">
+document.addEventListener('click', event => {
+  const link = event.target.closest?.('a');
+  if (!link) return;
+  event.preventDefault();
+  if (event.isTrusted) parent.postMessage({type: 'google-search-link', token: '${nonce}', url: link.href}, '*');
+}, true);
+document.addEventListener('DOMContentLoaded', () => {
+  new ResizeObserver(() => parent.postMessage({type: 'google-search-size', token: '${nonce}', height: document.documentElement.scrollHeight}, '*')).observe(document.body);
+});
+</script></head><body>${html}</body></html>`;
+}
+
+export function isSearchSuggestionsMessage(
+  event: MessageEvent,
+  frame: Window | null | undefined,
+  token: string,
+): boolean {
+  return !!frame && event.source === frame && !!token && event.data?.token === token;
+}

--- a/asyar-launcher/src/components/index.ts
+++ b/asyar-launcher/src/components/index.ts
@@ -152,3 +152,6 @@ export { default as InspectorShell } from './dev/InspectorShell.svelte';
 //                       services/feedback/feedbackBoundary.test.ts.
 // dev/Panel*, dev/JsonTree, dev/StreamTail, dev/ExtensionNav, dev/HelpPanel,
 // dev/TimestampRelative — internals of InspectorShell (see above).
+
+// AI
+export { default as GoogleSearchSuggestions } from './ai/GoogleSearchSuggestions.svelte';

--- a/asyar-launcher/src/locales/en.json
+++ b/asyar-launcher/src/locales/en.json
@@ -285,6 +285,8 @@
       "type_theme": "Theme"
     },
     "ai": {
+      "google_search": "Google Search",
+      "google_search_description": "Let Gemini search the web and show sources. Uses your Gemini API key. Combining search with agent tools requires a Gemini 3 model; provider search charges may apply.",
       "no_provider": "No AI provider configured yet",
       "tab_continues_last_thread": "Tab continues last thread",
       "tab_continues_last_thread_description": "Pressing Tab in the launcher reopens your previous conversation instead of starting a new one.",
@@ -652,6 +654,8 @@
       "you": "You",
       "copy_message": "Copy message",
       "searching": "Searching…",
+      "sources": "Sources",
+      "google_search_suggestions": "Google Search Suggestions",
       "error_open_ai_settings": "Could not open AI settings. Try again."
     },
     "sticky": {

--- a/asyar-launcher/src/locales/en.json
+++ b/asyar-launcher/src/locales/en.json
@@ -285,6 +285,9 @@
       "type_theme": "Theme"
     },
     "ai": {
+      "hosted_web_search": "Web search",
+      "anthropic_search_description": "Let Claude search the web and cite sources using your Anthropic API key. Requires a supported model and web search enabled for your organization. Provider search charges may apply.",
+      "openrouter_search_description": "Search the web with OpenRouter’s web plugin and show sources. Uses your OpenRouter API key; additional search charges apply, including on free models.",
       "google_search": "Google Search",
       "google_search_description": "Let Gemini search the web and show sources. Uses your Gemini API key. Combining search with agent tools requires a Gemini 3 model; provider search charges may apply.",
       "no_provider": "No AI provider configured yet",

--- a/asyar-launcher/src/locales/pt-BR.json
+++ b/asyar-launcher/src/locales/pt-BR.json
@@ -285,6 +285,8 @@
       "type_theme": "Tema"
     },
     "ai": {
+      "google_search": "Pesquisa Google",
+      "google_search_description": "Permita que o Gemini pesquise na web e mostre fontes. Usa sua chave de API do Gemini. Combinar pesquisa com ferramentas do agente exige um modelo Gemini 3; podem ser aplicadas cobranças de pesquisa do provedor.",
       "no_provider": "Nenhum provedor de IA configurado ainda",
       "tab_continues_last_thread": "Tab continua a última conversa",
       "tab_continues_last_thread_description": "Pressionar Tab no launcher reabre a conversa anterior em vez de iniciar uma nova.",
@@ -650,7 +652,9 @@
       "you": "Você",
       "copy_message": "Copiar mensagem",
       "searching": "Pesquisando…",
-      "error_open_ai_settings": "Não foi possível abrir as configurações de IA. Tente novamente."
+      "error_open_ai_settings": "Não foi possível abrir as configurações de IA. Tente novamente.",
+      "sources": "Fontes",
+      "google_search_suggestions": "Sugestões da Pesquisa Google"
     },
     "sticky": {
       "new_sticky": "Novo lembrete",

--- a/asyar-launcher/src/locales/pt-BR.json
+++ b/asyar-launcher/src/locales/pt-BR.json
@@ -285,6 +285,9 @@
       "type_theme": "Tema"
     },
     "ai": {
+      "hosted_web_search": "Pesquisa na web",
+      "anthropic_search_description": "Permita que o Claude pesquise na web e cite fontes usando sua chave de API da Anthropic. Exige um modelo compatível e pesquisa na web habilitada para sua organização. Podem ser aplicadas cobranças de pesquisa do provedor.",
+      "openrouter_search_description": "Pesquise na web com o plugin web do OpenRouter e mostre fontes. Usa sua chave de API do OpenRouter; há cobranças adicionais de pesquisa, inclusive em modelos gratuitos.",
       "google_search": "Pesquisa Google",
       "google_search_description": "Permita que o Gemini pesquise na web e mostre fontes. Usa sua chave de API do Gemini. Combinar pesquisa com ferramentas do agente exige um modelo Gemini 3; podem ser aplicadas cobranças de pesquisa do provedor.",
       "no_provider": "Nenhum provedor de IA configurado ainda",

--- a/asyar-launcher/src/routes/settings/tabs/AiTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/AiTab.svelte
@@ -495,7 +495,9 @@
                     <div class="hosted-search-setting">
                       <div class="hosted-search-heading">
                         <label class="field-label" for="hosted-web-search-{providerId}">
-                          OpenAI Hosted Web Search
+                          {plugin.id === 'google'
+                            ? t('settings.ai.google_search')
+                            : 'OpenAI Hosted Web Search'}
                         </label>
                         <Toggle
                           id="hosted-web-search-{providerId}"
@@ -507,9 +509,13 @@
                         />
                       </div>
                       <p class="field-description">
-                        Lets compatible OpenAI/Codex proxy endpoints search the live web. No
-                        separate search API key is needed; unsupported endpoints may reject requests
-                        while this is enabled.
+                        {#if plugin.id === 'google'}
+                          {t('settings.ai.google_search_description')}
+                        {:else}
+                          Lets compatible OpenAI/Codex proxy endpoints search the live web. No
+                          separate search API key is needed; unsupported endpoints may reject
+                          requests while this is enabled.
+                        {/if}
                       </p>
                     </div>
                   {/if}

--- a/asyar-launcher/src/routes/settings/tabs/AiTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/AiTab.svelte
@@ -497,7 +497,7 @@
                         <label class="field-label" for="hosted-web-search-{providerId}">
                           {plugin.id === 'google'
                             ? t('settings.ai.google_search')
-                            : 'OpenAI Hosted Web Search'}
+                            : t('settings.ai.hosted_web_search')}
                         </label>
                         <Toggle
                           id="hosted-web-search-{providerId}"
@@ -511,6 +511,10 @@
                       <p class="field-description">
                         {#if plugin.id === 'google'}
                           {t('settings.ai.google_search_description')}
+                        {:else if plugin.id === 'anthropic'}
+                          {t('settings.ai.anthropic_search_description')}
+                        {:else if plugin.id === 'openrouter'}
+                          {t('settings.ai.openrouter_search_description')}
                         {:else}
                           Lets compatible OpenAI/Codex proxy endpoints search the live web. No
                           separate search API key is needed; unsupported endpoints may reject

--- a/asyar-launcher/src/services/ai/initProviders.test.ts
+++ b/asyar-launcher/src/services/ai/initProviders.test.ts
@@ -11,6 +11,13 @@ describe('initProviders', () => {
     vi.clearAllMocks();
   });
 
+  it('exposes native Google Search', () => {
+    initProviders();
+    expect(providerRegistry.list().find((p) => p.id === 'google')?.supportsHostedWebSearch).toBe(
+      true,
+    );
+  });
+
   it('registers exactly 6 provider plugins', () => {
     initProviders();
     expect(providerRegistry.list()).toHaveLength(6);

--- a/asyar-launcher/src/services/ai/initProviders.test.ts
+++ b/asyar-launcher/src/services/ai/initProviders.test.ts
@@ -11,11 +11,9 @@ describe('initProviders', () => {
     vi.clearAllMocks();
   });
 
-  it('exposes native Google Search', () => {
+  it.each(['google', 'anthropic', 'openrouter'])('exposes hosted search for %s', (id) => {
     initProviders();
-    expect(providerRegistry.list().find((p) => p.id === 'google')?.supportsHostedWebSearch).toBe(
-      true,
-    );
+    expect(providerRegistry.list().find((p) => p.id === id)?.supportsHostedWebSearch).toBe(true);
   });
 
   it('registers exactly 6 provider plugins', () => {

--- a/asyar-launcher/src/services/ai/initProviders.ts
+++ b/asyar-launcher/src/services/ai/initProviders.ts
@@ -31,6 +31,7 @@ const PROVIDERS: IProviderPlugin[] = [
   descriptor({
     id: 'google',
     name: 'Google Gemini',
+    supportsHostedWebSearch: true,
     requiresApiKey: true,
     requiresBaseUrl: false,
     reasoningEfforts: ['minimal', 'low', 'medium', 'high'],

--- a/asyar-launcher/src/services/ai/initProviders.ts
+++ b/asyar-launcher/src/services/ai/initProviders.ts
@@ -25,6 +25,7 @@ const PROVIDERS: IProviderPlugin[] = [
   descriptor({
     id: 'anthropic',
     name: 'Anthropic',
+    supportsHostedWebSearch: true,
     requiresApiKey: true,
     requiresBaseUrl: false,
   }),
@@ -46,6 +47,7 @@ const PROVIDERS: IProviderPlugin[] = [
   descriptor({
     id: 'openrouter',
     name: 'OpenRouter',
+    supportsHostedWebSearch: true,
     requiresApiKey: true,
     requiresBaseUrl: false,
     reasoningEfforts: ALL_REASONING_EFFORTS,


### PR DESCRIPTION
Hi! I've been using Asyar since yesterday - after trying to migrate away from Raycast.

It's been mostly smooth so far but I've noticed three missing feature from my normal use, and probably something most people would need to.

Here's the first one about Web Search on Anthropic and OpenRouter.

---

Anthropic and OpenRouter currently have no web-search option in AI settings. This enables the existing toggle for both providers and sends their native request formats: Anthropic’s versioned web-search tool and OpenRouter’s web plugin.

Depends on #738 for shared grounding presentation. This branch includes that prerequisite; review the additional provider changes in the [incremental comparison](https://github.com/viteinfinite/asyar/compare/ai/gemini-web-search...ai/provider-web-search).

Specifically:
- Anthropic server-side tool calls remain separate from local agent tools. Native response blocks and encrypted citation references are retained for continuation, including paused turns within the existing agent-loop limit. Cited text gets source links, and links open through the existing opener service.
- OpenRouter annotations retain their original offsets and stay separate from reasoning data; sources appear below the answer without rewriting the model’s Markdown.

Draft pending review of prerequisite #738 and live Anthropic/OpenRouter API testing.
