### PR TITLE
feat(agents): add Copy Last Response action to the chat ⌘K palette

### DIFF
--- a/asyar-launcher/src/built-in-features/agents/AgentChatView.svelte
+++ b/asyar-launcher/src/built-in-features/agents/AgentChatView.svelte
@@ -13,6 +13,7 @@
     extractToolUsesFromMessage,
     messageBubbleVariant,
     resolveThreadId,
+    lastAssistantMessageText,
   } from './agentChatView.helpers';
   import EmptyState from '../../components/feedback/EmptyState.svelte';
   import { Button, IconButton, GoogleSearchSuggestions } from '../../components';
@@ -48,6 +49,7 @@
         agent = null;
         threads = [];
         messages = [];
+        agentsManager.lastAssistantMessageText = null;
         return;
       }
 
@@ -70,17 +72,22 @@
       if (resolvedThreadId !== currentThreadId) {
         agentsManager.currentThreadId = resolvedThreadId;
         messages = [];
+        agentsManager.lastAssistantMessageText = null;
         return;
       }
 
       if (!resolvedThreadId) {
         messages = [];
+        agentsManager.lastAssistantMessageText = null;
         return;
       }
 
       try {
         const nextMessages = await agentService.listMessages(resolvedThreadId);
-        if (!cancelled) messages = nextMessages;
+        if (!cancelled) {
+          messages = nextMessages;
+          agentsManager.lastAssistantMessageText = lastAssistantMessageText(nextMessages);
+        }
       } catch (err) {
         if (cancelled) return;
         logService.warn(`[agents] listMessages failed: ${err}`);

--- a/asyar-launcher/src/built-in-features/agents/AgentChatView.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/AgentChatView.test.ts
@@ -79,6 +79,7 @@ describe('AgentChatView', () => {
     agentsManager.currentAgentId = agent.id;
     agentsManager.currentThreadId = thread.id;
     agentsManager.sending = false;
+    agentsManager.lastAssistantMessageText = null;
   });
 
   afterEach(() => {
@@ -178,6 +179,52 @@ describe('AgentChatView', () => {
 
     await waitFor(() => expect(screen.queryByText('Stale message')).toBeNull());
     expect(screen.getByText('Current message')).toBeTruthy();
+  });
+
+  it('mirrors the latest assistant message onto agentsManager for copy-last-response', async () => {
+    mockedAgentService.listMessages.mockResolvedValue([
+      {
+        id: 'm1',
+        threadId: thread.id,
+        role: 'user',
+        content: { text: 'Hi' },
+        createdAt: 1,
+        runId: null,
+      },
+      {
+        id: 'm2',
+        threadId: thread.id,
+        role: 'assistant',
+        content: { text: 'Hello there' },
+        createdAt: 2,
+        runId: null,
+      },
+    ]);
+
+    render(AgentChatView);
+    await screen.findByText(thread.title);
+
+    await waitFor(() => expect(agentsManager.lastAssistantMessageText).toBe('Hello there'));
+  });
+
+  it('clears the mirrored assistant text once the thread is cleared', async () => {
+    mockedAgentService.listMessages.mockResolvedValue([
+      {
+        id: 'm2',
+        threadId: thread.id,
+        role: 'assistant',
+        content: { text: 'Hello there' },
+        createdAt: 2,
+        runId: null,
+      },
+    ]);
+    render(AgentChatView);
+    await waitFor(() => expect(agentsManager.lastAssistantMessageText).toBe('Hello there'));
+
+    mockedAgentService.listThreads.mockResolvedValue([]);
+    agentsManager.currentThreadId = null;
+
+    await waitFor(() => expect(agentsManager.lastAssistantMessageText).toBeNull());
   });
 
   it('keeps pending scroll callbacks safe after unmount', async () => {

--- a/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.test.ts
@@ -9,6 +9,7 @@ import {
   messageBubbleVariant,
   handleCancelSend,
   resolveThreadId,
+  lastAssistantMessageText,
 } from './agentChatView.helpers';
 
 import type { ThreadDef, MessageDef } from './types';
@@ -306,5 +307,29 @@ describe('persisted Gemini grounding', () => {
     expect(extractGroundingFromMessage(message)).toEqual([display]);
     expect(extractGroundingFromMessage({ ...message, content: { text: 'No search' } })).toEqual([]);
     expect(extractGroundingFromMessage({ ...message, role: 'user' })).toEqual([]);
+  });
+});
+
+// ── lastAssistantMessageText ─────────────────────────────────────────────────
+
+describe('lastAssistantMessageText', () => {
+  it('returns null for an empty thread', () => {
+    expect(lastAssistantMessageText([])).toBeNull();
+  });
+
+  it('returns null when the thread only has user messages', () => {
+    const messages = [makeMessage({ role: 'user', content: { text: 'Hi' } })];
+    expect(lastAssistantMessageText(messages)).toBeNull();
+  });
+
+  it('returns the most recent assistant message, ignoring later user/tool messages', () => {
+    const messages = [
+      makeMessage({ id: 'm1', role: 'user', content: { text: 'first question' } }),
+      makeMessage({ id: 'm2', role: 'assistant', content: { text: 'first answer' } }),
+      makeMessage({ id: 'm3', role: 'user', content: { text: 'second question' } }),
+      makeMessage({ id: 'm4', role: 'assistant', content: { text: 'second answer' } }),
+      makeMessage({ id: 'm5', role: 'tool', content: { toolResult: { output: 'ignored' } } }),
+    ];
+    expect(lastAssistantMessageText(messages)).toBe('second answer');
   });
 });

--- a/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.ts
@@ -85,6 +85,19 @@ export function extractToolUsesFromMessage(msg: MessageDef): ToolCall[] {
   return toolUse ?? [];
 }
 
+// ── lastAssistantMessageText ──────────────────────────────────────────────────
+
+/** Markdown text of the most recent assistant message, or null if none exists
+ * yet (empty thread, or only user/tool messages so far). Used to mirror the
+ * copy-able text onto `agentsManager.lastAssistantMessageText` so the
+ * `agents:copy-last-response` action can read and gate on it synchronously. */
+export function lastAssistantMessageText(messages: MessageDef[]): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'assistant') return extractTextFromMessage(messages[i]);
+  }
+  return null;
+}
+
 // ── messageBubbleVariant ──────────────────────────────────────────────────────
 
 export function messageBubbleVariant(msg: MessageDef): 'user' | 'assistant' | 'tool' {

--- a/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentChatView.helpers.ts
@@ -87,10 +87,7 @@ export function extractToolUsesFromMessage(msg: MessageDef): ToolCall[] {
 
 // ── lastAssistantMessageText ──────────────────────────────────────────────────
 
-/** Markdown text of the most recent assistant message, or null if none exists
- * yet (empty thread, or only user/tool messages so far). Used to mirror the
- * copy-able text onto `agentsManager.lastAssistantMessageText` so the
- * `agents:copy-last-response` action can read and gate on it synchronously. */
+/** Text of the most recent assistant message, or null if there is none yet. */
 export function lastAssistantMessageText(messages: MessageDef[]): string | null {
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i].role === 'assistant') return extractTextFromMessage(messages[i]);

--- a/asyar-launcher/src/built-in-features/agents/agents.actions.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/agents.actions.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mocks MUST be defined before the module under test is imported.
+
+vi.mock('asyar-sdk/contracts', () => ({
+  ActionContext: {
+    EXTENSION_VIEW: 'EXTENSION_VIEW',
+  },
+}));
+
+vi.mock('../../services/context/contextModeService.svelte', () => ({
+  contextModeService: {
+    registerProvider: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/action/actionService.svelte', () => ({
+  actionService: {
+    registerAction: vi.fn(),
+    unregisterAction: vi.fn(),
+    setActionExecutor: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/log/logService', () => ({
+  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../utils/copyText', () => ({
+  copyText: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../../services/i18n', () => ({
+  t: (key: string) => key,
+}));
+
+vi.mock('./agentsManager.svelte', () => ({
+  agentsManager: {
+    currentAgentId: null,
+    currentThreadId: null,
+    sending: false,
+    streamingText: '',
+    lastAssistantMessageText: null as string | null,
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    activeAbortController: null,
+  },
+}));
+
+vi.mock('./agentService.svelte', () => ({
+  agentService: {
+    delete: vi.fn(),
+    createThread: vi.fn(),
+    deleteThread: vi.fn(),
+    listThreads: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('./dispatch', () => ({
+  dispatchAgentCommand: vi.fn(),
+}));
+
+vi.mock('./agentLoop', () => ({
+  runAgent: vi.fn(),
+}));
+
+vi.mock('./agentChatView.helpers', () => ({
+  ensureThread: vi.fn(),
+}));
+
+vi.mock('../../services/extension/builtinDynamicDispatchers', () => ({
+  registerBuiltinDynamicDispatcher: vi.fn(),
+}));
+
+vi.mock('../../services/settings/settingsService.svelte', () => ({
+  settingsService: {
+    currentSettings: { ai: { tabContinuesLastThread: false, defaultAgentId: null, providers: {} } },
+  },
+}));
+
+vi.mock('./tabRouter', () => ({
+  decideTabDestination: vi.fn(() => ({ agentId: 'agent-1' })),
+}));
+
+vi.mock('./threadOpener', () => ({
+  openAgentForTab: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./AgentListView.svelte', () => ({ default: {} }));
+vi.mock('./AgentEditView.svelte', () => ({ default: {} }));
+vi.mock('./AgentChatView.svelte', () => ({ default: {} }));
+
+import agentsExtension from './index';
+import { actionService } from '../../services/action/actionService.svelte';
+import { agentsManager } from './agentsManager.svelte';
+import { copyText } from '../../utils/copyText';
+
+type RegisteredAction = {
+  id: string;
+  visible?: () => boolean;
+  execute: () => Promise<void> | void;
+};
+
+function getRegisteredAction(id: string): RegisteredAction {
+  const call = vi
+    .mocked(actionService.registerAction)
+    .mock.calls.find(([action]) => (action as RegisteredAction).id === id);
+  if (!call) throw new Error(`action ${id} was never registered`);
+  return call[0] as RegisteredAction;
+}
+
+describe('agents:copy-last-response action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    agentsManager.currentAgentId = null;
+    agentsManager.currentThreadId = null;
+    agentsManager.sending = false;
+    agentsManager.lastAssistantMessageText = null;
+  });
+
+  describe('registration', () => {
+    it('registers agents:copy-last-response when the chat view activates', async () => {
+      await agentsExtension.viewActivated?.('agents/AgentChatView');
+
+      expect(actionService.registerAction).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'agents:copy-last-response', shortcut: 'Super+Shift+C' }),
+      );
+    });
+
+    it('unregisters agents:copy-last-response when the chat view deactivates', async () => {
+      await agentsExtension.viewDeactivated?.('agents/AgentChatView');
+
+      expect(actionService.unregisterAction).toHaveBeenCalledWith('agents:copy-last-response');
+    });
+  });
+
+  describe('visibility', () => {
+    it('is hidden when the thread has no assistant message yet', async () => {
+      agentsManager.lastAssistantMessageText = null;
+      agentsManager.sending = false;
+      await agentsExtension.viewActivated?.('agents/AgentChatView');
+
+      const action = getRegisteredAction('agents:copy-last-response');
+
+      expect(action.visible?.()).toBe(false);
+    });
+
+    it('is hidden while a response is still generating, even with prior assistant text', async () => {
+      agentsManager.lastAssistantMessageText = 'previous answer';
+      agentsManager.sending = true;
+      await agentsExtension.viewActivated?.('agents/AgentChatView');
+
+      const action = getRegisteredAction('agents:copy-last-response');
+
+      expect(action.visible?.()).toBe(false);
+    });
+
+    it('is visible once an assistant message exists and nothing is generating', async () => {
+      agentsManager.lastAssistantMessageText = 'the answer';
+      agentsManager.sending = false;
+      await agentsExtension.viewActivated?.('agents/AgentChatView');
+
+      const action = getRegisteredAction('agents:copy-last-response');
+
+      expect(action.visible?.()).toBe(true);
+    });
+  });
+
+  describe('execute', () => {
+    it('copies the latest assistant response text to the clipboard', async () => {
+      agentsManager.lastAssistantMessageText = 'the latest assistant answer';
+      await agentsExtension.viewActivated?.('agents/AgentChatView');
+
+      const action = getRegisteredAction('agents:copy-last-response');
+      await action.execute();
+
+      expect(copyText).toHaveBeenCalledWith('the latest assistant answer');
+    });
+
+    it('does nothing when there is no assistant response to copy', async () => {
+      agentsManager.lastAssistantMessageText = null;
+      await agentsExtension.viewActivated?.('agents/AgentChatView');
+
+      const action = getRegisteredAction('agents:copy-last-response');
+      await action.execute();
+
+      expect(copyText).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/asyar-launcher/src/built-in-features/agents/agentsManager.svelte.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentsManager.svelte.ts
@@ -26,6 +26,14 @@ export class AgentsManager {
   /** True while a `runAgent` invocation is in-flight for the active thread. */
   sending = $state<boolean>(false);
   /**
+   * Markdown text of the latest assistant message in the active thread, or
+   * null when there isn't one yet. Set by AgentChatView whenever it
+   * (re)loads messages for the current thread; read by the
+   * `agents:copy-last-response` action so it can gate its visibility and
+   * copy the text without an extra async fetch.
+   */
+  lastAssistantMessageText = $state<string | null>(null);
+  /**
    * AbortController for the active send. The chat view's Cancel button (and
    * the launcher Esc handler) call `.abort()` on this; agentLoop watches it
    * via the abortSignal arg.

--- a/asyar-launcher/src/built-in-features/agents/agentsManager.svelte.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentsManager.svelte.ts
@@ -25,13 +25,8 @@ export class AgentsManager {
   streamingStatus = $state<ChatStreamStatus | null>(null);
   /** True while a `runAgent` invocation is in-flight for the active thread. */
   sending = $state<boolean>(false);
-  /**
-   * Markdown text of the latest assistant message in the active thread, or
-   * null when there isn't one yet. Set by AgentChatView whenever it
-   * (re)loads messages for the current thread; read by the
-   * `agents:copy-last-response` action so it can gate its visibility and
-   * copy the text without an extra async fetch.
-   */
+  /** Latest assistant message's text in the active thread, or null. Set by
+   * AgentChatView on message load; read by the copy-last-response action. */
   lastAssistantMessageText = $state<string | null>(null);
   /**
    * AbortController for the active send. The chat view's Cancel button (and

--- a/asyar-launcher/src/built-in-features/agents/index.ts
+++ b/asyar-launcher/src/built-in-features/agents/index.ts
@@ -6,6 +6,8 @@ import { agentService } from './agentService.svelte';
 import { runAgent } from './agentLoop';
 import { ensureThread } from './agentChatView.helpers';
 import { actionService } from '../../services/action/actionService.svelte';
+import { copyText } from '../../utils/copyText';
+import { t } from '../../services/i18n';
 import { logService } from '../../services/log/logService';
 import { contextModeService } from '../../services/context/contextModeService.svelte';
 import { settingsService } from '../../services/settings/settingsService.svelte';
@@ -27,6 +29,7 @@ const ACTION_DELETE_AGENT = 'agents:delete-agent';
 const ACTION_NEW_THREAD = 'agents:new-thread';
 const ACTION_DELETE_THREAD = 'agents:delete-thread';
 const ACTION_CANCEL_SEND = 'agents:cancel-send';
+const ACTION_COPY_LAST_RESPONSE = 'agents:copy-last-response';
 
 class AgentsExtension implements Extension {
   private extensionManager?: IExtensionManager;
@@ -154,6 +157,12 @@ class AgentsExtension implements Extension {
     agentsManager.activeAbortController?.abort();
   }
 
+  private async runCopyLastResponse(): Promise<void> {
+    const text = agentsManager.lastAssistantMessageText;
+    if (!text) return;
+    await copyText(text);
+  }
+
   // ── View-context action registration ───────────────────────────────────────
 
   private registerListViewActions(): void {
@@ -227,12 +236,25 @@ class AgentsExtension implements Extension {
       visible: () => agentsManager.sending,
       execute: async () => this.runCancelSend(),
     });
+    actionService.registerAction({
+      id: ACTION_COPY_LAST_RESPONSE,
+      label: t('features.agents.copy_last_response'),
+      icon: '📋',
+      description: t('features.agents.copy_last_response_description'),
+      category: 'Agents',
+      extensionId: 'agents',
+      context: ActionContext.EXTENSION_VIEW,
+      shortcut: 'Super+Shift+C',
+      visible: () => !agentsManager.sending && !!agentsManager.lastAssistantMessageText,
+      execute: async () => this.runCopyLastResponse(),
+    });
   }
 
   private unregisterChatViewActions(): void {
     actionService.unregisterAction(ACTION_NEW_THREAD);
     actionService.unregisterAction(ACTION_DELETE_THREAD);
     actionService.unregisterAction(ACTION_CANCEL_SEND);
+    actionService.unregisterAction(ACTION_COPY_LAST_RESPONSE);
   }
 
   async executeCommand(commandId: string, args?: Record<string, unknown>): Promise<unknown> {

--- a/asyar-launcher/src/locales/en.json
+++ b/asyar-launcher/src/locales/en.json
@@ -653,6 +653,8 @@
       "streaming_cancel": "Streaming… ⌘K to cancel",
       "you": "You",
       "copy_message": "Copy message",
+      "copy_last_response": "Copy Last Response",
+      "copy_last_response_description": "Copy the latest assistant response in this thread",
       "searching": "Searching…",
       "sources": "Sources",
       "google_search_suggestions": "Google Search Suggestions",

--- a/asyar-launcher/src/locales/pt-BR.json
+++ b/asyar-launcher/src/locales/pt-BR.json
@@ -651,6 +651,8 @@
       "streaming_cancel": "Transmitindo… ⌘K para cancelar",
       "you": "Você",
       "copy_message": "Copiar mensagem",
+      "copy_last_response": "Copiar última resposta",
+      "copy_last_response_description": "Copiar a resposta mais recente do assistente nesta conversa",
       "searching": "Pesquisando…",
       "error_open_ai_settings": "Não foi possível abrir as configurações de IA. Tente novamente.",
       "sources": "Fontes",


### PR DESCRIPTION
## Pull Request Description
Adds the `agents:copy-last-response` action described in #744: register a "Copy Last Response" entry in the agent chat view's ⌘K action palette that copies the latest assistant message's text to the clipboard.

- `agentsManager.lastAssistantMessageText` mirrors the current thread's latest assistant message (set by `AgentChatView`'s existing message-load effect), so the action can gate its visibility and copy synchronously instead of re-fetching.
- Action is visible only once the thread has an assistant reply and nothing is still generating; hidden on empty/user-only threads.
- Copies via the existing `copyText()` util, same clipboard/toast behavior as the per-message copy button.
- Localized label/description added to `en.json` / `pt-BR.json`.
- Tests: pure-helper unit tests, a dedicated `agents.actions.test.ts` (registration/visibility/execute), and component-level coverage in `AgentChatView.test.ts` for the actual mirroring + thread-switch reset.

Ran the full local CI matrix (`pnpm check:ci`) before opening this: Prettier, design system, all frontend tests (asyar-launcher + asyar-sdk), and Rust fmt/clippy/tests all pass.

## Related Issues
Resolves: #744