### PR TITLE
feat(agents): add Copy Last Response action

### DIFF
--- a/asyar-launcher/src/built-in-features/agents/AgentChatView.svelte
+++ b/asyar-launcher/src/built-in-features/agents/AgentChatView.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { openerService } from '../../services/opener/openerService';
   import { externalSearchUrl } from '../../components/ai/googleSearchSuggestions';
-  import { onMount, onDestroy, tick } from 'svelte';
+  import { onMount, onDestroy, tick, untrack } from 'svelte';
+  import { actionService } from '../../services/action/actionService.svelte';
   import { agentService } from './agentService.svelte';
   import { agentsManager } from './agentsManager.svelte';
   import { renderMarkdown, handleMarkdownCopyClick } from '../../utils/markdown';
@@ -42,6 +43,8 @@
     const currentThreadId = agentsManager.currentThreadId;
     void agentsManager.sending;
     let cancelled = false;
+    agentsManager.lastAssistantResponse = null;
+    untrack(() => actionService.refreshFiltered());
 
     void (async () => {
       if (!currentAgentId) {
@@ -80,7 +83,18 @@
 
       try {
         const nextMessages = await agentService.listMessages(resolvedThreadId);
-        if (!cancelled) messages = nextMessages;
+        if (!cancelled) {
+          messages = nextMessages;
+          for (let i = nextMessages.length - 1; i >= 0; i -= 1) {
+            const message = nextMessages[i];
+            const text = extractTextFromMessage(message);
+            if (message.role === 'assistant' && text.trim()) {
+              agentsManager.lastAssistantResponse = { threadId: resolvedThreadId, text };
+              break;
+            }
+          }
+          actionService.refreshFiltered();
+        }
       } catch (err) {
         if (cancelled) return;
         logService.warn(`[agents] listMessages failed: ${err}`);
@@ -190,6 +204,8 @@
   });
 
   onDestroy(() => {
+    agentsManager.lastAssistantResponse = null;
+    actionService.refreshFiltered();
     window.removeEventListener('keydown', handleWindowKeydown, true);
     // Intentionally do NOT abort the active controller here. The user can
     // navigate away (Esc to launcher) and the run should keep streaming so

--- a/asyar-launcher/src/built-in-features/agents/AgentChatView.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/AgentChatView.test.ts
@@ -19,6 +19,10 @@ vi.mock('../../services/log/logService', () => ({
   logService: { warn: vi.fn() },
 }));
 
+vi.mock('../../services/action/actionService.svelte', () => ({
+  actionService: { refreshFiltered: vi.fn() },
+}));
+
 vi.mock('../../services/feedback/feedbackService.svelte', () => ({
   feedbackService: { report: vi.fn() },
 }));
@@ -132,6 +136,26 @@ describe('AgentChatView', () => {
     await waitFor(() => expect(screen.queryByText(thread.title)).toBeNull());
   });
 
+  it('publishes the last non-empty assistant reply and clears it for an empty thread', async () => {
+    const text = '    code\n';
+    const message = { threadId: thread.id, createdAt: 1, runId: null };
+    mockedAgentService.listMessages.mockResolvedValue([
+      { ...message, id: 'old', role: 'assistant', content: { text: 'older' } },
+      { ...message, id: 'reply', role: 'assistant', content: { text } },
+      { ...message, id: 'empty', role: 'assistant', content: { text: '  ' } },
+      { ...message, id: 'user', role: 'user', content: { text: 'question' } },
+    ]);
+    const view = render(AgentChatView);
+    await waitFor(() =>
+      expect(agentsManager.lastAssistantResponse).toEqual({ threadId: thread.id, text }),
+    );
+    mockedAgentService.listMessages.mockResolvedValue([]);
+    agentsManager.sending = true;
+    await waitFor(() => expect(agentsManager.lastAssistantResponse).toBeNull());
+    view.unmount();
+    expect(agentsManager.lastAssistantResponse).toBeNull();
+  });
+
   it('fetches the initial thread list only once', async () => {
     render(AgentChatView);
 
@@ -178,6 +202,7 @@ describe('AgentChatView', () => {
 
     await waitFor(() => expect(screen.queryByText('Stale message')).toBeNull());
     expect(screen.getByText('Current message')).toBeTruthy();
+    expect(agentsManager.lastAssistantResponse).toBeNull();
   });
 
   it('keeps pending scroll callbacks safe after unmount', async () => {

--- a/asyar-launcher/src/built-in-features/agents/agentsManager.svelte.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentsManager.svelte.ts
@@ -16,6 +16,8 @@ export class AgentsManager {
    * routes the query into the right thread.
    */
   currentThreadId = $state<string | null>(null);
+  /** Latest copyable reply loaded by the chat view, bound to its source thread. */
+  lastAssistantResponse = $state<{ threadId: string; text: string } | null>(null);
   /**
    * In-flight assistant response. While a turn is streaming, tokens land
    * here and the chat view renders them as a temporary bubble. Cleared

--- a/asyar-launcher/src/built-in-features/agents/index.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/index.test.ts
@@ -24,6 +24,8 @@ vi.mock('../../services/action/actionService.svelte', () => ({
   },
 }));
 
+vi.mock('../../utils/copyText', () => ({ copyText: vi.fn() }));
+
 vi.mock('../../services/log/logService', () => ({
   logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
@@ -47,6 +49,7 @@ vi.mock('./agentsManager.svelte', () => ({
   agentsManager: {
     currentAgentId: null,
     currentThreadId: null,
+    lastAssistantResponse: null,
     sending: false,
     streamingText: '',
     start: vi.fn().mockResolvedValue(undefined),
@@ -120,6 +123,8 @@ import { agentsManager } from './agentsManager.svelte';
 import { agentService } from './agentService.svelte';
 import { runAgent } from './agentLoop';
 import { ensureThread } from './agentChatView.helpers';
+import { actionService } from '../../services/action/actionService.svelte';
+import { copyText } from '../../utils/copyText';
 
 describe('AgentsExtension', () => {
   let mockExtensionManager: any;
@@ -128,6 +133,7 @@ describe('AgentsExtension', () => {
     vi.clearAllMocks();
     agentsManager.currentAgentId = null;
     agentsManager.currentThreadId = null;
+    agentsManager.lastAssistantResponse = null;
     agentsManager.sending = false;
     agentsManager.streamingText = '';
     agentsManager.activeAbortController = null;
@@ -135,6 +141,41 @@ describe('AgentsExtension', () => {
       navigateToView: vi.fn(),
       setActiveViewSubtitle: vi.fn(),
     };
+  });
+
+  it('scopes Copy Last Response to a loaded, idle chat and preserves markdown', async () => {
+    await agentsExtension.viewActivated?.('agents/AgentChatView');
+    const action = vi.mocked(actionService.registerAction).mock.calls[0][0];
+    expect(action).toMatchObject({
+      id: 'agents.copy-last-response',
+      label: 'Copy Last Response',
+      context: 'EXTENSION_VIEW',
+      shortcut: 'Super+Shift+C',
+    });
+    const visible = (action as { visible: () => boolean }).visible;
+    expect(visible()).toBe(false);
+    agentsManager.currentThreadId = 'thread-1';
+    expect(visible()).toBe(false);
+    await action.execute();
+    expect(copyText).not.toHaveBeenCalled();
+
+    const text = '    indented code\n\n**answer**\n';
+    agentsManager.lastAssistantResponse = { threadId: 'thread-1', text };
+    expect(visible()).toBe(true);
+    await action.execute();
+    expect(copyText).toHaveBeenCalledExactlyOnceWith(text);
+
+    agentsManager.sending = true;
+    expect(visible()).toBe(false);
+    await action.execute();
+    agentsManager.sending = false;
+    agentsManager.currentThreadId = 'thread-2';
+    expect(visible()).toBe(false);
+    await action.execute();
+    expect(copyText).toHaveBeenCalledTimes(1);
+
+    await agentsExtension.viewDeactivated?.('agents/AgentChatView');
+    expect(actionService.unregisterAction).toHaveBeenCalledWith('agents.copy-last-response');
   });
 
   describe('chat submission', () => {

--- a/asyar-launcher/src/built-in-features/agents/index.ts
+++ b/asyar-launcher/src/built-in-features/agents/index.ts
@@ -5,6 +5,8 @@ import { agentsManager } from './agentsManager.svelte';
 import { agentService } from './agentService.svelte';
 import { runAgent } from './agentLoop';
 import { ensureThread } from './agentChatView.helpers';
+import { copyText } from '../../utils/copyText';
+import { t } from '../../services/i18n';
 import { actionService } from '../../services/action/actionService.svelte';
 import { logService } from '../../services/log/logService';
 import { contextModeService } from '../../services/context/contextModeService.svelte';
@@ -27,6 +29,7 @@ const ACTION_DELETE_AGENT = 'agents:delete-agent';
 const ACTION_NEW_THREAD = 'agents:new-thread';
 const ACTION_DELETE_THREAD = 'agents:delete-thread';
 const ACTION_CANCEL_SEND = 'agents:cancel-send';
+const ACTION_COPY_LAST_RESPONSE = 'agents.copy-last-response';
 
 class AgentsExtension implements Extension {
   private extensionManager?: IExtensionManager;
@@ -154,6 +157,13 @@ class AgentsExtension implements Extension {
     agentsManager.activeAbortController?.abort();
   }
 
+  private async runCopyLastResponse(): Promise<void> {
+    const response = agentsManager.lastAssistantResponse;
+    if (!response || response.threadId !== agentsManager.currentThreadId || agentsManager.sending)
+      return;
+    await copyText(response.text);
+  }
+
   // ── View-context action registration ───────────────────────────────────────
 
   private registerListViewActions(): void {
@@ -197,6 +207,21 @@ class AgentsExtension implements Extension {
 
   private registerChatViewActions(): void {
     actionService.registerAction({
+      id: ACTION_COPY_LAST_RESPONSE,
+      label: t('features.agents.copy_last_response'),
+      icon: '📋',
+      description: t('features.agents.copy_last_response_description'),
+      category: 'Agents',
+      extensionId: 'agents',
+      context: ActionContext.EXTENSION_VIEW,
+      shortcut: 'Super+Shift+C',
+      visible: () =>
+        !!agentsManager.lastAssistantResponse &&
+        agentsManager.lastAssistantResponse.threadId === agentsManager.currentThreadId &&
+        !agentsManager.sending,
+      execute: async () => this.runCopyLastResponse(),
+    });
+    actionService.registerAction({
       id: ACTION_NEW_THREAD,
       label: 'New Thread',
       icon: '💬',
@@ -233,6 +258,7 @@ class AgentsExtension implements Extension {
     actionService.unregisterAction(ACTION_NEW_THREAD);
     actionService.unregisterAction(ACTION_DELETE_THREAD);
     actionService.unregisterAction(ACTION_CANCEL_SEND);
+    actionService.unregisterAction(ACTION_COPY_LAST_RESPONSE);
   }
 
   async executeCommand(commandId: string, args?: Record<string, unknown>): Promise<unknown> {

--- a/asyar-launcher/src/locales/en.json
+++ b/asyar-launcher/src/locales/en.json
@@ -653,6 +653,8 @@
       "streaming_cancel": "Streaming… ⌘K to cancel",
       "you": "You",
       "copy_message": "Copy message",
+      "copy_last_response": "Copy Last Response",
+      "copy_last_response_description": "Copy the latest assistant response in this thread",
       "searching": "Searching…",
       "sources": "Sources",
       "google_search_suggestions": "Google Search Suggestions",

--- a/asyar-launcher/src/locales/pt-BR.json
+++ b/asyar-launcher/src/locales/pt-BR.json
@@ -651,6 +651,8 @@
       "streaming_cancel": "Transmitindo… ⌘K para cancelar",
       "you": "Você",
       "copy_message": "Copiar mensagem",
+      "copy_last_response": "Copiar última resposta",
+      "copy_last_response_description": "Copiar a resposta mais recente do assistente nesta conversa",
       "searching": "Pesquisando…",
       "error_open_ai_settings": "Não foi possível abrir as configurações de IA. Tente novamente.",
       "sources": "Fontes",


### PR DESCRIPTION
Closes #744

Adds Copy Last Response to the chat action panel with Super+Shift+C. The action copies the latest non-empty assistant reply through the existing clipboard/feedback helper, preserving its markdown whitespace. It is hidden while generating, before replies load, and in empty or user-only threads. Cached reply text is bound to its source thread and cleared on reload/unmount, preventing a thread switch from copying an old conversation.

Includes English and Brazilian Portuguese labels and regression coverage for registration, visibility, copying, cleanup, and stale thread loads.

Validation: workspace formatting and design checks pass; all 4,163 workspace tests pass (3,463 launcher + 700 SDK), including 137 agents tests. No Rust code changed. The repository-wide type check still reports 170 errors; a pristine checkout comparison is recorded in the local verification report. No native desktop smoke test was performed.
